### PR TITLE
Add repeated division_id field to election type.

### DIFF
--- a/vip_spec_v5.0.xsd
+++ b/vip_spec_v5.0.xsd
@@ -24,6 +24,7 @@
                             <xs:element name="date" type="xs:date"/>
                             <xs:element name="election_type" type="electionTypeEnum" minOccurs="0"/>
                             <xs:element name="name" type="xs:string" minOccurs="0"/>
+                            <xs:element name="division_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
                             <xs:element name="state_id" type="xs:string"/>
                             <xs:element name="statewide" type="yesNoEnum" minOccurs="0"/>
                             <xs:element name="registration_info" type="xs:string" minOccurs="0"/>


### PR DESCRIPTION
division_id is intended for any number of divisions (specified as [OCD Division IDs](https://github.com/opencivicdata/ocd-division-ids)) to which the election is relevant.
