### PR TITLE
Annotate strings with a purpose

### DIFF
--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -908,7 +908,7 @@
       <AddressLine>Washington, DC 20006</AddressLine>
       <Email>president@whitehouse.gov</Email>
       <Phone>202-456-1111</Phone>
-      <Phone purpose="TDD">202-456-6213</Phone>
+      <Phone annotation="TDD">202-456-6213</Phone>
       <Uri>http://www.whitehouse.gov</Uri>
     </ContactInformation>
     <FirstName>Barack</FirstName>
@@ -2187,7 +2187,7 @@
   <!-- Street segments -->
   <StreetSegment id="ss999999">
     <City>Charlottesville</City>
-    <IncludesAllAddresses>true</IncludeAllAddresses>
+    <IncludesAllAddresses>true</IncludesAllAddresses>
     <OddEvenBoth>both</OddEvenBoth>
     <PrecinctId>pre99999</PrecinctId>
     <State>VA</State>

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -908,6 +908,7 @@
       <AddressLine>Washington, DC 20006</AddressLine>
       <Email>president@whitehouse.gov</Email>
       <Phone>202-456-1111</Phone>
+      <Phone purpose="TDD">202-456-6213</Phone>
       <Uri>http://www.whitehouse.gov</Uri>
     </ContactInformation>
     <FirstName>Barack</FirstName>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -217,8 +217,8 @@
   <xs:complexType name="ContactInformation">
     <xs:sequence>
       <xs:element name="AddressLine" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Email" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Fax" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Email" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Fax" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
       <!-- Note: The "Hours" element is being deprecated and will be removed
            in future versions of VIP.
         -->
@@ -226,7 +226,7 @@
       <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
       <!-- This can be a person or place name. -->
       <xs:element name="Name" type="xs:string" minOccurs="0" />
-      <xs:element name="Phone" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Phone" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="Uri" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="identifier" type="xs:string" use="required" />
@@ -520,6 +520,17 @@
       <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <!--
+      PurposeString: a type representing a string with a purpose specified.
+    -->
+  <xs:complexType name="PurposeString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="purpose" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
   </xs:complexType>
 
   <xs:complexType name="RetentionContest">

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -124,6 +124,12 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="ShortString">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="16" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="TimeWithZone">
     <xs:restriction base="xs:string">
       <xs:pattern value="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))" />
@@ -131,6 +137,17 @@
   </xs:simpleType>
 
   <!-- Complex types. -->
+  <!--
+      AnnotatedString: a type representing a string with a purpose specified.
+    -->
+  <xs:complexType name="AnnotatedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="annotation" type="ShortString" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:complexType name="BallotMeasureContest">
     <xs:complexContent>
       <xs:extension base="ContestBase">
@@ -217,8 +234,8 @@
   <xs:complexType name="ContactInformation">
     <xs:sequence>
       <xs:element name="AddressLine" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Email" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Fax" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Email" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Fax" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
       <!-- Note: The "Hours" element is being deprecated and will be removed
            in future versions of VIP.
         -->
@@ -226,7 +243,7 @@
       <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
       <!-- This can be a person or place name. -->
       <xs:element name="Name" type="xs:string" minOccurs="0" />
-      <xs:element name="Phone" type="PurposeString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Phone" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="Uri" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="identifier" type="xs:string" use="required" />
@@ -520,17 +537,6 @@
       <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
-  </xs:complexType>
-
-  <!--
-      PurposeString: a type representing a string with a purpose specified.
-    -->
-  <xs:complexType name="PurposeString">
-    <xs:simpleContent>
-      <xs:extension base="xs:string">
-        <xs:attribute name="purpose" type="xs:string" />
-      </xs:extension>
-    </xs:simpleContent>
   </xs:complexType>
 
   <xs:complexType name="RetentionContest">


### PR DESCRIPTION
This is a rough attempt to address #242. The idea behind it is to have strings with optional attributes named `purpose` that allow the feed creator to indicate that an email address, phone number, or fax number is for a specified purpose. The obvious use here is for TTY/TDD phone numbers, but can also be used to indicate different divisions within an organization.

Feedback welcome.