### PR TITLE
Update the spec to include the latest revision of 1622.2

### DIFF
--- a/docs/xml/elements/ordered_contest.rst
+++ b/docs/xml/elements/ordered_contest.rst
@@ -6,41 +6,42 @@ ballot selections. ``OrderedContest`` elements can be collected within a
 :doc:`BallotStyle <ballot_style>` to accurate depict exactly what will show up on a particular
 ballot in the proper order.
 
-+-------------------+------------+------------+----------+---------------------------+---------------------------------+
-| Tag               | Data Type  | Required?  | Repeats? |Description                |Error Handling                   |
-|                   |            |            |          |                           |                                 |
-+===================+============+============+==========+===========================+=================================+
-| BallotSelectionId | xs:IDREF   | Optional   | Repeats  |Links to elements that     |If the field is invalid or not   |
-|                   |            |            |          |extend                     |present, the implementation is   |
-|                   |            |            |          |:doc:`BallotSelectionBase  |required to ignore it. If no     |
-|                   |            |            |          |<ballot_selection_base>`.  |``BallotSelectionId`` elements   |
-|                   |            |            |          |                           |are present, the presumed order  |
-|                   |            |            |          |                           |of the selection will be the     |
-|                   |            |            |          |                           |order of                         |
-|                   |            |            |          |                           |:doc:`BallotSelectionBase        |
-|                   |            |            |          |                           |<ballot_selection_base>`-extended|
-|                   |            |            |          |                           |elements referenced by the       |
-|                   |            |            |          |                           |underlying :doc:`ContestBase     |
-|                   |            |            |          |                           |<contest_base>`-extended         |
-|                   |            |            |          |                           |elements.                        |
-+-------------------+------------+------------+----------+---------------------------+---------------------------------+
-| ContestId         | xs:IDREF   |**Required**| Single   |Links to elements that     |If the field is invalid or not   |
-|                   |            |            |          |extend :doc:`ContestBase   |present, the implementation is   |
-|                   |            |            |          |<contest_base>`.           |required to ignore the           |
-|                   |            |            |          |                           |``OrderedContest`` element       |
-|                   |            |            |          |                           |containing it.                   |
-|                   |            |            |          |                           |                                 |
-|                   |            |            |          |                           |                                 |
-|                   |            |            |          |                           |                                 |
-|                   |            |            |          |                           |                                 |
-+-------------------+------------+------------+----------+---------------------------+---------------------------------+
++--------------------------+------------+------------+----------+---------------------------+---------------------------------+
+| Tag                      | Data Type  | Required?  | Repeats? |Description                |Error Handling                   |
+|                          |            |            |          |                           |                                 |
++==========================+============+============+==========+===========================+=================================+
+| ContestId                | xs:IDREF   |**Required**| Single   |Links to elements that     |If the field is invalid or not   |
+|                          |            |            |          |extend :doc:`ContestBase   |present, the implementation is   |
+|                          |            |            |          |<contest_base>`.           |required to ignore the           |
+|                          |            |            |          |                           |``OrderedContest`` element       |
+|                          |            |            |          |                           |containing it.                   |
+|                          |            |            |          |                           |                                 |
+|                          |            |            |          |                           |                                 |
+|                          |            |            |          |                           |                                 |
+|                          |            |            |          |                           |                                 |
++--------------------------+------------+------------+----------+---------------------------+---------------------------------+
+| OrderedBallotSelectionId | xs:IDREF   | Optional   | Repeats  |Links to elements that     |If the field is invalid or not   |
+|                          |            |            |          |extend                     |present, the implementation is   |
+|                          |            |            |          |:doc:`BallotSelectionBase  |required to ignore it. If no     |
+|                          |            |            |          |<ballot_selection_base>`.  |``OrderedBallotSelectionId``     |
+|                          |            |            |          |                           |elements are present, the        |
+|                          |            |            |          |                           |presumed order of the selection  |
+|                          |            |            |          |                           |will be the order of                         |
+|                          |            |            |          |                           |:doc:`BallotSelectionBase        |
+|                          |            |            |          |                           |<ballot_selection_base>`-extended|
+|                          |            |            |          |                           |elements referenced by the       |
+|                          |            |            |          |                           |underlying :doc:`ContestBase     |
+|                          |            |            |          |                           |<contest_base>`-extended         |
+|                          |            |            |          |                           |elements.                        |
++--------------------------+------------+------------+----------+---------------------------+---------------------------------+
 
 .. code-block:: xml
    :linenos:
 
    <OrderedContest id="oc20003abc">
-      <BallotSelectionId>cs10961</BallotSelectionId>
-      <BallotSelectionId>cs10962</BallotSelectionId>
-      <BallotSelectionId>cs10963</BallotSelectionId>
+
       <ContestId>cc20003</ContestId>
+      <OrderedBallotSelectionId>cs10961</OrderedBallotSelectionId>
+      <OrderedBallotSelectionId>cs10962</OrderedBallotSelectionId>
+      <OrderedBallotSelectionId>cs10963</OrderedBallotSelectionId>
    </OrderedContest>

--- a/docs/xml/elements/person.rst
+++ b/docs/xml/elements/person.rst
@@ -28,6 +28,15 @@ or elected official. These elements reference ``Person``:
 |                    |                           |              |            |                           |required to ignore it.          |
 |                    |                           |              |            |                           |                                |
 +--------------------+---------------------------+--------------+------------+---------------------------+--------------------------------+
+| FullName           |:doc:`InternationalizedText| Optional     | Single     |Specifies a person's       |If the field is invalid or not  |
+|                    |<internationalized_text>`  |              |            |full name (**NB:** this    |present, the implementation is  |
+|                    |                           |              |            |information is             |required to ignore it.          |
+|                    |                           |              |            |:doc:`InternationalizedText|                                |
+|                    |                           |              |            |<internationalized_text>`  |                                |
+|                    |                           |              |            |because it sometimes       |                                |
+|                    |                           |              |            |appears on ballots in      |                                |
+|                    |                           |              |            |multiple languages).       |                                |
++--------------------+---------------------------+--------------+------------+---------------------------+--------------------------------+
 | LastName           | xs:string                 | Optional     | Single     |Represents an              |If the field is invalid or not  |
 |                    |                           |              |            |individual's last name.    |present, the implementation is  |
 |                    |                           |              |            |                           |required to ignore it.          |

--- a/docs/xml/enumerations/district_type.rst
+++ b/docs/xml/enumerations/district_type.rst
@@ -1,10 +1,12 @@
 DistrictType
 ============
 
-.. todo::
-
-   Document DistrictType
-
+Enumeration describing the set of possible jurisdiction and district types.
+Please use the enumeration value which most accurately reflects the type of
+district or jurisdiction in your state or county. For example, "town" and
+"township" may mean different things -- or not be defined at all -- in your
+state, so please use the definition which best matches your local meaning.
+ 
 +----------------------+----------------------------------------------------------------------------------+
 | Name                 | Description                                                                      |
 |                      |                                                                                  |
@@ -35,7 +37,9 @@ DistrictType
 +----------------------+----------------------------------------------------------------------------------+
 | state-senate         | The upper house of a state legislature.                                          |
 +----------------------+----------------------------------------------------------------------------------+
-| township             | A town.                                                                          |
+| town                 | A town_.                                                                         |
++----------------------+----------------------------------------------------------------------------------+
+| township             | A township, which may be different than a town. See the `Wikipedia article`_.    |
 +----------------------+----------------------------------------------------------------------------------+
 | utility              | A non-water public or municipal utility district.                                |
 +----------------------+----------------------------------------------------------------------------------+
@@ -49,3 +53,5 @@ DistrictType
 +----------------------+----------------------------------------------------------------------------------+
 
 .. _`special-purpose district`: http://en.wikipedia.org/wiki/Special-purpose_district
+.. _town: http://en.wikipedia.org/wiki/Town#United_States
+.. _`Wikipedia article`: http://en.wikipedia.org/wiki/Town#United_States

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -830,22 +830,22 @@
   </OrderedContest>
   <!-- Start of ballot rotation examples for the gubenatorial race. -->
   <OrderedContest id="oc20003abc">
-    <BallotSelectionId>cs10961</BallotSelectionId>
-    <BallotSelectionId>cs10962</BallotSelectionId>
-    <BallotSelectionId>cs10963</BallotSelectionId>
     <ContestId>cc20003</ContestId>
+    <OrderedBallotSelectionId>cs10961</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10962</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10963</OrderedBallotSelectionId>
   </OrderedContest>
   <OrderedContest id="oc20003bca">
-    <BallotSelectionId>cs10962</BallotSelectionId>
-    <BallotSelectionId>cs10963</BallotSelectionId>
-    <BallotSelectionId>cs10961</BallotSelectionId>
     <ContestId>cc20003</ContestId>
+    <OrderedBallotSelectionId>cs10962</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10963</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10961</OrderedBallotSelectionId>
   </OrderedContest>
   <OrderedContest id="oc20003cab">
-    <BallotSelectionId>cs10963</BallotSelectionId>
-    <BallotSelectionId>cs10961</BallotSelectionId>
-    <BallotSelectionId>cs10962</BallotSelectionId>
     <ContestId>cc20003</ContestId>
+    <OrderedBallotSelectionId>cs10963</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10961</OrderedBallotSelectionId>
+    <OrderedBallotSelectionId>cs10962</OrderedBallotSelectionId>
   </OrderedContest>
   <!-- End of ballot rotation for gubenatorial race. -->
   <OrderedContest id="oc20005">

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -50,6 +50,7 @@
       <xs:enumeration value="state" />
       <xs:enumeration value="state-house" />
       <xs:enumeration value="state-senate" />
+      <xs:enumeration value="town" />
       <xs:enumeration value="township" />
       <xs:enumeration value="utility" />
       <xs:enumeration value="village" />
@@ -426,8 +427,8 @@
 
   <xs:complexType name="OrderedContest">
     <xs:sequence>
-      <xs:element name="BallotSelectionId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="ContestId" type="xs:IDREF" />
+      <xs:element name="OrderedBallotSelectionId" type="xs:IDREF" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>
@@ -464,6 +465,7 @@
       <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="DateOfBirth" type="xs:date" minOccurs="0" />
       <xs:element name="FirstName" type="xs:string" minOccurs="0" />
+      <xs:element name="FullName" type="InternationalizedText" minOccurs="0" />
       <xs:element name="LastName" type="xs:string" minOccurs="0" />
       <xs:element name="MiddleName" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="Nickname" type="xs:string" minOccurs="0" />


### PR DESCRIPTION
This PR addresses #232, and should be included after PR #231. It

1. Re-syncs the `DistrictType` enum to separate "town" and "township";
2. Updates the documentation to reflect that;
3. Adds `FullName` to `Person`;
4. Renames `OrderedContest.BallotSelectionId` to `OrderedContest.OrderedBallotSelectionId`; and
5. Updates the sample feed as needed.