### PR TITLE
Update HISTORY.md with changes since 3.x

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,61 +7,61 @@ This document includes release notes for the [VIP Spec][vip] for versions
 
 ### Spec Changes
 * Convergence with the [VSSC 1622.2][vssc_1622.2] election results reporting spec.
-  [[issue #42](https://github.com/votinginfoproject/vip-specification/issues/42)]
-  Objects and enumerations also used in 1622.2 include:
-  * `CandidatePreElectionStatus` and `CandidatePostElectionStatus`
-  * `DistrictType`
-  * `IdentifierType` (known in 1622.2 as `CodeType`)
-  * `BallotSelectionBase`, `BallotMeasureSelection`, and `CandidateSelection`
-  * `BallotStyle`
-  * `Candidate`
-  * `ContactInformation`
-  * `ContestBase`, `BallotMeasureContest`, `CandidateContest`, `PartyContest`,
-    and `RetentionContest`
-  * `HoursOpen` (known in 1622.2 as `Schedule`)
-  * `Office`
-  * `OrderedContest`
-  * `Party`
-  * `Person`
+  * Issue [#42](https://github.com/votinginfoproject/vip-specification/issues/42)
+  * Objects and enumerations also used in 1622.2 include:
+    * `CandidatePreElectionStatus` and `CandidatePostElectionStatus`
+    * `DistrictType`
+    * `IdentifierType` (known in 1622.2 as `CodeType`)
+    * `BallotSelectionBase`, `BallotMeasureSelection`, and `CandidateSelection`
+    * `BallotStyle`
+    * `Candidate`
+    * `ContactInformation`
+    * `ContestBase`, `BallotMeasureContest`, `CandidateContest`, `PartyContest`,
+      and `RetentionContest`
+    * `HoursOpen` (known in 1622.2 as `Schedule`)
+    * `Office`
+    * `OrderedContest`
+    * `Party`
+    * `Person`
 * Object identifiers use the `xs:ID` and `xs:IDREF` types instead of `xs:string`
   or `xs:integer`. The `xs:ID` type [has certain restrictions and
   requirements](http://books.xmlschemata.org/relaxng/ch19-77151.html) beyond
   normal strings or integers.
-  [[issue #45](https://github.com/votinginfoproject/vip-specification/issues/45)]
+  * Issue [#45](https://github.com/votinginfoproject/vip-specification/issues/45)
 * Add support for internationalization (i.e. multiple languages) via the
   `InternationalizedText` type.
-  [issues #39](https://github.com/votinginfoproject/vip-specification/issues/39) and
-  [#77](https://github.com/votinginfoproject/vip-specification/issues/77)]
+  * Issues [#39](https://github.com/votinginfoproject/vip-specification/issues/39) and
+  [#77](https://github.com/votinginfoproject/vip-specification/issues/77)
 * Per-`Precinct` links to `BallotStyle` elements.
-  [[issue #94](https://github.com/votinginfoproject/vip-specification/issues/94)]
+  * Issue [#94](https://github.com/votinginfoproject/vip-specification/issues/94)
 * Structured hours for open and close times.
-  [[issue #21](https://github.com/votinginfoproject/vip-specification/issues/21)]
+  * Issue [#21](https://github.com/votinginfoproject/vip-specification/issues/21)
 * Support for various voter services being handled by different departments or
   people.
-  [[issue #63](https://github.com/votinginfoproject/vip-specification/issues/63)]
+  * Issue [#63](https://github.com/votinginfoproject/vip-specification/issues/63)
 * Better handling of apartments/multi-home lots.
-  [[issue #22](https://github.com/votinginfoproject/vip-specification/issues/22)]
+  * Issue [#22](https://github.com/votinginfoproject/vip-specification/issues/22)
 * All elements which specify web links are now of type `xs:anyURI` (instead of
   `xs:string`) and end in `Uri` instead of `Url`.
-  [[issue #87](https://github.com/votinginfoproject/vip-specification/issues/87)]
+  * Issue [#87](https://github.com/votinginfoproject/vip-specification/issues/87)
 * Structured handling of types for `ElectoralDistrict` and `Locality`, replacing
   the free-form string with an enumeration.
-  [[issues #30](https://github.com/votinginfoproject/vip-specification/issues/30) and
-  [#129](https://github.com/votinginfoproject/vip-specification/issues/129)]
+  * Issues [#30](https://github.com/votinginfoproject/vip-specification/issues/30) and
+  [#129](https://github.com/votinginfoproject/vip-specification/issues/129)
 * The odd/even/both type (`OebType`) is now lower-case only.
-  [[issue #46](https://github.com/votinginfoproject/vip-specification/issues/46)]
+  * Issue [#46](https://github.com/votinginfoproject/vip-specification/issues/46)
 * The `yesNoEnum` has been replaced by `xs:boolean`, meaning those field can
   only take the values `true` or `false` (case-sensitive).
-  [[issue #66](https://github.com/votinginfoproject/vip-specification/issues/66)]
+  * Issue [#66](https://github.com/votinginfoproject/vip-specification/issues/66)
 
 ### Other Changes
 * The spec generally uses a [Venetian
   Blind](http://www.oracle.com/technetwork/java/design-patterns-142138.html) design philosophy.
-  [[issue #113](https://github.com/votinginfoproject/vip-specification/issues/113)]
+  * Issue [#113](https://github.com/votinginfoproject/vip-specification/issues/113)
 * Created a
   [spec style
   guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/STYLEGUIDE.md).
-  [[issues #41](https://github.com/votinginfoproject/vip-specification/issues/41),
+  * Issues [#41](https://github.com/votinginfoproject/vip-specification/issues/41),
   [#74](https://github.com/votinginfoproject/vip-specification/issues/74),
   [#75](https://github.com/votinginfoproject/vip-specification/issues/75),
   [#83](https://github.com/votinginfoproject/vip-specification/issues/83),
@@ -69,15 +69,15 @@ This document includes release notes for the [VIP Spec][vip] for versions
   [#106](https://github.com/votinginfoproject/vip-specification/issues/106),
   [#126](https://github.com/votinginfoproject/vip-specification/issues/126),
   [#136](https://github.com/votinginfoproject/vip-specification/issues/136), and
-  [#138](https://github.com/votinginfoproject/vip-specification/issues/138)]
+  [#138](https://github.com/votinginfoproject/vip-specification/issues/138)
 * Created a
   [CONTRIBUTING
   guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/CONTRIBUTING.md).
-  [[issue #93](https://github.com/votinginfoproject/vip-specification/issues/93)]
+  * Issue [#93](https://github.com/votinginfoproject/vip-specification/issues/93)
 * Created an approval process for pull requests.
-  [[issue #117](https://github.com/votinginfoproject/vip-specification/issues/117)]
+  * Issue [#117](https://github.com/votinginfoproject/vip-specification/issues/117)
 * The sample feed now uses UTF-8.
-  [[issue #81](https://github.com/votinginfoproject/vip-specification/issues/81)]
+  * Issue [#81](https://github.com/votinginfoproject/vip-specification/issues/81)
 
 [vssc_1622.2]: http://grouper.ieee.org/groups/1622/groups/2/
 [vip]: https://github.com/votinginfoproject/vip-specification

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,14 +24,14 @@ This document includes release notes for the [VIP Spec][vip] for versions
   * `Party`
   * `Person`
 * Object identifiers use the `xs:ID` and `xs:IDREF` types instead of `xs:string`
-  or `xs:integer`. The `xs:ID` type [[has certain restrictions and
-  requirements](http://books.xmlschemata.org/relaxng/ch19-77151.html)] beyond
+  or `xs:integer`. The `xs:ID` type [has certain restrictions and
+  requirements](http://books.xmlschemata.org/relaxng/ch19-77151.html) beyond
   normal strings or integers.
-  [issue #45](https://github.com/votinginfoproject/vip-specification/issues/45)]
+  [[issue #45](https://github.com/votinginfoproject/vip-specification/issues/45)]
 * Add support for internationalization (i.e. multiple languages) via the
   `InternationalizedText` type.
-  [[issue #39](https://github.com/votinginfoproject/vip-specification/issues/39) and
-  [issue #77](https://github.com/votinginfoproject/vip-specification/issues/77)]
+  [issues #39](https://github.com/votinginfoproject/vip-specification/issues/39) and
+  [#77](https://github.com/votinginfoproject/vip-specification/issues/77)]
 * Per-`Precinct` links to `BallotStyle` elements.
   [[issue #94](https://github.com/votinginfoproject/vip-specification/issues/94)]
 * Structured hours for open and close times.
@@ -46,8 +46,8 @@ This document includes release notes for the [VIP Spec][vip] for versions
   [[issue #87](https://github.com/votinginfoproject/vip-specification/issues/87)]
 * Structured handling of types for `ElectoralDistrict` and `Locality`, replacing
   the free-form string with an enumeration.
-  [[issue #30](https://github.com/votinginfoproject/vip-specification/issues/30) and
-  [issue #129](https://github.com/votinginfoproject/vip-specification/issues/129)]
+  [[issues #30](https://github.com/votinginfoproject/vip-specification/issues/30) and
+  [#129](https://github.com/votinginfoproject/vip-specification/issues/129)]
 * The odd/even/both type (`OebType`) is now lower-case only.
   [[issue #46](https://github.com/votinginfoproject/vip-specification/issues/46)]
 * The `yesNoEnum` has been replaced by `xs:boolean`, meaning those field can
@@ -55,24 +55,24 @@ This document includes release notes for the [VIP Spec][vip] for versions
   [[issue #66](https://github.com/votinginfoproject/vip-specification/issues/66)]
 
 ### Other Changes
-* The spec generally uses a [[Venetian
-  Blind](http://www.oracle.com/technetwork/java/design-patterns-142138.html)] design philosophy.
+* The spec generally uses a [Venetian
+  Blind](http://www.oracle.com/technetwork/java/design-patterns-142138.html) design philosophy.
   [[issue #113](https://github.com/votinginfoproject/vip-specification/issues/113)]
 * Created a
-  [[spec style
-  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/STYLEGUIDE.md)]
-  [[issue #41](https://github.com/votinginfoproject/vip-specification/issues/41),
-  [issue #74](https://github.com/votinginfoproject/vip-specification/issues/74),
-  [issue #75](https://github.com/votinginfoproject/vip-specification/issues/75),
-  [issue #83](https://github.com/votinginfoproject/vip-specification/issues/83),
-  [issue #85](https://github.com/votinginfoproject/vip-specification/issues/85),
-  [issue #106](https://github.com/votinginfoproject/vip-specification/issues/106),
-  [issue #126](https://github.com/votinginfoproject/vip-specification/issues/126),
-  [issue #136](https://github.com/votinginfoproject/vip-specification/issues/136), and
-  [issue #138](https://github.com/votinginfoproject/vip-specification/issues/138)]
+  [spec style
+  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/STYLEGUIDE.md).
+  [[issues #41](https://github.com/votinginfoproject/vip-specification/issues/41),
+  [#74](https://github.com/votinginfoproject/vip-specification/issues/74),
+  [#75](https://github.com/votinginfoproject/vip-specification/issues/75),
+  [#83](https://github.com/votinginfoproject/vip-specification/issues/83),
+  [#85](https://github.com/votinginfoproject/vip-specification/issues/85),
+  [#106](https://github.com/votinginfoproject/vip-specification/issues/106),
+  [#126](https://github.com/votinginfoproject/vip-specification/issues/126),
+  [#136](https://github.com/votinginfoproject/vip-specification/issues/136), and
+  [#138](https://github.com/votinginfoproject/vip-specification/issues/138)]
 * Created a
-  [[CONTRIBUTING
-  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/CONTRIBUTING.md)]
+  [CONTRIBUTING
+  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/CONTRIBUTING.md).
   [[issue #93](https://github.com/votinginfoproject/vip-specification/issues/93)]
 * Created an approval process for pull requests.
   [[issue #117](https://github.com/votinginfoproject/vip-specification/issues/117)]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,22 +1,83 @@
-VIP Release Notes
-=================
+# VIP Release Notes
 
 This document includes release notes for the [VIP Spec][vip] for versions
 5.0 and later.
 
+## Version 5.0
 
-Version 5.0 (in progress)
--------------------------
-
+### Spec Changes
+* Convergence with the [VSSC 1622.2][vssc_1622.2] election results reporting spec.
+  [[issue #42](https://github.com/votinginfoproject/vip-specification/issues/42)]
+  Objects and enumerations also used in 1622.2 include:
+  * `CandidatePreElectionStatus` and `CandidatePostElectionStatus`
+  * `DistrictType`
+  * `IdentifierType` (known in 1622.2 as `CodeType`)
+  * `BallotSelectionBase`, `BallotMeasureSelection`, and `CandidateSelection`
+  * `BallotStyle`
+  * `Candidate`
+  * `ContactInformation`
+  * `ContestBase`, `BallotMeasureContest`, `CandidateContest`, `PartyContest`,
+    and `RetentionContest`
+  * `HoursOpen` (known in 1622.2 as `Schedule`)
+  * `Office`
+  * `OrderedContest`
+  * `Party`
+  * `Person`
+* Object identifiers use the `xs:ID` and `xs:IDREF` types instead of `xs:string`
+  or `xs:integer`. The `xs:ID` type [[has certain restrictions and
+  requirements](http://books.xmlschemata.org/relaxng/ch19-77151.html)] beyond
+  normal strings or integers.
+  [issue #45](https://github.com/votinginfoproject/vip-specification/issues/45)]
 * Add support for internationalization (i.e. multiple languages) via the
   `InternationalizedText` type.
   [[issue #39](https://github.com/votinginfoproject/vip-specification/issues/39) and
   [issue #77](https://github.com/votinginfoproject/vip-specification/issues/77)]
-* Port ballot objects from the latest version of the [VSSC 1622.2][vssc_1622.2]
-  spec (includes types like `Candidate`, `Contest`, `Office`, `Party`, etc).
-  [[issue #42](https://github.com/votinginfoproject/vip-specification/issues/42)]
-* TODO
+* Per-`Precinct` links to `BallotStyle` elements.
+  [[issue #94](https://github.com/votinginfoproject/vip-specification/issues/94)]
+* Structured hours for open and close times.
+  [[issue #21](https://github.com/votinginfoproject/vip-specification/issues/21)]
+* Support for various voter services being handled by different departments or
+  people.
+  [[issue #63](https://github.com/votinginfoproject/vip-specification/issues/63)]
+* Better handling of apartments/multi-home lots.
+  [[issue #22](https://github.com/votinginfoproject/vip-specification/issues/22)]
+* All elements which specify web links are now of type `xs:anyURI` (instead of
+  `xs:string`) and end in `Uri` instead of `Url`.
+  [[issue #87](https://github.com/votinginfoproject/vip-specification/issues/87)]
+* Structured handling of types for `ElectoralDistrict` and `Locality`, replacing
+  the free-form string with an enumeration.
+  [[issue #30](https://github.com/votinginfoproject/vip-specification/issues/30) and
+  [issue #129](https://github.com/votinginfoproject/vip-specification/issues/129)]
+* The odd/even/both type (`OebType`) is now lower-case only.
+  [[issue #46](https://github.com/votinginfoproject/vip-specification/issues/46)]
+* The `yesNoEnum` has been replaced by `xs:boolean`, meaning those field can
+  only take the values `true` or `false` (case-sensitive).
+  [[issue #66](https://github.com/votinginfoproject/vip-specification/issues/66)]
 
+### Other Changes
+* The spec generally uses a [[Venetian
+  Blind](http://www.oracle.com/technetwork/java/design-patterns-142138.html)] design philosophy.
+  [[issue #113](https://github.com/votinginfoproject/vip-specification/issues/113)]
+* Created a
+  [[spec style
+  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/STYLEGUIDE.md)]
+  [[issue #41](https://github.com/votinginfoproject/vip-specification/issues/41),
+  [issue #74](https://github.com/votinginfoproject/vip-specification/issues/74),
+  [issue #75](https://github.com/votinginfoproject/vip-specification/issues/75),
+  [issue #83](https://github.com/votinginfoproject/vip-specification/issues/83),
+  [issue #85](https://github.com/votinginfoproject/vip-specification/issues/85),
+  [issue #106](https://github.com/votinginfoproject/vip-specification/issues/106),
+  [issue #126](https://github.com/votinginfoproject/vip-specification/issues/126),
+  [issue #136](https://github.com/votinginfoproject/vip-specification/issues/136), and
+  [issue #138](https://github.com/votinginfoproject/vip-specification/issues/138)]
+* Created a
+  [[CONTRIBUTING
+  guide](https://github.com/votinginfoproject/vip-specification/blob/vip5/CONTRIBUTING.md)]
+  [[issue #93](https://github.com/votinginfoproject/vip-specification/issues/93)]
+* Created an approval process for pull requests.
+  [[issue #117](https://github.com/votinginfoproject/vip-specification/issues/117)]
+* The sample feed now uses UTF-8.
+  [[issue #81](https://github.com/votinginfoproject/vip-specification/issues/81)]
 
 [vssc_1622.2]: http://grouper.ieee.org/groups/1622/groups/2/
 [vip]: https://github.com/votinginfoproject/vip-specification


### PR DESCRIPTION
Updated the HISTORY.md document to highlight most of the changes we've made since the 3.x release. Changes are broken down into how they update the spec itself and how they update the process of contributing to and designing the spec.