### PR TITLE
Replace BallotStyleImageUri with a BallotStyleId

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -87,7 +87,7 @@ reference elements for polling location
               <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="PollingLocationId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
               <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
-              <xs:element name="BallotStyleImageUrl" type="xs:anyURI" minOccurs="0" />
+              <xs:element name="BallotStyleId" type="xs:IDREF" minOccurs="1" maxOccurs="1" />
               <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
             </xs:sequence>
             <xs:attribute name="id" type="xs:ID" use="required" />


### PR DESCRIPTION
The BallotStyle object can hold both an image URI as well as a set of contests (i.e., it's a superset of the URI, without loss of flexibility).

This should address issue #94.