### PR TITLE
Reuse some 1622.2 objects in VIP

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -31,12 +31,12 @@ reference elements for polling location
               <xs:element name="Date" type="xs:date" />
               <xs:element name="ElectionType" type="InternationalizedText" minOccurs="0" />
               <xs:element name="StateId" type="xs:IDREF" />
-              <xs:element name="Statewide" type="xs:boolean" minOccurs="0" />
+              <xs:element name="IsStatewide" type="xs:boolean" minOccurs="0" />
               <xs:element name="RegistrationInfo" type="InternationalizedText" minOccurs="0" />
               <xs:element name="AbsenteeBallotInfo" type="InternationalizedText" minOccurs="0" />
               <xs:element name="ResultsUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="PollingHours" type="InternationalizedText" minOccurs="0" />
-              <xs:element name="ElectionDayRegistration" type="xs:boolean" minOccurs="0" />
+              <xs:element name="HasElectionDayRegistration" type="xs:boolean" minOccurs="0" />
               <xs:element name="RegistrationDeadline" type="xs:date" minOccurs="0" />
               <xs:element name="AbsenteeRequestDeadline" type="xs:date" minOccurs="0" />
             </xs:all>
@@ -82,7 +82,7 @@ reference elements for polling location
               <xs:element name="ElectoralDistrictId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
-              <xs:element name="MailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+              <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
               <xs:element name="BallotStyleImageUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="ExternalIdentifierId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
@@ -147,8 +147,8 @@ reference elements for polling location
               <xs:element name="Address" type="SimpleAddressType" />
               <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
               <xs:element name="PhotoUrl" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
-              <xs:element name="EarlyVoting" type="xs:boolean" minOccurs="0" maxOccurs="1" />
-              <xs:element name="DropBox" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+              <xs:element name="IsEarlyVoting" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+              <xs:element name="IsDropBox" type="xs:boolean" minOccurs="0" maxOccurs="1" />
               <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
             <xs:attribute name="id" type="xs:ID" use="required" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -54,7 +54,7 @@ reference elements for polling location
           <xs:complexType>
             <xs:sequence>
               <xs:element name="Name" type="xs:string" />
-              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
+              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="ExternalIdentifierId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
@@ -68,7 +68,7 @@ reference elements for polling location
               <xs:element name="Name" type="xs:string" />
               <xs:element name="StateId" type="xs:IDREF" />
               <xs:element name="Type" type="xs:string" />
-              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
+              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="ExternalIdentifierId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -266,7 +266,6 @@ reference elements for polling location
               <xs:element name="IsPartisan" type="xs:boolean" minOccurs="0" />
               <xs:element name="FilingDeadline" type="xs:dateTime" minOccurs="0" />
               <xs:element name="Term" type="Term" minOccurs="0" />
-              <!-- The following are not currently in 1622.2 -->
               <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
             <xs:attribute name="id" type="xs:ID" use="required" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -19,7 +19,7 @@ reference elements for polling location
               <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
               <xs:element name="OrganizationUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="FeedContactId" type="xs:IDREF" minOccurs="0" />
-              <xs:element name="TouUrl" type="xs:anyURI" minOccurs="0" />
+              <xs:element name="TermsOfUseUrl" type="xs:anyURI" minOccurs="0" />
             </xs:all>
             <xs:attribute name="id" type="xs:ID" use="required" />
           </xs:complexType>
@@ -35,7 +35,11 @@ reference elements for polling location
               <xs:element name="RegistrationInfo" type="InternationalizedText" minOccurs="0" />
               <xs:element name="AbsenteeBallotInfo" type="InternationalizedText" minOccurs="0" />
               <xs:element name="ResultsUrl" type="xs:anyURI" minOccurs="0" />
+              <!-- Note: The "PollingHours" element is being deprecated
+                   and will be removed in future versions of VIP.
+                -->
               <xs:element name="PollingHours" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="HasElectionDayRegistration" type="xs:boolean" minOccurs="0" />
               <xs:element name="RegistrationDeadline" type="xs:date" minOccurs="0" />
               <xs:element name="AbsenteeRequestDeadline" type="xs:date" minOccurs="0" />
@@ -50,7 +54,7 @@ reference elements for polling location
           <xs:complexType>
             <xs:sequence>
               <xs:element name="Name" type="xs:string" />
-              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
+              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="ExternalIdentifierId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
@@ -64,7 +68,7 @@ reference elements for polling location
               <xs:element name="Name" type="xs:string" />
               <xs:element name="StateId" type="xs:IDREF" />
               <xs:element name="Type" type="xs:string" />
-              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
+              <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="ExternalIdentifierId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
             </xs:sequence>
@@ -110,7 +114,8 @@ reference elements for polling location
           <xs:complexType>
             <xs:all>
               <xs:element name="Name" type="InternationalizedText" minOccurs="0" />
-              <xs:element name="EoId" type="xs:IDREF" minOccurs="0" />
+              <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
+              <!-- Q: Please remind me what OVC stands for so we can expand this. -->
               <xs:element name="OvcId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="PhysicalAddress" type="SimpleAddressType" minOccurs="0" />
               <xs:element name="MailingAddress" type="SimpleAddressType" minOccurs="0" />
@@ -122,20 +127,11 @@ reference elements for polling location
               <xs:element name="WhatIsOnMyBallotUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="RulesUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="VoterServices" type="InternationalizedText" minOccurs="0" />
+              <!-- Note: The "Hours" element is being deprecated and will be removed
+                   in future versions of VIP.
+                -->
               <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
-            </xs:all>
-            <xs:attribute name="id" type="xs:ID" use="required" />
-          </xs:complexType>
-        </xs:element>
-
-        <xs:element name="ElectionOfficial">
-          <xs:complexType>
-            <xs:all>
-              <xs:element name="Name" type="xs:string" />
-              <xs:element name="Title" type="InternationalizedText" minOccurs="0" />
-              <xs:element name="Phone" type="xs:string" minOccurs="0" />
-              <xs:element name="Fax" type="xs:string" minOccurs="0" />
-              <xs:element name="Email" type="xs:string" minOccurs="0" />
+              <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
             </xs:all>
             <xs:attribute name="id" type="xs:ID" use="required" />
           </xs:complexType>
@@ -329,7 +325,7 @@ reference elements for polling location
               <xs:element name="Prefix" type="xs:string" minOccurs="0" />
               <xs:element name="Profession" type="InternationalizedText" minOccurs="0" />
               <xs:element name="Suffix" type="xs:string" minOccurs="0" />
-              <xs:element name="Title" type="xs:string" minOccurs="0" />
+              <xs:element name="Title" type="InternationalizedText" minOccurs="0" />
             </xs:sequence>
             <xs:attribute name="id" type="xs:ID" use="required" />
           </xs:complexType>


### PR DESCRIPTION
This PR needs a bit of love and attention, but the basic plan is to reuse 1622.2 objects within VIP where possible, and clean up some of the references, variable names, and links.

This also implements a simple solution to #63 by making ElectionAdministrationId a repeated field at the state and local level. Combined with the VoterServices field, this may be "good enough" for our purposes.

Cc: @jktomer @pstenbjorn @jungshadow @cjerdonek @pkoms @djbridges 