### PR TITLE
Add examples to sample feed

### DIFF
--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -1468,12 +1468,20 @@
     <AddressLine>Charlottesville, VA 229018917</AddressLine>
     <HoursOpenId>hours0002</HoursOpenId>
     <IsEarlyVoting>true</IsEarlyVoting>
+    <LatLng>
+      <Latitude>38.075578</Latitude>
+      <Longitude>-78.501695</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl81274">
     <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
     <AddressLine>2775 Hydraulic Rd</AddressLine>
     <AddressLine>Charlottesville, VA 229018917</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.075578</Latitude>
+      <Longitude>-78.501695</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80232">
     <AddressLine>SENIOR CENTER</AddressLine>
@@ -1492,12 +1500,20 @@
     <AddressLine>210 Lambs Ln</AddressLine>
     <AddressLine>Charlottesville, VA 229018951</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.077069</Latitude>
+      <Longitude>-78.506559</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80142">
     <AddressLine>HOLLYMEAD ELEMENTARY SCHOOL</AddressLine>
     <AddressLine>2775 Powell Creek Dr</AddressLine>
     <AddressLine>Charlottesville, VA 229117539</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.112383</Latitude>
+      <Longitude>-78.439298</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80522">
     <AddressLine>CATEC</AddressLine>
@@ -1510,6 +1526,10 @@
     <AddressLine>958 N Milton Rd</AddressLine>
     <AddressLine>Charlottesville, VA 229113612</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.010650</Latitude>
+      <Longitude>-78.397309</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80469">
     <AddressLine>ELKS LODGE HALL</AddressLine>
@@ -1522,12 +1542,20 @@
     <AddressLine>3893 Stony Point Rd</AddressLine>
     <AddressLine>Keswick, VA 229471503</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>41.229539</Latitude>
+      <Longitude>-73.987085</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl82419">
     <AddressLine>EARLYSVILLE FIRE DEPARTMENT</AddressLine>
     <AddressLine>283 Reas Ford Rd</AddressLine>
     <AddressLine>Earlysville, VA 229362410</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.152907</Latitude>
+      <Longitude>-78.462406</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl81466">
     <AddressLine>UNIVERSITY HALL</AddressLine>
@@ -1537,24 +1565,40 @@
       <Text language="en">North Lobby</Text>
     </Directions>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.044667</Latitude>
+      <Longitude>-78.508818</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl81857">
     <AddressLine>WOODBROOK ELEMENTARY SCHOOL</AddressLine>
     <AddressLine>100 Woodbrook Dr</AddressLine>
     <AddressLine>Charlottesville, VA 229011133</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.087175</Latitude>
+      <Longitude>-78.466174</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl81990">
     <AddressLine>RED HILL ELEMENTARY SCHOOL</AddressLine>
     <AddressLine>3901 Red Hill School Rd</AddressLine>
     <AddressLine>North Garden, VA 229591704</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>37.964307</Latitude>
+      <Longitude>-78.634461</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl82177">
     <AddressLine>PAUL H CALE ELEMENTARY SCHOOL</AddressLine>
     <AddressLine>1757 Avon Street Ext</AddressLine>
     <AddressLine>Charlottesville, VA 229028708</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>37.996254</Latitude>
+      <Longitude>-78.499288</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80548">
     <AddressLine>BEREAN BAPTIST CHURCH</AddressLine>
@@ -1567,6 +1611,10 @@
     <AddressLine>5870 Rockfish Gap Tpke</AddressLine>
     <AddressLine>Crozet, VA 229323401</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.052251</Latitude>
+      <Longitude>-78.702520</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80354">
     <AddressLine>ZION HILL BAPTIST CHURCH</AddressLine>
@@ -1579,12 +1627,20 @@
     <AddressLine>1407 Crozet Ave</AddressLine>
     <AddressLine>Crozet, VA 229322722</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.074684</Latitude>
+      <Longitude>-78.697296</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80541">
     <AddressLine>SCOTTSVILLE ELEMENTARY SCHOOL</AddressLine>
     <AddressLine>7868 Scottsville Rd</AddressLine>
     <AddressLine>Scottsville, VA 245903963</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>37.818476</Latitude>
+      <Longitude>-78.510843</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl80432">
     <AddressLine>AGNOR-HURT ELEMENTARY SCHOOL</AddressLine>
@@ -1597,6 +1653,10 @@
     <AddressLine>799 Faulconer Drive</AddressLine>
     <AddressLine>Charlottesville, VA 22903</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.055801</Latitude>
+      <Longitude>-78.520233</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl82220">
     <AddressLine>MONTICELLO HIGH SCHOOL</AddressLine>
@@ -1609,6 +1669,10 @@
     <AddressLine>185 Buck Mountain Rd</AddressLine>
     <AddressLine>Earlysville, VA 229362009</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.162374</Latitude>
+      <Longitude>-78.489944</Longitude>
+    </LatLng>
   </PollingLocation>
   <PollingLocation id="pl81118">
     <AddressLine>MERIWETHER LEWIS ELEM SCHOOL</AddressLine>
@@ -1621,6 +1685,10 @@
     <AddressLine>2201 Old Ivy Rd</AddressLine>
     <AddressLine>Charlottesville, VA 229034822</AddressLine>
     <HoursOpenId>hours0001</HoursOpenId>
+    <LatLng>
+      <Latitude>38.047660</Latitude>
+      <Longitude>-78.513654</Longitude>
+    </LatLng>
   </PollingLocation>
 
   <!--

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -143,6 +143,34 @@
       <EndDate>2013-11-05</EndDate>
     </Schedule>
   </HoursOpen>
+  <!-- Early voting hours. Note the different time zones. -->
+  <HoursOpen id="hours0002">
+    <Schedule>
+      <Hours>
+        <StartTime>07:00:00-04:00</StartTime>
+        <EndTime>19:00:00-04:00</EndTime>
+      </Hours>
+      <StartDate>2013-10-21</StartDate>
+      <EndDate>2013-10-26</EndDate>
+    </Schedule>
+    <Schedule>
+      <Hours>
+        <StartTime>07:00:00-04:00</StartTime>
+        <EndTime>19:00:00-04:00</EndTime>
+      </Hours>
+      <StartDate>2013-10-28</StartDate>
+      <EndDate>2013-11-02</EndDate>
+    </Schedule>
+    <!-- Clocks fall back. -->
+    <Schedule>
+      <Hours>
+        <StartTime>07:00:00-05:00</StartTime>
+        <EndTime>19:00:00-05:00</EndTime>
+      </Hours>
+      <StartDate>2013-11-04</StartDate>
+      <EndDate>2013-11-04</EndDate>
+    </Schedule>
+  </HoursOpen>
 
   <!--
        The various political parties. These are defined separately to allow
@@ -1434,6 +1462,13 @@
   </BallotMeasureSelection>
 
   <!-- The polling locations in this jurisdiction. -->
+  <PollingLocation id="pl81273">
+    <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
+    <AddressLine>2775 Hydraulic Rd</AddressLine>
+    <AddressLine>Charlottesville, VA 229018917</AddressLine>
+    <HoursOpenId>hours0002</HoursOpenId>
+    <IsEarlyVoting>true</IsEarlyVoting>
+  </PollingLocation>
   <PollingLocation id="pl81274">
     <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
     <AddressLine>2775 Hydraulic Rd</AddressLine>
@@ -1601,6 +1636,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>203 - GEORGETOWN</Name>
     <Number>0203</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81274</PollingLocationId>
   </Precinct>
   <Precinct id="pre90139">
@@ -1612,6 +1648,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>103 - BRANCHLANDS</Name>
     <Number>0103</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80232</PollingLocationId>
   </Precinct>
   <Precinct id="pre90183">
@@ -1622,6 +1659,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>602 - FREE UNION</Name>
     <Number>0602</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81853</PollingLocationId>
   </Precinct>
   <Precinct id="pre90348sp0000">
@@ -1633,6 +1671,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>201 - JACK JOUETT</Name>
     <Number>0201</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81662</PollingLocationId>
     <PrecinctSplitName>0000</PrecinctSplitName>
   </Precinct>
@@ -1645,6 +1684,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>201 - JACK JOUETT</Name>
     <Number>0201</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81662</PollingLocationId>
     <PrecinctSplitName>0001</PrecinctSplitName>
   </Precinct>
@@ -1656,6 +1696,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>503 - HOLLYMEAD</Name>
     <Number>0503</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80142</PollingLocationId>
   </Precinct>
   <Precinct id="pre90666">
@@ -1667,6 +1708,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>105 - DUNLORA</Name>
     <Number>0105</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80522</PollingLocationId>
   </Precinct>
   <Precinct id="pre90929">
@@ -1678,6 +1720,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>406 - STONE ROBINSON</Name>
     <Number>0406</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81500</PollingLocationId>
   </Precinct>
   <Precinct id="pre90994sp0000">
@@ -1688,6 +1731,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>504 - FREE BRIDGE</Name>
     <Number>0504</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80469</PollingLocationId>
     <PrecinctSplitName>0000</PrecinctSplitName>
   </Precinct>
@@ -1699,6 +1743,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>504 - FREE BRIDGE</Name>
     <Number>0504</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80469</PollingLocationId>
     <PrecinctSplitName>0001</PrecinctSplitName>
   </Precinct>
@@ -1710,6 +1755,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>502 - STONY POINT</Name>
     <Number>0502</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81516</PollingLocationId>
     <PrecinctSplitName>0000</PrecinctSplitName>
   </Precinct>
@@ -1721,6 +1767,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>502 - STONY POINT</Name>
     <Number>0502</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81516</PollingLocationId>
     <PrecinctSplitName>0001</PrecinctSplitName>
   </Precinct>
@@ -1733,6 +1780,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>106 - NORTHSIDE</Name>
     <Number>0106</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl82419</PollingLocationId>
   </Precinct>
   <Precinct id="pre91602">
@@ -1744,6 +1792,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>202 - UNIVERSITY HALL</Name>
     <Number>0202</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81466</PollingLocationId>
   </Precinct>
   <Precinct id="pre91781sp0000">
@@ -1756,6 +1805,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>101 - WOODBROOK</Name>
     <Number>0101</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81857</PollingLocationId>
     <PrecinctSplitName>0000</PrecinctSplitName>
   </Precinct>
@@ -1768,6 +1818,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>101 - WOODBROOK</Name>
     <Number>0101</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81857</PollingLocationId>
     <PrecinctSplitName>0001</PrecinctSplitName>
   </Precinct>
@@ -1780,6 +1831,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>302 - RED HILL</Name>
     <Number>0302</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81990</PollingLocationId>
   </Precinct>
   <Precinct id="pre91999">
@@ -1791,6 +1843,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>405 - CALE</Name>
     <Number>0405</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl82177</PollingLocationId>
   </Precinct>
   <Precinct id="pre92065">
@@ -1802,6 +1855,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>305 - COUNTRY GREEN</Name>
     <Number>0305</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80548</PollingLocationId>
   </Precinct>
   <Precinct id="pre92087">
@@ -1812,6 +1866,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>604 - BROWNSVILLE</Name>
     <Number>0604</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81939</PollingLocationId>
   </Precinct>
   <Precinct id="pre92140">
@@ -1822,6 +1877,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>501 - KESWICK</Name>
     <Number>0501</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80354</PollingLocationId>
   </Precinct>
   <Precinct id="pre92145">
@@ -1832,6 +1888,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>601 - CROZET</Name>
     <Number>0601</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl82204</PollingLocationId>
   </Precinct>
   <Precinct id="pre92171sp0000">
@@ -1843,6 +1900,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>401 - SCOTTSVILLE</Name>
     <Number>0401</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80541</PollingLocationId>
     <PrecinctSplitName>0000</PrecinctSplitName>
   </Precinct>
@@ -1855,6 +1913,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>401 - SCOTTSVILLE</Name>
     <Number>0401</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80541</PollingLocationId>
     <PrecinctSplitName>0001</PrecinctSplitName>
   </Precinct>
@@ -1867,6 +1926,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>104 - AGNOR-HURT</Name>
     <Number>0104</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80432</PollingLocationId>
   </Precinct>
   <Precinct id="pre92306">
@@ -1878,6 +1938,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>204 - BELFIELD</Name>
     <Number>0204</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81191</PollingLocationId>
   </Precinct>
   <Precinct id="pre92320">
@@ -1889,6 +1950,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>402 - MONTICELLO</Name>
     <Number>0402</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl82220</PollingLocationId>
   </Precinct>
   <Precinct id="pre92353">
@@ -1899,6 +1961,7 @@
     <LocalityId>loc70001</LocalityId>
     <Name>603 - EARLYSVILLE</Name>
     <Number>0603</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl80131</PollingLocationId>
   </Precinct>
   <Precinct id="pre92360">
@@ -1921,8 +1984,11 @@
     <LocalityId>loc70001</LocalityId>
     <Name>304 - EAST IVY</Name>
     <Number>0304</Number>
+    <PollingLocationId>pl81273</PollingLocationId>
     <PollingLocationId>pl81213</PollingLocationId>
   </Precinct>
+
+  <!-- Street segments -->
   <StreetSegment id="ss309904">
     <NonHouseAddress>
       <City>GREENWOOD</City>

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -603,6 +603,29 @@
     <OfficeId>off20476</OfficeId>
     <VotesAllowed>1</VotesAllowed>
   </CandidateContest>
+  <BallotMeasureContest id="bmc30001">
+    <BallotSelectionId>bms30001a</BallotSelectionId>
+    <BallotSelectionId>bms30001b</BallotSelectionId>
+    <BallotTitle>
+      <Text language="en">State of the State</Text>
+      <Text language="es">Estado del Estado.</Text>
+    </BallotTitle>
+    <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+    <Name>Referendum on Virginia</Name>
+    <ConStatement identifier="bmc30001con">
+      <Text language="en">This is no good.</Text>
+      <Text language="es">Esto no es bueno.</Text>
+    </ConStatement>
+    <EffectOfAbstain identifier="bmc30001abs">
+      <Text language="en">Nothing will happen.</Text>
+      <Text language="es">Nada pasará.</Text>
+    </EffectOfAbstain>
+    <ProStatement identifier="bmc30001pro">
+      <Text language="en">Everything will be great.</Text>
+      <Text language="es">Todo va a estar bien.</Text>
+    </ProStatement>
+    <Type>referendum</Type>
+  </BallotMeasureContest>
 
   <!-- The various ballot styles in use by the different precincts. -->
   <BallotStyle id="bs00000">
@@ -613,6 +636,7 @@
     <OrderedContestId>oc20025</OrderedContestId>
     <OrderedContestId>oc20355</OrderedContestId>
     <OrderedContestId>oc20449</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00001">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -622,6 +646,7 @@
     <OrderedContestId>oc20033</OrderedContestId>
     <OrderedContestId>oc20350</OrderedContestId>
     <OrderedContestId>oc20473</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00002">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -631,6 +656,7 @@
     <OrderedContestId>oc20024</OrderedContestId>
     <OrderedContestId>oc20305</OrderedContestId>
     <OrderedContestId>oc20476</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00003">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -638,12 +664,14 @@
     <OrderedContestId>oc20004</OrderedContestId>
     <OrderedContestId>oc20005</OrderedContestId>
     <OrderedContestId>oc20100</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00004">
     <OrderedContestId>oc20003bca</OrderedContestId>
     <OrderedContestId>oc20004</OrderedContestId>
     <OrderedContestId>oc20005</OrderedContestId>
     <OrderedContestId>oc20024</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00005">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -651,6 +679,7 @@
     <OrderedContestId>oc20004</OrderedContestId>
     <OrderedContestId>oc20005</OrderedContestId>
     <OrderedContestId>oc20025</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00006">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -660,6 +689,7 @@
     <OrderedContestId>oc20024</OrderedContestId>
     <OrderedContestId>oc20350</OrderedContestId>
     <OrderedContestId>oc20473</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00007">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -669,6 +699,7 @@
     <OrderedContestId>oc20100</OrderedContestId>
     <OrderedContestId>oc20355</OrderedContestId>
     <OrderedContestId>oc20449</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00008">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -679,6 +710,7 @@
     <OrderedContestId>oc20100</OrderedContestId>
     <OrderedContestId>oc20355</OrderedContestId>
     <OrderedContestId>oc20449</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00009">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -687,6 +719,7 @@
     <OrderedContestId>oc20005</OrderedContestId>
     <OrderedContestId>oc20100</OrderedContestId>
     <OrderedContestId>oc20262</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00010">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -696,6 +729,7 @@
     <OrderedContestId>oc20025</OrderedContestId>
     <OrderedContestId>oc20305</OrderedContestId>
     <OrderedContestId>oc20476</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
   <BallotStyle id="bs00011">
     <OrderedContestId>oc20002</OrderedContestId>
@@ -704,6 +738,7 @@
     <OrderedContestId>oc20005</OrderedContestId>
     <OrderedContestId>oc20025</OrderedContestId>
     <OrderedContestId>oc20262</OrderedContestId>
+    <OrderedContestId>oc30001</OrderedContestId>
   </BallotStyle>
 
   <!--
@@ -772,6 +807,9 @@
   </OrderedContest>
   <OrderedContest id="oc20350">
     <ContestId>cc20350</ContestId>
+  </OrderedContest>
+  <OrderedContest id="oc30001">
+    <ContestId>bmc30001</ContestId>
   </OrderedContest>
 
   <!--
@@ -1381,6 +1419,19 @@
     <Nickname>Kate</Nickname>
     <PartyId>par0004</PartyId>
   </Person>
+  <!-- Ballot measure selections -->
+  <BallotMeasureSelection id="bms30001a">
+    <Selection identifier="bms30001at">
+      <Text language="en">Yes</Text>
+      <Text language="es">Sí</Text>
+    </Selection>
+  </BallotMeasureSelection>
+  <BallotMeasureSelection id="bms30001b">
+    <Selection identifier="bms30001bt">
+      <Text language="en">No</Text>
+      <Text language="es">No</Text>
+    </Selection>
+  </BallotMeasureSelection>
 
   <!-- The polling locations in this jurisdiction. -->
   <PollingLocation id="pl81274">


### PR DESCRIPTION
The examples added include:
1. `LatLng` for several polling locations;
2. A `BallotMeasureContest`;
3. An early vote site which is also an election-day site; and
4. An `HoursOpen` example which spans time zone changes (EST vs EDT).

This addresses some of the requests in #179. There will be at least one more PR after this one which adds the other requests from #179.