### PR TITLE
Address issue #63: voter services with different contacts

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -128,10 +128,6 @@ reference elements for polling location
               <xs:element name="Department" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:all>
-                    <!-- Note: The "Hours" element is being deprecated and will be removed
-                         in future versions of VIP.
-                    -->
-                    <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
                     <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" />
                     <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
                     <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
@@ -270,6 +266,10 @@ reference elements for polling location
               <xs:element name="AddressLine" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="Email" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="Fax" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+              <!-- Note: The "Hours" element is being deprecated and will be removed
+                   in future versions of VIP.
+              -->
+              <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
               <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="Name" type="xs:string" minOccurs="0" />
               <xs:element name="Phone" type="xs:string" minOccurs="0" maxOccurs="unbounded" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -113,12 +113,10 @@ reference elements for polling location
         <xs:element name="ElectionAdministration">
           <xs:complexType>
             <xs:all>
-              <xs:element name="Name" type="InternationalizedText" minOccurs="0" />
-              <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
-              <!-- Q: Please remind me what OVC stands for so we can expand this. -->
+              <!-- Q: Please remind me what OVC stands for so we can expand this,
+                      and should we move it to Department?
+              -->
               <xs:element name="OvcId" type="xs:IDREF" minOccurs="0" />
-              <xs:element name="PhysicalAddress" type="SimpleAddressType" minOccurs="0" />
-              <xs:element name="MailingAddress" type="SimpleAddressType" minOccurs="0" />
               <xs:element name="ElectionsUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="RegistrationUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="AmIRegisteredUrl" type="xs:anyURI" minOccurs="0" />
@@ -126,12 +124,36 @@ reference elements for polling location
               <xs:element name="WhereDoIVoteUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="WhatIsOnMyBallotUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="RulesUrl" type="xs:anyURI" minOccurs="0" />
-              <xs:element name="VoterServices" type="InternationalizedText" minOccurs="0" />
-              <!-- Note: The "Hours" element is being deprecated and will be removed
-                   in future versions of VIP.
-                -->
-              <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
-              <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
+              <!-- A locality may have more than one department with each handling different services. -->
+              <xs:element name="Department" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:all>
+                    <!-- Note: The "Hours" element is being deprecated and will be removed
+                         in future versions of VIP.
+                    -->
+                    <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
+                    <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
+                    <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:all>
+                          <xs:element name="Type" type="VoterServiceType" minOccurs="0" />
+                          <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+                          <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
+                          <!--
+                            The contact information below can be used to override or
+                            add specific fields to the base Departmental contact information if
+                            the service has different information.  For example, if the voter
+                            service has its own phone number, the Contact object below can be
+                            an object containing only a Phone element.
+                          -->
+                          <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" />
+                        </xs:all>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:all>
+                </xs:complexType>
+              </xs:element>
             </xs:all>
             <xs:attribute name="id" type="xs:ID" use="required" />
           </xs:complexType>
@@ -628,6 +650,14 @@ reference elements for polling location
       <xs:enumeration value="rcv" />
       <xs:enumeration value="rcv-borda" />
       <xs:enumeration value="super-majority" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="VoterServiceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="absentee-ballots" />
+      <xs:enumeration value="polling-places" />
+      <xs:enumeration value="voter-registration" />
     </xs:restriction>
   </xs:simpleType>
   <!-- End of enumerated values -->

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -132,7 +132,7 @@ reference elements for polling location
                          in future versions of VIP.
                     -->
                     <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
-                    <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" />
                     <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
                     <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
                       <xs:complexType>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -113,10 +113,6 @@ reference elements for polling location
         <xs:element name="ElectionAdministration">
           <xs:complexType>
             <xs:all>
-              <!-- Q: Please remind me what OVC stands for so we can expand this,
-                      and should we move it to Department?
-              -->
-              <xs:element name="OvcId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="ElectionsUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="RegistrationUrl" type="xs:anyURI" minOccurs="0" />
               <xs:element name="AmIRegisteredUrl" type="xs:anyURI" minOccurs="0" />
@@ -144,6 +140,11 @@ reference elements for polling location
                             an object containing only a Phone element.
                           -->
                           <xs:element name="ContactId" type="xs:IDREF" minOccurs="0" />
+                          <!--
+                            This is for use if a certain person handles the particular service,
+                            for example a contact person for overseas voting.
+                          -->
+                          <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
                         </xs:all>
                       </xs:complexType>
                     </xs:element>
@@ -656,6 +657,8 @@ reference elements for polling location
   <xs:simpleType name="VoterServiceType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="absentee-ballots" />
+      <xs:enumeration value="other" />
+      <xs:enumeration value="overseas-voting" />
       <xs:enumeration value="polling-places" />
       <xs:enumeration value="voter-registration" />
     </xs:restriction>


### PR DESCRIPTION
This is a first crack at addressing issue #63.

It addresses both of the following use cases: 1) the use case raised by @jungshadow of two different locations / departments handling different services, and 2) the use case mentioned by myself of different services having their own contact information within a department.

It also stubs out a `VoterServiceType` enum to address the common types of services.