### PR TITLE
Temporarily remove references to the CSV documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,20 +5,17 @@
 
 Welcome to the VIP Specification documentation
 ==============================================
-Welcome to the `Voting Information Project's`_ (VIP) open XML and flat file (CSV) format. This data
-format provides an easy way to produce data that lets developers take a voter's address, compare it
-to street segments, and determine that voter's precinct (or precinct split). Knowing a voter's
-precinct allows information disseminators (such as `Google`_) to provide voters with their official
-polling locations (and early voting sites), ballots (including both candidates and referenda), local
-election administrations, and election officials.
+Welcome to the `Voting Information Project's`_ (VIP) :ref:`open XML <xml-docs>`
+format specification. This data format provides an easy way to produce data that
+lets developers take a voter's address, compare it to street segments, and
+determine that voter's precinct (or precinct split). Knowing a voter's precinct
+allows information disseminators (such as `Google`_) to provide voters with
+their official polling locations (and early voting sites), ballots (including
+both candidates and referenda), local election administrations, and election
+officials.
 
 .. _Voting Information Project's: https://www.votinginfoproject.org/
 .. _Google: https://developers.google.com/civic-information/
-
-The documentation is split into two distinct parts.
-
-* :ref:`xml-docs`
-* :ref:`csv-docs`
 
 To see a changelog of all of the updates, please see `the GitHub repository`_.
 
@@ -34,13 +31,3 @@ XML Documentation
 
    xml/index
 
-.. todolist::
-   
-.. _csv-docs:
-
-CSV Documentation
------------------
-
-.. todo::
-
-   Add CSV documentation


### PR DESCRIPTION
The CSV documentation will get added in soon, and with it the links from the index.