### PR TITLE
Change table scroll behavior

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,11 @@
+/* override table width restrictions
+ * modified solution from https://github.com/snide/sphinx_rtd_theme/issues/117#issuecomment-41606147
+ */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal !important;
+    padding: 4px 8px !important;
+}
+
+.wy-table-responsive {
+    overflow: visible !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,6 +155,11 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_context = {
+  'css_files': [
+    '_static/theme_overrides.css',
+  ],
+}
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.


### PR DESCRIPTION
This should address #249 to a limited degree. While it does expose the entire table in the main view, the tables are effectively too wide to fit within the confines of the theme. More work will have to be done in a future PR.