### PR TITLE
Address issue #255: Take Two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+_build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,23 +51,91 @@ dev branch (called 'vip5' in the vip-specification's case, but it may change to 
 future), a stable branch (called 'master' in most cases), and, if necessary, a documentation branch
 (called 'gh-pages' if hosted on GitHub).
 
-# Installing Sphinx
-In order to build the documentation, you must install [Sphinx](http://sphinx-doc.org), which
-involves first [installing python](https://www.python.org/downloads/). Once python is installed,
-you should have access to the python package installer, `pip`. Open a terminal window and enter the
-following commands:
+
+## Documentation Format
+
+VIP writes its documentation in a format called [reStructuredText][reST]
+(aka reST).  reST is a markup language used mainly for documentation.
+VIP chose reST because of its enhanced formatting capabilities.
+For example, reST supports tables.
+
+The documentation that VIP exposes to the public is in HTML.  VIP generates
+its HTML documentation from the reST files automatically using a process
+called "building" the documentation.  Instructions for building are below.
+
+One problem with reST is that tables in reST are hard to edit and maintain
+by hand.  For this reason, VIP stores the tabular documentation data in
+separate files in an open data format called [YAML][YAML]
+(specifically [YAML version 1.1][YAML_1.1]). YAML files are human-readable and
+easy to edit by hand.  The YAML files are stored in the
+[`docs/yaml`](docs/yaml) directory.
+
+
+## Dev Environment
+
+This section explains how to set up your local development environment for
+contributing.  First, [install Python][python_download].  We recommend
+installing the latest stable version of Python 3 (Python 3.4.3 as of June 2015).
+
+We also recommend setting up a virtual environment for the repo (e.g. using
+[virtualenv][virtualenv]) prior to installing dependencies.
+
+Use [`pip`][pip] to install dependencies, which comes with Python 3.4+
+(and is installed automatically when creating a virtual environment).
+Open a terminal window and run:
 
 ```sh
-$ pip install Sphinx
+$ pip install Sphinx PyYAML
+```
+
+([Sphinx](http://sphinx-doc.org) is for building the documentation.)
+
+
+## Building the Documentation
+
+To build the documentation:
+
+```sh
 $ cd /path/to/vip-specification/docs/
 $ make html
 ```
 
-To see changes to the documentation as the files are edited, use the following command:
+To see changes to the documentation as the files are edited, use the
+following command:
 
 ```sh
 $ sphinx-autobuild . _build/html
 ```
 
-Once the above command is executed, open a browser and enter http://127.0.0.1:8000 to see the
-documentation.
+Once the above command is executed, open a browser and view
+[http://127.0.0.1:8000](http://127.0.0.1:8000) to see the documentation.
+
+
+## Updating Tables in the Documentation
+
+To make changes to the tables, edit the YAML files by hand as needed.
+Do not edit the reST tables by hand since they are generated automatically
+from the YAML files.
+
+Then, normalize the YAML files and update the reST tables:
+
+```sh
+$ python scripts/vip.py norm_yaml
+$ python scripts/vip.py update_tables
+```
+
+After this, you will want to build the documentation as described above.
+
+When submitting a PR, changes to both the YAML files and the updated reST
+tables should be checked in.  This lets people reviewing your pull request
+check to see how the reST tables will be affected by your patch.
+However, do not check in the generated HTML files.
+
+
+[Markdown]: http://daringfireball.net/projects/markdown/
+[pip]: https://pip.pypa.io/en/stable/
+[python_download]: https://www.python.org/downloads
+[reST]: http://docutils.sourceforge.net/rst.html
+[virtualenv]: https://pypi.python.org/pypi/virtualenv/
+[YAML]: http://yaml.org/
+[YAML_1.1]: http://yaml.org/spec/1.1/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,18 @@ tables should be checked in.  This lets people reviewing your pull request
 check to see how the reST tables will be affected by your patch.
 However, do not check in the generated HTML files.
 
+For help using the Python script above:
+
+```sh
+$ python scripts/vip.py -h
+```
+
+Or for help with a specific command (for example):
+
+```sh
+$ python scripts/vip.py update_tables -h
+```
+
 
 [Markdown]: http://daringfireball.net/projects/markdown/
 [pip]: https://pip.pypa.io/en/stable/

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -24,11 +24,12 @@ usernames are included below.
 
 ### Independent Contributors
 * Aaron Strauss (aaron-strauss); former Pew and Google contractor
-* Chris Jerdonek (cjerdonek); President, San Francisco Elections Commission\*
+* Chris Jerdonek (cjerdonek); President, San Francisco Elections
+  Commission<sup>\*</sup>
 * David McGivney (decmg & df-dave); Digital Foundry
 * Joshua Bray (Josh-LACRRCC); Application Developer, Registrar-Recorder/County
   Clerk, County of Los Angeles
 * Kenneth Bennett (kennethmbennett); IT Manager, Registrar-Recorder/County
   Clerk, County of Los Angeles
 
-\* For identification purposes only.
+<sup>\*</sup> For identification purposes only.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -24,7 +24,7 @@ usernames are included below.
 
 ### Independent Contributors
 * Aaron Strauss (aaron-strauss); former Pew and Google contractor
-* Chris Jerdonek (cjerdonek); President SF Election Commission\*
+* Chris Jerdonek (cjerdonek); President, San Francisco Elections Commission\*
 * David McGivney (decmg & df-dave); Digital Foundry
 * Joshua Bray (Josh-LACRRCC); Application Developer, Registrar-Recorder/County
   Clerk, County of Los Angeles

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -24,9 +24,11 @@ usernames are included below.
 
 ### Independent Contributors
 * Aaron Strauss (aaron-strauss); former Pew and Google contractor
-* Chris Jerdonek (cjerdonek); President SF Election Commission
+* Chris Jerdonek (cjerdonek); President SF Election Commission\*
 * David McGivney (decmg & df-dave); Digital Foundry
 * Joshua Bray (Josh-LACRRCC); Application Developer, Registrar-Recorder/County
   Clerk, County of Los Angeles
 * Kenneth Bennett (kennethmbennett); IT Manager, Registrar-Recorder/County
   Clerk, County of Los Angeles
+
+\* For identification purposes only.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,8 @@ exclude_patterns = [
   '_build',
   '*~',
   '#*',
+  'tables/elements/*.rst',
+  'tables/enumerations/*.rst',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/xml/elements/election.rst
+++ b/docs/xml/elements/election.rst
@@ -52,7 +52,7 @@ with one Election object.
 |                           |                             |             |         |URL                                    |required to ignore it.           |
 |                           |                             |             |         |                                       |                                 |
 +---------------------------+-----------------------------+-------------+---------+---------------------------------------+---------------------------------+
-| ResultsUrl                |xs:anyUri                    |Optional     |Single   |Contains a URL where results for the   |If the field is invalid or not   |
+| ResultsUrl                |xs:anyURI                    |Optional     |Single   |Contains a URL where results for the   |If the field is invalid or not   |
 |                           |                             |             |         |election may be found                  |present, the implementation is   |
 |                           |                             |             |         |                                       |required to ignore it.           |
 |                           |                             |             |         |                                       |                                 |

--- a/docs/xml/elements/ordered_contest.rst
+++ b/docs/xml/elements/ordered_contest.rst
@@ -26,7 +26,7 @@ ballot in the proper order.
 |                          |            |            |          |<ballot_selection_base>`.  |``OrderedBallotSelectionId``     |
 |                          |            |            |          |                           |elements are present, the        |
 |                          |            |            |          |                           |presumed order of the selection  |
-|                          |            |            |          |                           |will be the order of                         |
+|                          |            |            |          |                           |will be the order of             |
 |                          |            |            |          |                           |:doc:`BallotSelectionBase        |
 |                          |            |            |          |                           |<ballot_selection_base>`-extended|
 |                          |            |            |          |                           |elements referenced by the       |

--- a/scripts/vip.py
+++ b/scripts/vip.py
@@ -1,0 +1,185 @@
+"""
+Entry point for the reST script for VIP contributors.
+
+Script usage:
+
+From the repository root (using Python 3.4 or above):
+
+  $ python scripts/vip.py -h
+
+reStructuredText (aka reST) [1] is a markup language used for
+documentation.  VIP uses reST for its documentation.
+
+This script is mainly for auto-generating much of the reST markup
+(especially the reST that involve tables).  The script generates the
+reST from configuration files that are in a format called YAML [2]
+(specifically YAML 1.1 [3]).  YAML files are much easier to edit and
+manipulate than reST when tables are involved.  The YAML can also be
+thought of as at part of the VIP documentation in an "open data" format,
+since the YAML represents tabular data stored in a structured,
+machine-readable form.
+
+
+[1] reST: http://docutils.sourceforge.net/rst.html
+[2] YAML: http://yaml.org/
+[3] YAML 1.1: http://yaml.org/spec/1.1/
+
+"""
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import textwrap
+
+from vippy import common
+from vippy.common import XML_DIR
+from vippy import parsing
+from vippy import rest
+
+
+_log = logging.getLogger()
+
+FORMATTER_CLASS = argparse.RawDescriptionHelpFormatter
+
+HELP_SUMMARY = """\
+Helper script for VIP contributors.
+"""
+
+def _wrap(text):
+    """Format text for help outuput."""
+    paras = text.split("\n\n")
+    paras = [textwrap.fill(p) for p in paras]
+    text = "\n\n".join(paras)
+
+    return text
+
+
+def ns_to_paths(ns, parent_dir, ext):
+    """Return the list of paths specified by an argparse.Namespace object."""
+    path = ns.path
+    if path:
+        paths = [path]
+    else:
+        rel_paths = common.get_all_files(parent_dir, ext=ext)
+        paths = [os.path.join(parent_dir, p) for p in rel_paths]
+    return paths
+
+
+def command_norm_yaml(ns):
+    """Run the norm_yaml command."""
+    parent_dir = common.YAML_DIR
+    paths = ns_to_paths(ns, parent_dir=parent_dir, ext='.yaml')
+    for path in paths:
+        common.normalize_yaml(path)
+
+
+def command_rest2yaml(ns):
+    """Run the rest2yaml command."""
+    parent_dir = common.XML_DIR
+    paths = ns_to_paths(ns, parent_dir=parent_dir, ext='.rst')
+    for path in paths:
+        parsing.rest_file_to_yaml(parent_dir, path)
+
+
+def command_update_tables(ns):
+    """Run the update_tables command."""
+    rest.update_table_files(ns.type_name)
+
+
+def command_scratch(ns):
+    """Run the scratch command."""
+    rest.analyze_types()
+
+
+def make_subparser(sub, command_name, help, command_func=None, details=None, **kwargs):
+    """
+    Create the "sub-parser" for our command-line parser.
+
+    This facilitates having multiple "commands" for a single script,
+    for example "norm_yaml", "rest2yaml", etc.
+    """
+    if command_func is None:
+        command_func_name = "command_{0}".format(command_name)
+        command_func = globals()[command_func_name]
+
+    # Capitalize the first letter for the long description.
+    desc = help[0].upper() + help[1:]
+    if details is not None:
+        desc += "\n\n{0}".format(details)
+    desc = _wrap(desc)
+    parser = sub.add_parser(command_name, formatter_class=FORMATTER_CLASS,
+                            help=help, description=desc, **kwargs)
+    parser.set_defaults(run_command=command_func)
+    return parser
+
+
+def create_parser():
+    """
+    Create the command-line parser.
+
+    Returns an ArgumentParser object.
+    """
+    root_parser = argparse.ArgumentParser(formatter_class=FORMATTER_CLASS,
+            description=HELP_SUMMARY)
+    sub = root_parser.add_subparsers(help='sub-command help')
+
+    parser = make_subparser(sub, "norm_yaml",
+        help=("normalize one or more YAML files.  This command does things "
+              "like alphabetize the keys in the YAML files, normalize the "
+              "spacing, etc."))
+    parser.add_argument('path', metavar='PATH', nargs='?',
+        help="a path to a YAML file. Defaults to all files.")
+
+    parser = make_subparser(sub, "update_tables",
+        help=("update all reST tables from the data in the YAML files."))
+    parser.add_argument('type_name', metavar='TYPE_NAME', nargs='?',
+        help=('the name of a type (e.g. "HoursOpen"). '
+              "Defaults to all types."))
+
+    parser = make_subparser(sub, "rest2yaml",
+        help=("rewrite all reST files to use tables generated from YAML files. "
+              "This command only needs to be run on the repo once. "
+              "After that, this command can be permanently deleted."))
+    parser.add_argument('path', metavar='PATH', nargs='?',
+        help="a path to a reST file. Defaults to all files.")
+
+    parser = make_subparser(sub, "scratch",
+        help=("temporary command for development purposes. You can "
+              "use / modify this command if you ever need a command for "
+              "experimental purposes (e.g. to analyze the contents of "
+              "the YAML files)."))
+
+    return root_parser
+
+
+def main(argv=None):
+    """
+    Starting point for the script.
+
+    This is what gets executed when the following is run from the
+    repository root:
+
+      $ python <path-to-this-file>
+
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    logging.basicConfig(level='DEBUG')
+    common.configure_yaml()
+    parser = create_parser()
+    ns = parser.parse_args(argv)  # an argparse.Namespace object.
+    try:
+        ns.run_command
+    except AttributeError:
+        # We need to handle this exception because of the following
+        # behavior change:
+        #   http://bugs.python.org/issue16308
+        parser.print_help()
+    else:
+        ns.run_command(ns)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/vip.py
+++ b/scripts/vip.py
@@ -48,7 +48,7 @@ Helper script for VIP contributors.
 """
 
 def _wrap(text):
-    """Format text for help outuput."""
+    """Format text for help output."""
     paras = text.split("\n\n")
     paras = [textwrap.fill(p) for p in paras]
     text = "\n\n".join(paras)

--- a/scripts/vippy/common.py
+++ b/scripts/vippy/common.py
@@ -1,0 +1,337 @@
+from contextlib import contextmanager
+import copy
+import logging
+import os.path
+from pprint import pformat, pprint
+
+import yaml
+
+
+_log = logging.getLogger()
+
+YAML_DIR = 'docs/yaml'
+TABLES_DIR = 'docs/tables'
+XML_DIR = 'docs/xml'
+
+TAG_KEY_NAME = '_name'
+TAG_KEY_TYPE = 'type'
+TAG_KEY_REQUIRED = 'required'
+TAG_KEY_REPEATING = 'repeating'
+TAG_KEY_DESCRIPTION = 'description'
+# The error_handling key corresponds to the aggregate error-handling tag
+# value and does not correspond to a literal key-value in the YAML data.
+TAG_KEY_ERROR_HANDLE = 'error_handling'
+TAG_KEY_ERROR_BASE = 'error'
+TAG_KEY_ERROR_THEN = 'error_then'
+TAG_KEY_ERROR_EXTRA = 'error_extra'
+
+DEFAULT_TAG_VALUES = {
+    TAG_KEY_REQUIRED: False,
+    TAG_KEY_REPEATING: False,
+}
+
+_ERROR_FORMAT_STRING = ("the implementation {action} ignore {ignore}.")
+
+_ERROR_THEN_FORMAT_REQUIRED = _ERROR_FORMAT_STRING.format(action='is required to',
+                                    ignore='the ``{containing_type}`` element containing it')
+
+_ERROR_THENS = {
+    '=must-ignore': _ERROR_FORMAT_STRING.format(action='is required to', ignore='it'),
+    '=should-ignore': _ERROR_FORMAT_STRING.format(action='should', ignore='it'),
+}
+
+
+def reverse_map(mapping):
+    inverted = {}
+    for k, v in mapping.items():
+        if v in inverted:
+            raise Exception("key appears twice: {0}".format(key))
+        inverted[v] = k
+    return inverted
+
+
+def read_file(path):
+    with open(path, encoding='utf-8') as f:
+        text = f.read()
+    return text
+
+
+@contextmanager
+def detect_change(path):
+    """A context manager for logging whether a text file changes."""
+    if os.path.exists(path):
+        text = read_file(path)
+    else:
+        text = None
+    yield
+    # Check whether the file changed.
+    new_text = read_file(path)
+    if new_text != text:
+        _log.info("updated: {0}".format(path))
+
+
+def write_file(path, text):
+    """Write to a file, and return whether the file changed."""
+    with detect_change(path):
+        with open(path, mode='w', encoding='utf-8') as f:
+            f.write(text)
+
+
+def get_all_files(parent_dir, ext=None):
+    """Return a list of paths relative to the given dir_path."""
+    paths = []
+    for root_dir, dir_paths, file_names in os.walk(parent_dir):
+        for file_name in file_names:
+            path = os.path.join(root_dir, file_name)
+            rel_path = os.path.relpath(path, start=parent_dir)
+            paths.append(rel_path)
+    if ext is not None:
+        paths = [p for p in paths if os.path.splitext(p)[1] == ext]
+
+    return paths
+
+
+# The idea for this comes from here:
+# http://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data
+def _yaml_str_representer(dumper, data):
+    """A PyYAML representer that uses literal blocks for multi-line strings.
+
+    For example--
+
+      long: |
+        This is
+        a multi-line
+        string.
+      short: This is a one-line string.
+    """
+    style = '|' if '\n' in data else None
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
+
+
+def configure_yaml():
+    yaml.add_representer(str, _yaml_str_representer)
+
+
+def read_yaml(path):
+    with open(path) as f:
+        data = yaml.load(f)
+    return data
+
+
+def yaml_dump(*args):
+    return yaml.dump(*args, default_flow_style=False, allow_unicode=True,
+                     default_style=None)
+
+
+def write_yaml(data, path):
+    """Write a YAML file, and return whether the file changed."""
+    with detect_change(path):
+        with open(path, "w", encoding='utf-8') as f:
+            yaml_dump(data, f)
+
+
+def normalize_yaml(path):
+    """Normalize a YAML file, and return whether the file changed."""
+    data = read_yaml(path)
+    changed = write_yaml(data, path)
+    return changed
+
+
+def read_type(parent_dir, rel_path):
+    yaml_path = os.path.join(parent_dir, rel_path)
+    type_yaml = read_yaml(yaml_path)
+    data_type = DataType.from_yaml(type_yaml, rel_path=rel_path)
+    return data_type
+
+
+def read_types():
+    """
+    Return information about all types by reading all of the YAML files.
+
+    The information is returned in the form of a dict mapping type names
+    to `DataType` objects (i.e. element and enumeration types).  Examples
+    of type names include "BallotMeasureContest" in the case of elements
+    and "DistrictType" in the case of enumerations.
+    """
+    parent_dir = YAML_DIR
+    data_types = {}
+    rel_paths = get_all_files(parent_dir, ext='.yaml')
+    for rel_path in rel_paths:
+        data_type = read_type(parent_dir, rel_path)
+        type_name = data_type.name
+        data_types[type_name] = data_type
+
+    return data_types
+
+
+def get_type(all_types, type_name):
+    try:
+        data_type = all_types[type_name]
+    except KeyError:
+        all_names = sorted(all_types.keys())
+        raise Exception("available type names: {0}".format(", ".join(all_names)))
+
+    return data_type
+
+
+def is_tag_field(all_types, tag_data):
+    type_name = tag_data[TAG_KEY_TYPE]
+    try:
+        data_type = all_types[type_name]
+    except KeyError:
+        # Then we assume it is a simple type like "xs:string" or "TimeWithZone".
+        return True
+    return data_type.is_enum
+
+
+def get_simple_tag_value(tag_data, key):
+    """This works for everything except for the error values."""
+    try:
+        value = tag_data[key]
+    except KeyError:
+        value = DEFAULT_TAG_VALUES[key]
+    return value
+
+
+def make_error_if(all_types, tag_data):
+    noun = 'field' if is_tag_field(all_types, tag_data) else 'element'
+    required = get_simple_tag_value(tag_data, TAG_KEY_REQUIRED)
+    condition = 'invalid' if required else 'invalid or not present'
+
+    return "the {noun} is {condition},".format(noun=noun, condition=condition)
+
+
+def make_error_if_then(all_types, tag_data, error_then):
+    if error_then.startswith('='):
+        error_then_format = _ERROR_THENS[error_then]
+        containing_type = tag_data['containing_type']
+        error_then = error_then_format.format(containing_type=containing_type)
+    error_if = make_error_if(all_types, tag_data)
+    error = "If {0} then {1}".format(error_if, error_then)
+
+    return error
+
+
+def make_error_default(all_types, tag_data):
+    required = get_simple_tag_value(tag_data, TAG_KEY_REQUIRED)
+    if not required:
+        raise Exception('we have not defined a default "error" value for '
+                        "tags that are not required.\n"
+                        "tag data:\n{0}".format(pformat(tag_data)))
+    error_then = _ERROR_THEN_FORMAT_REQUIRED.format(**tag_data)
+    error = make_error_if_then(all_types, tag_data, error_then)
+    return error
+
+
+def make_error_base(all_types, tag_data):
+    try:
+        error = tag_data[TAG_KEY_ERROR_BASE]
+    except KeyError:
+        error = make_error_default(all_types, tag_data)
+    return error
+
+
+def make_error_initial(all_types, tag_data):
+    try:
+        error_then = tag_data[TAG_KEY_ERROR_THEN]
+    except KeyError:
+        error = make_error_base(all_types, tag_data)
+    else:
+        error = make_error_if_then(all_types, tag_data, error_then)
+
+    return error
+
+
+def get_error_handling_value(all_types, tag_data):
+    """
+    Here is a description in human terms of how this value is calculated:
+
+    1. If the "error_then" YAML value is present, then construct the
+       standard "If ... then ..." phrase using our template.
+    2. If "error_then" is not present, then use the "error" value.
+    3. TODO (finish this description)
+    4. Lastly, if the "error_extra" YAML value is present, then add it
+       to the end of the string we have built so far from the previous
+       steps.
+
+    """
+    error = make_error_initial(all_types, tag_data)
+    try:
+        error_extra = tag_data[TAG_KEY_ERROR_EXTRA]
+    except KeyError:
+        pass
+    else:
+        error += " " + error_extra
+
+    return error
+
+
+def get_tag_value(all_types, tag_data, key):
+    """
+    Return the "pre-conversion" value to put in a cell of a reST table.
+    """
+    try:
+        if key == TAG_KEY_ERROR_HANDLE:
+            # We use extra logic to derive the error-handling value.
+            value = get_error_handling_value(all_types, tag_data)
+        else:
+            value = get_simple_tag_value(tag_data, key)
+    except Exception:
+        raise Exception("tag_data: {0}".format(pformat(tag_data)))
+
+    return value
+
+
+class DataType(object):
+
+    @classmethod
+    def from_yaml(cls, type_yaml, rel_path):
+        """
+        Create a DataType object from the information in a YAML file.
+
+        Arguments:
+          type_yaml: the contents of a YAML file deserialized as a
+            Python object.
+          rel_path: the path to the YAML file relative to the TODO
+            directory.
+        """
+        file_name = os.path.basename(rel_path)
+        snake_name, ext = os.path.splitext(file_name)
+
+        type_name = type_yaml['name']
+        type_data = copy.deepcopy(type_yaml)
+        tags = type_data['tags']
+        for tag in tags:
+            tag['containing_type'] = type_name
+
+        is_enum = 'enumerations' in rel_path
+
+        return cls(type_yaml, type_data, rel_path, snake_name=snake_name, is_enum=is_enum)
+
+    def __init__(self, yaml, data, rel_path, snake_name, is_enum):
+        self.data = data
+        self.is_enum = is_enum
+        self.rel_path = rel_path
+        self.snake_name = snake_name
+        self.yaml = yaml
+
+    def __repr__(self):
+        return ("<DataType object (name={0!r}, rel_path={1!r})>"
+                .format(self.name, self.rel_path))
+
+    @property
+    def name(self):
+        return self.data['name']
+
+    @property
+    def tags(self):
+        return self.data['tags']
+
+    @property
+    def table_path(self):
+        """Return a path relative to the repo root."""
+        rel_path = self.rel_path
+        root, ext = os.path.splitext(rel_path)
+        rest_rel_path = "{0}.rst".format(root)
+        path = os.path.join(TABLES_DIR, rest_rel_path)
+        return path

--- a/scripts/vippy/parsing.py
+++ b/scripts/vippy/parsing.py
@@ -1,0 +1,217 @@
+"""
+Supports parsing the reST files and generating the initial YAML files.
+
+"""
+
+import os
+import logging
+
+from vippy import common
+from vippy.common import (TAG_KEY_ERROR_BASE, TAG_KEY_ERROR_HANDLE, TAG_KEY_ERROR_THEN,
+                          TAG_KEY_REPEATING, TAG_KEY_REQUIRED, TAG_KEY_TYPE)
+from vippy import rest
+
+
+_log = logging.getLogger(__name__)
+
+
+XS_TYPES = set(['xs:anyURI', 'xs:boolean', 'xs:dateTime', 'xs:float', 'xs:integer',
+                'xs:date', 'xs:string', 'xs:IDREF'])
+
+TYPE_NAME_TO_BASE_NAME = {
+    'Department': 'department',
+    'ExternalIdentifier': 'external_identifier',
+    'Hours': 'hours',
+    'LatLng': 'lat_lng',
+    'NonHouseAddress': 'non_house_address',
+    'Schedule': 'schedule',
+    'Term': 'term',
+    'VoterService': 'voter_service',
+}
+
+ERROR_THEN_MAP = {
+    'If the element is invalid or not present, the implementation is required to ignore it.': '=must-ignore',
+    'If the element is invalid or not present, then the implementation is required to ignore it.': '=must-ignore',
+    'If the element is invalid or not present, the implementation should ignore it.': '=should-ignore',
+    'If the field is invalid or not present, the implementation is required to ignore it.': '=must-ignore',
+    'If the field is invalid or not present, the implementation should ignore it.': '=should-ignore',
+    'If the field is invalid or not present, then the implementation is required to ignore it.': '=must-ignore',
+    'If the field is invalid the implementation is required to ignore it.': '=must-ignore',
+    'If the field is invalid, the implementation is required to ignore it.': '=must-ignore',
+    'If the field is missing or invalid, the implementation is required to ignore it.': '=must-ignore',
+    'If the field is not present or invalid, the implementation is required to ignore it.': '=must-ignore',
+    'If the field is not present or invalid, the implementation is required to ignore the element containing it.': '=must-ignore-containing-element',
+    'If the field is invalid or not present, the implementation is required to ignore the element containing it.': '=must-ignore-containing-element',
+    'If field is invalid or not present, the implementation is required to ignore the element containing it.': '=must-ignore-containing-element',
+}
+
+REPEATING_MAP = {
+    'Single': None,
+    'Repeats': True,
+}
+
+REQUIRED_MAP = {
+    'Optional': None,
+    '**Required**': True,
+}
+
+REST_TO_TYPE_NAME = common.reverse_map(rest.TYPE_NAME_TO_REST)
+
+
+def parsed_value_to_yaml_value(value, info):
+    """
+    Convert a value parsed from the reST into the value that should
+    appear in the YAML file.
+    """
+    key, header_name, width = info
+
+    if key == TAG_KEY_REPEATING:
+        value = REPEATING_MAP[value]
+    elif key == TAG_KEY_REQUIRED:
+        value = REQUIRED_MAP[value]
+    elif key == TAG_KEY_TYPE:
+        try:
+            value = REST_TO_TYPE_NAME[value]
+        except KeyError:
+            if not value in XS_TYPES:
+                raise
+    elif key == TAG_KEY_ERROR_HANDLE:
+        try:
+            value = ERROR_THEN_MAP[value]
+        except KeyError:
+            key = TAG_KEY_ERROR_BASE
+        else:
+            if value == '=must-ignore-containing-element':
+                # This case is covered by our default error message generation.
+                value = '=must-ignore'
+            key = TAG_KEY_ERROR_THEN
+
+    return key, value
+
+
+def snake_to_camel(text):
+    """Convert a string from snake_case to CamelCase."""
+    parts = text.split("_")
+    camel = "".join([p.capitalize() for p in parts])
+    return camel
+
+
+def fix_rel_path(rel_path, type_name):
+    root, ext = os.path.splitext(rel_path)
+    rel_dir, base_name = os.path.split(root)
+    base_name = TYPE_NAME_TO_BASE_NAME.get(type_name, base_name)
+    camel_base_name = snake_to_camel(base_name)
+    if camel_base_name != type_name:
+        raise Exception("{0} != {1}".format(camel_base_name, type_name))
+    path = os.path.join(rel_dir, base_name)
+    return path
+
+
+def parse_row(iter_lines):
+    """
+    Parse the next row of a reST table.
+
+    Returns the values in the next row as a list of strings.
+    """
+    lines = []
+    for line in iter_lines:
+        if line.startswith('+--'):
+            break
+        if not line.startswith('|'):
+            return False
+        lines.append(line)
+    else:
+        # Then there are no more lines in the file.
+        return False
+    parts_seq = []
+    for line in lines:
+        line = line.strip().strip('|')
+        parts = [part.strip() for part in line.split('|')]
+        parts_seq.append(parts)
+    values = []
+    for i in range(len(parts_seq[0])):
+        value = " ".join(parts[i] for parts in parts_seq if parts[i])
+        values.append(value)
+    return values
+
+
+def values_to_tag_data(values, columns_info):
+    """
+    Returns a dict mapping tag keys to cell values.
+    """
+    data = {}
+    for column_info, value in zip(columns_info, values):
+        key = column_info[0]
+        key, value = parsed_value_to_yaml_value(value, column_info)
+        if value is not None:
+            data[key] = value
+    return data
+
+
+def parse_table(iter_lines, columns_info):
+    """Parse a single reST table"""
+    # Advance past the header row.
+    for line in iter_lines:
+        if line.startswith('+==='):
+            break
+    tags_data = []
+    while True:
+        values = parse_row(iter_lines)
+        if values is False:
+            break
+        if len(values) != len(columns_info):
+            raise Exception("{0} != {1}".format(len(values), len(columns_info)))
+        tag_data = values_to_tag_data(values, columns_info=columns_info)
+        tags_data.append(tag_data)
+    return tags_data
+
+
+def rest_file_to_yaml(parent_dir, rest_path):
+    """
+    Parse a reST file, and convert it to use a YAML file.
+
+    This function parses a reST file, extracts the table data,
+    creates (or updates) one or more YAML files in the correct location,
+    and then updates the reST file to use tables generated from the
+    YAML files.
+    """
+    dir_name = os.path.basename(os.path.dirname(rest_path))
+    if dir_name not in ('elements', 'enumerations'):
+        _log.info("skipping: {0}".format(rest_path))
+        return
+
+    _log.debug("parsing: {0}".format(rest_path))
+    is_enum = (dir_name == 'enumerations')
+    column_infos, cell_values = rest.get_type_info(is_enum)
+    rel_path = os.path.relpath(rest_path, start=parent_dir)
+    with open(rest_path) as f:
+        lines = f.readlines()
+    table_number = 0
+    iter_lines = iter(lines)
+    new_lines = []
+    for line in iter_lines:
+        norm_line = line.strip()
+        if (norm_line and " " not in norm_line and "-" not in norm_line and
+            "=" not in norm_line and not norm_line.endswith('.')):
+            type_name = norm_line.split(".")[-1]
+        if not norm_line.startswith("+---"):
+            new_lines.append(line)
+            continue
+        # Otherwise, we just started a table.
+        rel_base = fix_rel_path(rel_path, type_name)
+        rel_table_path = rel_base + ".rst"
+        yaml_path = os.path.join(common.YAML_DIR, rel_base + ".yaml")
+        dir_path = os.path.dirname(yaml_path)
+        if not os.path.exists(dir_path):
+            _log.info("creating dir: {0}".format(dir_path))
+            os.makedirs(dir_path)
+        new_line = ".. include:: ../../tables/{0}\n\n".format(rel_table_path)
+        new_lines.append(new_line)
+        tags_data = parse_table(iter_lines, column_infos)
+        data = {
+            'name': type_name,
+            'tags': tags_data,
+        }
+        common.write_yaml(data, yaml_path)
+    new_rest = "".join(new_lines)
+    common.write_file(rest_path, new_rest)

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -1,0 +1,264 @@
+import itertools
+import logging
+import os.path
+from pprint import pformat, pprint
+import textwrap
+
+from vippy import common
+from vippy.common import (TAG_KEY_NAME, TAG_KEY_TYPE, TAG_KEY_REQUIRED,
+                          TAG_KEY_REPEATING, TAG_KEY_DESCRIPTION,
+                          TAG_KEY_ERROR_HANDLE)
+
+
+_log = logging.getLogger()
+
+
+MIN_COLUMN_WIDTH = 12
+
+TABLE_COMMENT = """\
+.. This file is auto-generated.  Do not edit it by hand!
+
+"""
+
+
+# A dict mapping type names to how they should appear in the reST.
+TYPE_NAME_TO_REST = {
+    'BallotMeasureType': ':doc:`BallotMeasureType <../enumerations/ballot_measure_type>`',
+    'CandidatePostElectionStatus': ':doc:`CandidatePostElectionStatus <../enumerations/candidate_post_election_status>`',
+    'CandidatePreElectionStatus': ':doc:`CandidatePreElectionStatus <../enumerations/candidate_pre_election_status>`',
+    'ContactInformation': ':doc:`ContactInformation <contact_information>`',
+    'Department': ':ref:`Department <ea-dep>`',
+    'DistrictType': ':doc:`DistrictType <../enumerations/district_type>`',
+    'ExternalIdentifier': '`ExternalIdentifier`_',
+    'ExternalIdentifiers': ':doc:`ExternalIdentifiers <external_identifiers>`',
+    'Hours': '`Hours`_',
+    'HtmlColorString': '`HtmlColorString`_',
+    'IdentifierType': ':doc:`IdentifierType <../enumerations/identifier_type>`',
+    'InternationalizedText': ':doc:`InternationalizedText <internationalized_text>`',
+    'LanguageString': '`LanguageString`_',
+    'LatLng': '`LatLng`_',
+    'NonHouseAddress': '`NonHouseAddress`_',
+    'OebEnum': ':doc:`OebEnum <../enumerations/oeb_enum>`',
+    'OfficeTermType': ':doc:`OfficeTermType <../enumerations/office_term_type>`',
+    'Schedule': '`Schedule`_',
+    'Term': '`Term`_',
+    'TimeWithZone': '`TimeWithZone`_',
+    'VoteVariation': ':doc:`VoteVariation <../enumerations/vote_variation>`',
+    'VoterService': ':ref:`VoterService <ea-dep-voter-service>`',
+    'VoterServiceType': ':doc:`VoterServiceType <../enumerations/voter_service_type>`'
+}
+
+
+# The reST table columns for an element.
+ELEMENT_COLUMNS = [
+    (TAG_KEY_NAME, 'Tag', MIN_COLUMN_WIDTH),
+    (TAG_KEY_TYPE, 'Data Type', MIN_COLUMN_WIDTH),
+    (TAG_KEY_REQUIRED, 'Required?', MIN_COLUMN_WIDTH),
+    (TAG_KEY_REPEATING, 'Repeats?', MIN_COLUMN_WIDTH),
+    (TAG_KEY_DESCRIPTION, 'Description', 40),
+    (TAG_KEY_ERROR_HANDLE, 'Error Handling', 40),
+]
+
+# The reST table columns for an enumeration.
+ENUMERATION_COLUMNS = [
+    (TAG_KEY_NAME, 'Tag', MIN_COLUMN_WIDTH),
+    (TAG_KEY_DESCRIPTION, 'Description', 50),
+]
+
+
+# A dictionary of "conversions" for table cell values.
+# This is useful for converting Python objects and special string
+# values to formatted reST strings for human-readability.
+# For example, this dictionary converts a Python value of True for the
+# "required" column to the formatted reST string "**Required**".
+ELEMENT_CELL_VALUES = {
+    TAG_KEY_TYPE: TYPE_NAME_TO_REST,
+    TAG_KEY_REQUIRED: {
+        False: 'Optional',
+        True: '**Required**',
+    },
+    TAG_KEY_REPEATING: {
+        False: 'Single',
+        True: 'Repeats',
+    },
+}
+
+ENUMERATION_CELL_VALUES = {}
+
+
+def get_type_info(is_enum):
+    # Sanity-check to make sure this function is being used correctly.
+    assert type(is_enum) == bool
+    if is_enum:
+        column_infos = ENUMERATION_COLUMNS
+        cell_values = ENUMERATION_CELL_VALUES
+    else:
+        # Otherwise, it is an element.
+        column_infos = ELEMENT_COLUMNS
+        cell_values = ELEMENT_CELL_VALUES
+    return column_infos, cell_values
+
+
+def make_table_formatter(all_types, data_type):
+    is_enum = data_type.is_enum
+    column_infos, cell_values = get_type_info(is_enum)
+    keys, headers, widths = ([c[i] for c in column_infos] for i in range(3))
+    formatter = TableFormatter(all_types=all_types, headers=headers, keys=keys,
+                               widths=widths, cell_values=cell_values)
+    return formatter
+
+
+def make_table(all_types, data_type):
+    formatter = make_table_formatter(all_types, data_type)
+    lines = formatter.make_table(data_type)
+    table = "\n".join(lines) + "\n"
+
+    return table
+
+
+def update_table_files(type_name=None):
+    all_types = common.read_types()
+    if type_name is None:
+        type_names = sorted(all_types.keys())
+    else:
+        type_names = [type_name]
+
+    for type_name in type_names:
+        data_type = common.get_type(all_types, type_name)
+        table = make_table(all_types, data_type)
+        text = TABLE_COMMENT + table
+        rest_path = data_type.table_path
+        dir_path = os.path.dirname(rest_path)
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+        common.write_file(rest_path, text)
+
+
+def analyze_types():
+    dir_path = os.path.join(common.YAML_DIR, 'elements')
+    yaml_paths = common.get_all_files(dir_path, ext='.yaml')
+    values = {}
+    i = 0
+    for yaml_path in yaml_paths:
+#        _log.info("processing: {0}".format(path))
+        formatter = make_table_formatter(yaml_path)
+        type_info = common.read_type(yaml_path)
+        type_yaml = common.read_yaml(yaml_path)
+        tags_data = type_info['tags']
+        tags_yaml = type_yaml['tags']
+        for tag, tag_yaml in zip(tags_data, tags_yaml):
+            tag_name = tag[TAG_KEY_NAME]
+            tag_type = tag[TAG_KEY_TYPE]
+            required = common.get_tag_value(tag, TAG_KEY_REQUIRED)
+            if 'on_error_custom' in tag and 'error_then' not in tag:
+                print(yaml_path, tag_name)
+        #common.write_yaml(type_yaml, yaml_path)
+    #pprint(values)
+
+
+class TableFormatter(object):
+
+    # The size of the left and right margin of each cell as a number of spaces.
+    margin = 1
+
+    def __init__(self, all_types, cell_values, headers, keys, widths):
+        """
+        Arguments:
+          cell_values:
+
+        """
+        self.all_types = all_types
+        self.cell_values = cell_values
+        self.headers = headers
+        self.keys = keys
+        self.min_widths = widths
+
+    def wrap(self, text, width):
+        return textwrap.wrap(text, width=width, break_long_words=False,
+                             break_on_hyphens=False)
+
+    def get_cell_value(self, tag_data, key):
+        """
+        Return the text to put in the cell of a reST table.
+        """
+        data_value = common.get_tag_value(self.all_types, tag_data, key)
+        try:
+            conversions = self.cell_values[key]
+        except KeyError:
+            value = data_value
+        else:
+            value = conversions.get(data_value, data_value)
+        if value.startswith('='):
+            raise Exception("unconverted value: {0}".format(value))
+        return value
+
+    def make_width(self, i, header, tags_data):
+        all_words = [header]
+        key = self.keys[i]
+        for tag_data in tags_data:
+            value = self.get_cell_value(tag_data, key)
+            words = value.split(" ")
+            all_words.extend(words)
+        width = max(len(w) for w in all_words)
+        width = max(width, self.min_widths[i])
+        return width
+
+    def make_widths(self, headers, tags_data):
+        widths = []
+        for i, header in enumerate(headers):
+            width = self.make_width(i, header, tags_data)
+            widths.append(width)
+        return widths
+
+    def get_cell_widths(self, widths):
+        return [w + 2 * self.margin for w in widths]
+
+    def make_line(self, parts, glue):
+        parts = [''] + parts + ['']
+        line = glue.join(parts)
+        return line
+
+    def make_divider(self, widths, fill_char=None):
+        if fill_char is None:
+            fill_char = '-'
+        cell_widths = self.get_cell_widths(widths)
+        parts = [w * fill_char for w in cell_widths]
+        line = self.make_line(parts, glue='+')
+        return line
+
+    def make_text_line(self, parts, widths):
+        cell_widths = self.get_cell_widths(widths)
+        parts = [(self.margin * " " + s).ljust(w) for s, w in zip(parts, cell_widths)]
+        line = self.make_line(parts, glue='|')
+        return line
+
+    def make_row(self, cell_values, widths, separator=None):
+        if separator is None:
+            separator = '-'
+        contents = [self.wrap(s, width=w) for s, w in zip(cell_values, widths)]
+        parts_seq = itertools.zip_longest(*contents, fillvalue='')
+        lines = [self.make_text_line(parts, widths=widths) for parts in parts_seq]
+        lines.append(self.make_divider(widths=widths, fill_char=separator))
+        return lines
+
+    def make_row_from_data(self, tag_data, widths):
+        cell_values = [self.get_cell_value(tag_data, k) for k in self.keys]
+        lines = self.make_row(cell_values, widths=widths)
+        return lines
+
+    def make_table(self, data_type):
+        """
+        Return the reST table for an object type.
+
+        The table is returned as a list of lines of text.
+        """
+        try:
+            tags = data_type.tags
+            widths = self.make_widths(self.headers, tags)
+            lines = [self.make_divider(widths)]
+            lines.extend(self.make_row(self.headers, widths, separator='='))
+            for tag in tags:
+                lines.extend(self.make_row_from_data(tag, widths=widths))
+        except Exception:
+            raise Exception("with data_type:\n{0}".format(data_type))
+        return lines


### PR DESCRIPTION
This PR addresses issue #255 and is an improved version of PR #256.

This PR doesn't yet address all of the suggestions that were made in the comments to PR #256, but I wanted to get this PR posted as soon as possible to help meet the deadline, etc.

Note that this PR doesn't DRY up the YAML data quite as much as PR #256 since PR #256 involved some manual work mixed in with the automated script.  In this PR, however, everything is automated.

An example of something not handled by the current PR is the following:

> If the field is invalid or not present, the implementation is required to ignore the ``Office`` element containing it.

In the other PR, error-handling strings like this were generated automatically using a template (aka Python format string).  But in this PR, strings like this are "hard-coded" in the YAML.  It is slightly harder to convert these automatically since the word for the parent type varies.  This DRY-ing up can be done in a subsequent PR.

Also, this PR doesn't actually _run_ the parsing, YAML generation, and new reST table generation.  That can be done in a PR immediately after this, which was something that was requested.
