### PR TITLE
Generic hours_open structure and sample use

### DIFF
--- a/schedule.xsd
+++ b/schedule.xsd
@@ -1,0 +1,52 @@
+<!-- Structured element specifying hours that a location is open. This
+     allows precincts to simply reference the hours_open_id element instead
+     of using a structured string repeatedly.
+     Sample:
+     <hours_open>
+      <hours_open_id>1</hours_open_id>
+      <schedule>
+        <start_date>2014-10-20</start_date>
+        <end_date>2014-10-30</end_date>
+        <hours>
+          <start>09:00:00-05:00</start>
+          <end>12:00:00-05:00</end>
+        </hours>
+        <hours>
+          <start>13:00:00-05:00</start>
+          <end>18:00:00-05:00</end>
+        </hours>
+        <or_by_appointment>true</or_by_appointment>
+      </schedule>
+      <schedule>
+        <start_date>2014-11-01</start_date>
+        <end_date>2014-11-01</end_date>
+        <hours>
+          <start_time>07:00:00-05:00</start_time>
+          <end_time>21:00:00-05:00</end_time>
+        </hours>
+      </schedule>
+     </hours_open>
+  -->
+<xs:element name="hours_open">
+  <xs:complexType>
+    <xs:element type="xs:integer" name="hours_open_id" />
+    <xs:element maxOccurs="unbounded" name="schedule">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element type="xs:date" name="start_date" />
+          <xs:element type="xs:date" name="end_date" />
+          <xs:element maxOccurs="unbounded" name="hours">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element maxOccurs="1" type="xs:time" name="start_time" pattern="HH:mm:ss('Z'|('+'|'-')HH:mm)" />
+                <xs:element maxOccurs="1" type="xs:time" name="end_time" pattern="HH:mm:ss[('Z'|('+'|'-')HH:mm)" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" type="xs:boolean" name="or_by_appointment" />
+          <xs:element maxOccurs="1" type="xs:boolean" name="only_by_appointment" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </xs:complexType>
+</xs:element>

--- a/schedule.xsd
+++ b/schedule.xsd
@@ -38,8 +38,8 @@
           <xs:element maxOccurs="unbounded" name="hours">
             <xs:complexType>
               <xs:sequence>
-                <xs:element maxOccurs="1" type="xs:time" name="start_time" pattern="HH:mm:ss('Z'|('+'|'-')HH:mm)" />
-                <xs:element maxOccurs="1" type="xs:time" name="end_time" pattern="HH:mm:ss[('Z'|('+'|'-')HH:mm)" />
+                <xs:element maxOccurs="1" type="xs:time" name="start_time" pattern="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|(+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))" />
+                <xs:element maxOccurs="1" type="xs:time" name="end_time" pattern="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|(+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))" />
               </xs:sequence>
             </xs:complexType>
           </xs:element>

--- a/schedule_sample.xml
+++ b/schedule_sample.xml
@@ -1,0 +1,69 @@
+<hours_open>
+  <hours_open_id>1</hours_open_id>
+  <schedule>
+    <start_date>2014-10-20</start_date>
+    <end_date>2014-10-30</end_date>
+    <hours>
+      <start_time>09:00:00-05:00</start_time>
+      <end_time>12:00:00-05:00</end_time>
+    </hours>
+    <hours>
+      <start_time>13:00:00-05:00</start_time>
+      <end_time>18:00:00-05:00</end_time>
+    </hours>
+    <or_by_appointment>true</or_by_appointment>
+  </schedule>
+  <schedule>
+    <start_date>2014-11-01</start_date>
+    <end_date>2014-11-01</end_date>
+    <hours>
+      <start_time>07:00:00-05:00</start_time>
+      <end_time>21:00:00-05:00</end_time>
+    </hours>
+  </schedule>
+</hours_open>
+<hours_open>
+  <hours_open_id>2</hours_open_id>
+  <schedule>
+    <start_date>2014-11-03</start_date>
+    <end_date>2014-11-03</end_date>
+    <hours>
+      <start_time>09:00:00-05:00</start_time>
+      <end_time>12:00:00-05:00</end_time>
+    </hours>
+    <hours>
+      <start_time>13:00:00-05:00</start_time>
+      <end_time>18:00:00-05:00</end_time>
+    </hours>
+    <only_by_appointment>true</only_by_appointment>
+  </schedule>
+</hours_open>
+<polling_location id="80011">
+  <address>
+    <location_name>Appalachian College of Pharmacy</location_name>
+    <line1>1060 Dragon Rd</line1>
+    <line2></line2>
+    <line3></line3>
+    <city>OAKWOOD</city>
+    <state>VA</state>
+    <zip>24631</zip>
+  </address>
+  <directions>Room 108</directions>
+  <photo_url></photo_url>
+  <hours_open_id>1</hours_open_id>
+  <hours_open_id>2</hours_open_id>
+</polling_location>
+<polling_location id="80012">
+  <address>
+    <location_name>WOODLAWN SCHOOL</location_name>
+    <line1>745 WOODLAWN RD</line1>
+    <line2></line2>
+    <line3></line3>
+    <city>WOODLAWN</city>
+    <state>VA</state>
+    <zip>243813419</zip>
+  </address>
+  <directions>CAFETERIA</directions>
+  <photo_url></photo_url>
+  <hours_open_id>1</hours_open_id>
+</polling_location>


### PR DESCRIPTION
Here's my take on the polling place hours idea. It's actually more generic than polling place hours, in that something like an election administration office could define hours of operation as well, and use the same hours element by reference.