### PR TITLE
Issue #300: generate the reST files from the YAML files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,8 @@ easy to edit by hand.  The YAML files are stored in the
 ## Dev Environment
 
 This section explains how to set up your local development environment for
-contributing.  First, [install Python][python_download].  **We recommend
-installing the latest stable version of Python 3** (Python 3.4.3 as of June
-2015).
+contributing. First, [install Python][python_download]. **You must use Python
+3.4 or higher.**
 
 We also recommend setting up a virtual environment for the repo (e.g. using
 [virtualenv][virtualenv]) prior to installing dependencies.
@@ -112,24 +111,24 @@ Once the above command is executed, open a browser and view
 [http://127.0.0.1:8000](http://127.0.0.1:8000) to see the documentation.
 
 
-## Updating Tables in the Documentation
+## Updating the Documentation
 
-To make changes to the tables, edit the YAML files by hand as needed.
-Do not edit the reST tables by hand since they are generated automatically
+To update the documentation, edit the YAML files by hand as needed.
+Do not edit the reST files by hand since they are generated automatically
 from the YAML files.
 
-Then, normalize the YAML files and update the reST tables:
+Then, normalize the YAML files and update the reST files:
 
 ```sh
 $ python scripts/vip.py norm_yaml
-$ python scripts/vip.py update_tables
+$ python scripts/vip.py update_rest
 ```
 
 After this, you will want to build the documentation as described above.
 
 When submitting a PR, changes to both the YAML files and the updated reST
-tables should be checked in.  This lets people reviewing your pull request
-check to see how the reST tables will be affected by your patch.
+files should be checked in.  This lets people reviewing your pull request
+check to see how the reST files will be affected by your patch.
 However, do not check in the generated HTML files.
 
 For help using the Python script above:
@@ -141,7 +140,7 @@ $ python scripts/vip.py -h
 Or for help with a specific command (for example):
 
 ```sh
-$ python scripts/vip.py update_tables -h
+$ python scripts/vip.py update_rest -h
 ```
 
 

--- a/docs/tables/elements/ballot_style.rst
+++ b/docs/tables/elements/ballot_style.rst
@@ -8,7 +8,7 @@
 |                  |              |              |              |                                          | ignore it.                               |
 +------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | OrderedContestId | xs:IDREF     | Optional     | Repeats      | Reference to an :doc:`OrderedContest     | If the field is invalid or not present,  |
-|                  |              |              |              | <ordered_contest>`                       | then the implementation is required to   |
+|                  |              |              |              | </xml/elements/ordered_contest>`         | then the implementation is required to   |
 |                  |              |              |              |                                          | ignore it.                               |
 +------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PartyId          | xs:IDREF     | Optional     | Repeats      | Reference to a :doc:`Party <party>`.     | If the field is invalid or not present,  |

--- a/docs/tables/elements/candidate.rst
+++ b/docs/tables/elements/candidate.rst
@@ -8,8 +8,8 @@
 |                     |                                                   |              |              | "Ken T. Cuccinelli II").                 | required to ignore the Candidate element |
 |                     |                                                   |              |              |                                          | containing it.                           |
 +---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :doc:`ExternalIdentifiers <external_identifiers>` | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
-|                     |                                                   |              |              | links to another source of information   | present, then the implementation is      |
+| ExternalIdentifiers | :doc:`ExternalIdentifiers                         | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>`             |              |              | links to another source of information   | present, then the implementation is      |
 |                     |                                                   |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
 |                     |                                                   |              |              | to a campaign finance system).           |                                          |
 +---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/contest_base.rst
+++ b/docs/tables/elements/contest_base.rst
@@ -1,63 +1,63 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                     | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=========================+===================================+==============+==============+==========================================+==========================================+
-| Abbreviation            | xs:string                         | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
-|                         |                                   |              |              |                                          | then the implementation should ignore    |
-|                         |                                   |              |              |                                          | it.                                      |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSelectionId       | xs:IDREF                          | Optional     | Repeats      | References a particular BallotSelection, | If the field is invalid or not present,  |
-|                         |                                   |              |              | which could be of any selection type     | then the implementation should ignore    |
-|                         |                                   |              |              | that extends :doc:`BallotSelectionBase   | it.                                      |
-|                         |                                   |              |              | <ballot_selection_base>`.                |                                          |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSubTitle          | :doc:`InternationalizedText       | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
-|                         | <internationalized_text>`         |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                   |              |              |                                          | ignore it.                               |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotTitle             | :doc:`InternationalizedText       | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
-|                         | <internationalized_text>`         |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                   |              |              |                                          | ignore it.                               |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId     | xs:IDREF                          | Optional     | Single       | References an :doc:`ElectoralDistrict    | If the field is invalid or not present,  |
-|                         |                                   |              |              | <electoral_district>` element that       | then the implementation should ignore    |
-|                         |                                   |              |              | represents the geographical scope of the | it.                                      |
-|                         |                                   |              |              | contest.                                 |                                          |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectorateSpecification | :doc:`InternationalizedText       | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
-|                         | <internationalized_text>`         |              |              | electorate for this contest past the     | present, then the implementation should  |
-|                         |                                   |              |              | usual, "all registered voters"           | ignore it.                               |
-|                         |                                   |              |              | electorate. This subtag will most often  |                                          |
-|                         |                                   |              |              | be used for primaries and local          |                                          |
-|                         |                                   |              |              | elections. In primaries, voters may have |                                          |
-|                         |                                   |              |              | to be registered as a specific party to  |                                          |
-|                         |                                   |              |              | vote, or there may be special rules for  |                                          |
-|                         |                                   |              |              | which ballot a voter can pull. In some   |                                          |
-|                         |                                   |              |              | local elections, non-citizens can vote.  |                                          |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers     | :doc:`ExternalIdentifiers         | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
-|                         | <external_identifiers>`           |              |              | links to another source of information.  | present, then the implementation should  |
-|                         |                                   |              |              |                                          | ignore it.                               |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HasRotation             | xs:boolean                        | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
-|                         |                                   |              |              | contest are rotated.                     | then the implementation should ignore    |
-|                         |                                   |              |              |                                          | it.                                      |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                    | xs:string                         | Optional     | Single       | Name of the contest, not necessarily how | If the field is invalid or not present,  |
-|                         |                                   |              |              | it appears on the ballot (NB:            | then the implementation should ignore    |
-|                         |                                   |              |              | BallotTitle should be used for this      | it.                                      |
-|                         |                                   |              |              | purpose).                                |                                          |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| SequenceOrder           | xs:integer                        | Optional     | Single       | Order in which the candidates are listed | If the field is invalid or not present,  |
-|                         |                                   |              |              | on the ballot.                           | then the implementation should ignore    |
-|                         |                                   |              |              |                                          | it.                                      |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VoteVariation           | :doc:`VoteVariation               | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
-|                         | <../enumerations/vote_variation>` |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
-|                         |                                   |              |              |                                          | it.                                      |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherVoteVariation      | xs:string                         | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
-|                         |                                   |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
-|                         |                                   |              |              | variation can be specified here.         | it.                                      |
-+-------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                     | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=========================+=======================================+==============+==============+==========================================+==========================================+
+| Abbreviation            | xs:string                             | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                         |                                       |              |              |                                          | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSelectionId       | xs:IDREF                              | Optional     | Repeats      | References a particular BallotSelection, | If the field is invalid or not present,  |
+|                         |                                       |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                         |                                       |              |              | that extends :doc:`BallotSelectionBase   | it.                                      |
+|                         |                                       |              |              | </xml/elements/ballot_selection_base>`.  |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSubTitle          | :doc:`InternationalizedText           | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotTitle             | :doc:`InternationalizedText           | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId     | xs:IDREF                              | Optional     | Single       | References an :doc:`ElectoralDistrict    | If the field is invalid or not present,  |
+|                         |                                       |              |              | <electoral_district>` element that       | then the implementation should ignore    |
+|                         |                                       |              |              | represents the geographical scope of the | it.                                      |
+|                         |                                       |              |              | contest.                                 |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectorateSpecification | :doc:`InternationalizedText           | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                         |                                       |              |              | usual, "all registered voters"           | ignore it.                               |
+|                         |                                       |              |              | electorate. This subtag will most often  |                                          |
+|                         |                                       |              |              | be used for primaries and local          |                                          |
+|                         |                                       |              |              | elections. In primaries, voters may have |                                          |
+|                         |                                       |              |              | to be registered as a specific party to  |                                          |
+|                         |                                       |              |              | vote, or there may be special rules for  |                                          |
+|                         |                                       |              |              | which ballot a voter can pull. In some   |                                          |
+|                         |                                       |              |              | local elections, non-citizens can vote.  |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers     | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                         | </xml/elements/external_identifiers>` |              |              | links to another source of information.  | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasRotation             | xs:boolean                            | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                         |                                       |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                    | xs:string                             | Optional     | Single       | Name of the contest, not necessarily how | If the field is invalid or not present,  |
+|                         |                                       |              |              | it appears on the ballot (NB:            | then the implementation should ignore    |
+|                         |                                       |              |              | BallotTitle should be used for this      | it.                                      |
+|                         |                                       |              |              | purpose).                                |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SequenceOrder           | xs:integer                            | Optional     | Single       | Order in which the candidates are listed | If the field is invalid or not present,  |
+|                         |                                       |              |              | on the ballot.                           | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VoteVariation           | :doc:`VoteVariation                   | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                         | <../enumerations/vote_variation>`     |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherVoteVariation      | xs:string                             | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                         |                                       |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                         |                                       |              |              | variation can be specified here.         | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/electoral_district.rst
+++ b/docs/tables/elements/electoral_district.rst
@@ -1,32 +1,32 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+==================================+==============+==============+==========================================+==========================================+
-| ExternalIdentifiers | :doc:`ExternalIdentifiers        | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
-|                     | <external_identifiers>`          |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
-|                     |                                  |              |              |                                          | required to ignore it.                   |
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                | xs:string                        | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
-|                     |                                  |              |              |                                          | then the implementation is required to   |
-|                     |                                  |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                     |                                  |              |              |                                          | containing it.                           |
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Number              | xs:integer                       | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
-|                     |                                  |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
-|                     |                                  |              |              | 34th State Senate District). If a number | ignore it.                               |
-|                     |                                  |              |              | is not applicable, instead of leaving    |                                          |
-|                     |                                  |              |              | the field blank, leave this field out of |                                          |
-|                     |                                  |              |              | the object; empty strings are not valid  |                                          |
-|                     |                                  |              |              | for xs:integer fields.                   |                                          |
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Type                | :doc:`DistrictType               | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
-|                     | <../enumerations/district_type>` |              |              |                                          | then the implementation is required to   |
-|                     |                                  |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                     |                                  |              |              |                                          | containing it.                           |
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherType           | xs:string                        | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
-|                     |                                  |              |              | :doc:`DistrictType                       | then the implementation is required to   |
-|                     |                                  |              |              | <../enumerations/district_type>` option  | ignore it.                               |
-|                     |                                  |              |              | when ``Type`` is specified as "other".   |                                          |
-+---------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
+|                     |                                       |              |              |                                          | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | xs:string                             | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
+|                     |                                       |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                       |              |              |                                          | containing it.                           |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number              | xs:integer                            | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
+|                     |                                       |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
+|                     |                                       |              |              | 34th State Senate District). If a number | ignore it.                               |
+|                     |                                       |              |              | is not applicable, instead of leaving    |                                          |
+|                     |                                       |              |              | the field blank, leave this field out of |                                          |
+|                     |                                       |              |              | the object; empty strings are not valid  |                                          |
+|                     |                                       |              |              | for xs:integer fields.                   |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                | :doc:`DistrictType                    | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
+|                     | <../enumerations/district_type>`      |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                       |              |              |                                          | containing it.                           |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType           | xs:string                             | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
+|                     |                                       |              |              | :doc:`DistrictType                       | then the implementation is required to   |
+|                     |                                       |              |              | <../enumerations/district_type>` option  | ignore it.                               |
+|                     |                                       |              |              | when ``Type`` is specified as "other".   |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/hours.rst
+++ b/docs/tables/elements/hours.rst
@@ -3,11 +3,11 @@
 +--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag          | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
 +==============+=================+==============+==============+==========================================+==========================================+
-| StartTime    | `TimeWithZone`_ | Optional     | Single       | The time at which this place opens.      | If the field is invalid or not present,  |
-|              |                 |              |              |                                          | then the implementation is required to   |
-|              |                 |              |              |                                          | ignore it.                               |
+| StartTime    | `TimeWithZone`_ | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                 |              |              |                                          | present, then the implementation is      |
+|              |                 |              |              |                                          | required to ignore it.                   |
 +--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndTime      | `TimeWithZone`_ | Optional     | Single       | The time at which this place closes.     | If the field is invalid or not present,  |
-|              |                 |              |              |                                          | then the implementation is required to   |
-|              |                 |              |              |                                          | ignore it.                               |
+| EndTime      | `TimeWithZone`_ | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                 |              |              |                                          | present, then the implementation is      |
+|              |                 |              |              |                                          | required to ignore it.                   |
 +--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/locality.rst
+++ b/docs/tables/elements/locality.rst
@@ -1,39 +1,39 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+==================================+==============+==============+==========================================+==========================================+
-| ElectionAdministrationId | xs:IDREF                         | Optional     | Single       | Links to the locality's :doc:`election   | If the field is invalid or not present,  |
-|                          |                                  |              |              | administration                           | then the implementation is required to   |
-|                          |                                  |              |              | <election_administration>` object.       | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers      | :doc:`ExternalIdentifiers        | Optional     | Single       | Another identifier for a locality that   | If the element is invalid or not         |
-|                          | <external_identifiers>`          |              |              | links to another dataset (e.g.           | present, then the implementation is      |
-|                          |                                  |              |              | `OCD-ID`_)                               | required to ignore it.                   |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | xs:string                        | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                          |                                  |              |              |                                          | the implementation is required to ignore |
-|                          |                                  |              |              |                                          | the Locality element containing it.      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingLocationId        | xs:IDREF                         | Optional     | Repeats      | Specifies a link to the locality's       | If the field is invalid or not present,  |
-|                          |                                  |              |              | :doc:`polling locations                  | the implementation is required to ignore |
-|                          |                                  |              |              | <polling_location>`. If early vote       | it. However, the implementation should   |
-|                          |                                  |              |              | centers or ballot drop locations are     | still check to see if there are any      |
-|                          |                                  |              |              | locality-wide, they should be specified  | polling locations associated with this   |
-|                          |                                  |              |              | here.                                    | locality's state.                        |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StateId                  | xs:IDREF                         | **Required** | Single       | References the locality's :doc:`state    | If the field is invalid or not present,  |
-|                          |                                  |              |              | <state>`.                                | the implementation is required to ignore |
-|                          |                                  |              |              |                                          | the Locality element containing.         |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Type                     | :doc:`DistrictType               | Optional     | Single       | Defines the kind of locality (e.g.       | If the field is invalid or not present,  |
-|                          | <../enumerations/district_type>` |              |              | county, town, et al.), which is one of   | then the implementation is required to   |
-|                          |                                  |              |              | the various :doc:`DistrictType           | ignore it.                               |
-|                          |                                  |              |              | enumerations                             |                                          |
-|                          |                                  |              |              | <../enumerations/district_type>`.        |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherType                | xs:string                        | Optional     | Single       | Allows for defining a type of locality   | If the field is invalid or not present,  |
-|                          |                                  |              |              | that falls outside the options listed in | then the implementation is required to   |
-|                          |                                  |              |              | :doc:`DistrictType                       | ignore it.                               |
-|                          |                                  |              |              | <../enumerations/district_type>`.        |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| ElectionAdministrationId | xs:IDREF                              | Optional     | Single       | Links to the locality's :doc:`election   | If the field is invalid or not present,  |
+|                          |                                       |              |              | administration                           | then the implementation is required to   |
+|                          |                                       |              |              | <election_administration>` object.       | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :doc:`ExternalIdentifiers             | Optional     | Single       | Another identifier for a locality that   | If the element is invalid or not         |
+|                          | </xml/elements/external_identifiers>` |              |              | links to another dataset (e.g.           | present, then the implementation is      |
+|                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | xs:string                             | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId        | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the locality's       | If the field is invalid or not present,  |
+|                          |                                       |              |              | :doc:`polling locations                  | the implementation is required to ignore |
+|                          |                                       |              |              | <polling_location>`. If early vote       | it. However, the implementation should   |
+|                          |                                       |              |              | centers or ballot drop locations are     | still check to see if there are any      |
+|                          |                                       |              |              | locality-wide, they should be specified  | polling locations associated with this   |
+|                          |                                       |              |              | here.                                    | locality's state.                        |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StateId                  | xs:IDREF                              | **Required** | Single       | References the locality's :doc:`state    | If the field is invalid or not present,  |
+|                          |                                       |              |              | <state>`.                                | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing.         |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                     | :doc:`DistrictType                    | Optional     | Single       | Defines the kind of locality (e.g.       | If the field is invalid or not present,  |
+|                          | <../enumerations/district_type>`      |              |              | county, town, et al.), which is one of   | then the implementation is required to   |
+|                          |                                       |              |              | the various :doc:`DistrictType           | ignore it.                               |
+|                          |                                       |              |              | enumerations                             |                                          |
+|                          |                                       |              |              | <../enumerations/district_type>`.        |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType                | xs:string                             | Optional     | Single       | Allows for defining a type of locality   | If the field is invalid or not present,  |
+|                          |                                       |              |              | that falls outside the options listed in | then the implementation is required to   |
+|                          |                                       |              |              | :doc:`DistrictType                       | ignore it.                               |
+|                          |                                       |              |              | <../enumerations/district_type>`.        |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/office.rst
+++ b/docs/tables/elements/office.rst
@@ -1,38 +1,38 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+=============================+==============+==============+==========================================+==========================================+
-| ContactInformation   | :doc:`ContactInformation    | Optional     | Repeats      | Specifies the contact information for    | If the element is invalid or not         |
-|                      | <contact_information>`      |              |              | the office and/or individual holding the | present, then the implementation is      |
-|                      |                             |              |              | office.                                  | required to ignore it.                   |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId  | xs:IDREF                    | **Required** | Single       | Links to the :doc:`ElectoralDistrict     | If the field is invalid or not present,  |
-|                      |                             |              |              | <electoral_district>` element associated | the implementation is required to ignore |
-|                      |                             |              |              | with the office.                         | the ``Office`` element containing it.    |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers  | :doc:`ExternalIdentifiers   | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
-|                      | <external_identifiers>`     |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
-|                      |                             |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FilingDeadline       | xs:date                     | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
-|                      |                             |              |              | candidate must have filed for the        | then the implementation is required to   |
-|                      |                             |              |              | contest for the office.                  | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsPartisan           | xs:boolean                  | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
-|                      |                             |              |              | partisan.                                | then the implementation is required to   |
-|                      |                             |              |              |                                          | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                 | :doc:`InternationalizedText | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
-|                      | <internationalized_text>`   |              |              |                                          | the implementation is required to ignore |
-|                      |                             |              |              |                                          | the ``Office`` element containing it.    |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OfficeHolderPersonId | xs:IDREF                    | Optional     | Repeats      | Links to the :doc:`Person <person>`      | If the field is invalid or not present,  |
-|                      |                             |              |              | element(s) that hold additional          | then the implementation is required to   |
-|                      |                             |              |              | information about the current office     | ignore it.                               |
-|                      |                             |              |              | holder(s).                               |                                          |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Term                 | `Term`_                     | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
-|                      |                             |              |              |                                          | present, then the implementation is      |
-|                      |                             |              |              |                                          | required to ignore it.                   |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+=======================================+==============+==============+==========================================+==========================================+
+| ContactInformation   | :doc:`ContactInformation              | Optional     | Repeats      | Specifies the contact information for    | If the element is invalid or not         |
+|                      | <contact_information>`                |              |              | the office and/or individual holding the | present, then the implementation is      |
+|                      |                                       |              |              | office.                                  | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId  | xs:IDREF                              | **Required** | Single       | Links to the :doc:`ElectoralDistrict     | If the field is invalid or not present,  |
+|                      |                                       |              |              | <electoral_district>` element associated | the implementation is required to ignore |
+|                      |                                       |              |              | with the office.                         | the ``Office`` element containing it.    |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers  | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
+|                      | </xml/elements/external_identifiers>` |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
+|                      |                                       |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FilingDeadline       | xs:date                               | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
+|                      |                                       |              |              | candidate must have filed for the        | then the implementation is required to   |
+|                      |                                       |              |              | contest for the office.                  | ignore it.                               |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsPartisan           | xs:boolean                            | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
+|                      |                                       |              |              | partisan.                                | then the implementation is required to   |
+|                      |                                       |              |              |                                          | ignore it.                               |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                 | :doc:`InternationalizedText           | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
+|                      | <internationalized_text>`             |              |              |                                          | the implementation is required to ignore |
+|                      |                                       |              |              |                                          | the ``Office`` element containing it.    |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeHolderPersonId | xs:IDREF                              | Optional     | Repeats      | Links to the :doc:`Person <person>`      | If the field is invalid or not present,  |
+|                      |                                       |              |              | element(s) that hold additional          | then the implementation is required to   |
+|                      |                                       |              |              | information about the current office     | ignore it.                               |
+|                      |                                       |              |              | holder(s).                               |                                          |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Term                 | `Term`_                               | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
+|                      |                                       |              |              |                                          | present, then the implementation is      |
+|                      |                                       |              |              |                                          | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/party.rst
+++ b/docs/tables/elements/party.rst
@@ -1,25 +1,25 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=============================+==============+==============+==========================================+==========================================+
-| Abbreviation        | xs:string                   | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
-|                     |                             |              |              |                                          | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Color               | `HtmlColorString`_          | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
-|                     |                             |              |              | party, for use in maps and other         | present, then the implementation is      |
-|                     |                             |              |              | displays.                                | required to ignore it.                   |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :doc:`ExternalIdentifiers   | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
-|                     | <external_identifiers>`     |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
-|                     |                             |              |              | campaign finance system, etc).           | required to ignore it.                   |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LogoUri             | xs:anyURI                   | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
-|                     |                             |              |              | displays.                                | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                | :doc:`InternationalizedText | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
-|                     | <internationalized_text>`   |              |              |                                          | present, then the implementation is      |
-|                     |                             |              |              |                                          | required to ignore it.                   |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| Abbreviation        | xs:string                             | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
+|                     |                                       |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Color               | `HtmlColorString`_                    | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
+|                     |                                       |              |              | party, for use in maps and other         | present, then the implementation is      |
+|                     |                                       |              |              | displays.                                | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
+|                     |                                       |              |              | campaign finance system, etc).           | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LogoUri             | xs:anyURI                             | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
+|                     |                                       |              |              | displays.                                | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | :doc:`InternationalizedText           | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
+|                     | <internationalized_text>`             |              |              |                                          | present, then the implementation is      |
+|                     |                                       |              |              |                                          | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/party.rst
+++ b/docs/tables/elements/party.rst
@@ -7,9 +7,9 @@
 |                     |                             |              |              |                                          | then the implementation is required to   |
 |                     |                             |              |              |                                          | ignore it.                               |
 +---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Color               | `HtmlColorString`_          | Optional     | Single       | The preferred display color for the      | If the field is invalid or not present,  |
-|                     |                             |              |              | party, for use in maps and other         | then the implementation is required to   |
-|                     |                             |              |              | displays.                                | ignore it.                               |
+| Color               | `HtmlColorString`_          | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
+|                     |                             |              |              | party, for use in maps and other         | present, then the implementation is      |
+|                     |                             |              |              | displays.                                | required to ignore it.                   |
 +---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ExternalIdentifiers | :doc:`ExternalIdentifiers   | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
 |                     | <external_identifiers>`     |              |              | to other related data sets (e.g. a       | present, then the implementation is      |

--- a/docs/tables/elements/precinct.rst
+++ b/docs/tables/elements/precinct.rst
@@ -1,59 +1,59 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+===========================+==============+==============+==========================================+==========================================+
-| BallotStyleId       | xs:IDREF                  | Optional     | Single       | Links to the :doc:`ballot style          | If the field is invalid or not present,  |
-|                     |                           |              |              | <ballot_style>`, which a person who      | then the implementation is required to   |
-|                     |                           |              |              | lives in this precinct will vote.        | ignore it.                               |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId | xs:IDREF                  | Optional     | Repeats      | Links to an :doc:`electoral district     | If the field is invalid or not present,  |
-|                     |                           |              |              | <electoral_district>` (e.g.,             | then the implementation is required to   |
-|                     |                           |              |              | congressional district, state house      | ignore it.                               |
-|                     |                           |              |              | district, school board district) to      |                                          |
-|                     |                           |              |              | which the precinct belongs. **Highly     |                                          |
-|                     |                           |              |              | Recommended** if candidate information   |                                          |
-|                     |                           |              |              | is to be provided. Multiple allowed and  |                                          |
-|                     |                           |              |              | recommended to specify the geography of  |                                          |
-|                     |                           |              |              | multiple electoral districts. If an      |                                          |
-|                     |                           |              |              | electoral district splits a precinct,    |                                          |
-|                     |                           |              |              | use the `PrecinctSplitName` object and   |                                          |
-|                     |                           |              |              | do not specify that particular electoral |                                          |
-|                     |                           |              |              | district in this object.                 |                                          |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :doc:`ExternalIdentifiers | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
-|                     | <external_identifiers>`   |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                     |                           |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsMailOnly          | xs:boolean                | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
-|                     |                           |              |              | mail-only elections.                     | implementation is required to assume     |
-|                     |                           |              |              |                                          | `IsMailOnly` is false.                   |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LocalityId          | xs:IDREF                  | **Required** | Single       | Links to the :doc:`locality <locality>`  | If the field is invalid or not present,  |
-|                     |                           |              |              | that comprises the precinct.             | the implementation is required to ignore |
-|                     |                           |              |              |                                          | the precinct element containing it.      |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                | xs:string                 | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid or not present,  |
-|                     |                           |              |              | if no name exists).                      | the implementation is required to ignore |
-|                     |                           |              |              |                                          | the precinct element containing it.      |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Number              | xs:string                 | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
-|                     |                           |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
-|                     |                           |              |              | legal). Should be used if the `Name`     | ignore it.                               |
-|                     |                           |              |              | field is populated by a name and not a   |                                          |
-|                     |                           |              |              | number.                                  |                                          |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingLocationId   | xs:IDREF                  | Optional     | Repeats      | Specifies a link to the precinct's       | If the field is invalid or not present,  |
-|                     |                           |              |              | :doc:`polling location                   | then the implementation is required to   |
-|                     |                           |              |              | <polling_location>` object(s). Multiple  | ignore it.                               |
-|                     |                           |              |              | `PollingLocationId` tags may be          |                                          |
-|                     |                           |              |              | specified.                               |                                          |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PrecinctSplitName   | xs:string                 | Optional     | Single       | Refers to name of the associated         | If the field is invalid or not present,  |
-|                     |                           |              |              | precinct split.                          | then the implementation is required to   |
-|                     |                           |              |              |                                          | ignore it.                               |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Ward                | xs:string                 | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
-|                     |                           |              |              | contained within.                        | then the implementation is required to   |
-|                     |                           |              |              |                                          | ignore it.                               |
-+---------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| BallotStyleId       | xs:IDREF                              | Optional     | Single       | Links to the :doc:`ballot style          | If the field is invalid or not present,  |
+|                     |                                       |              |              | <ballot_style>`, which a person who      | then the implementation is required to   |
+|                     |                                       |              |              | lives in this precinct will vote.        | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId | xs:IDREF                              | Optional     | Repeats      | Links to an :doc:`electoral district     | If the field is invalid or not present,  |
+|                     |                                       |              |              | <electoral_district>` (e.g.,             | then the implementation is required to   |
+|                     |                                       |              |              | congressional district, state house      | ignore it.                               |
+|                     |                                       |              |              | district, school board district) to      |                                          |
+|                     |                                       |              |              | which the precinct belongs. **Highly     |                                          |
+|                     |                                       |              |              | Recommended** if candidate information   |                                          |
+|                     |                                       |              |              | is to be provided. Multiple allowed and  |                                          |
+|                     |                                       |              |              | recommended to specify the geography of  |                                          |
+|                     |                                       |              |              | multiple electoral districts. If an      |                                          |
+|                     |                                       |              |              | electoral district splits a precinct,    |                                          |
+|                     |                                       |              |              | use the `PrecinctSplitName` object and   |                                          |
+|                     |                                       |              |              | do not specify that particular electoral |                                          |
+|                     |                                       |              |              | district in this object.                 |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                     |                                       |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsMailOnly          | xs:boolean                            | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
+|                     |                                       |              |              | mail-only elections.                     | implementation is required to assume     |
+|                     |                                       |              |              |                                          | `IsMailOnly` is false.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LocalityId          | xs:IDREF                              | **Required** | Single       | Links to the :doc:`locality <locality>`  | If the field is invalid or not present,  |
+|                     |                                       |              |              | that comprises the precinct.             | the implementation is required to ignore |
+|                     |                                       |              |              |                                          | the precinct element containing it.      |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | xs:string                             | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid or not present,  |
+|                     |                                       |              |              | if no name exists).                      | the implementation is required to ignore |
+|                     |                                       |              |              |                                          | the precinct element containing it.      |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number              | xs:string                             | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
+|                     |                                       |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
+|                     |                                       |              |              | legal). Should be used if the `Name`     | ignore it.                               |
+|                     |                                       |              |              | field is populated by a name and not a   |                                          |
+|                     |                                       |              |              | number.                                  |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId   | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the precinct's       | If the field is invalid or not present,  |
+|                     |                                       |              |              | :doc:`polling location                   | then the implementation is required to   |
+|                     |                                       |              |              | <polling_location>` object(s). Multiple  | ignore it.                               |
+|                     |                                       |              |              | `PollingLocationId` tags may be          |                                          |
+|                     |                                       |              |              | specified.                               |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrecinctSplitName   | xs:string                             | Optional     | Single       | Refers to name of the associated         | If the field is invalid or not present,  |
+|                     |                                       |              |              | precinct split.                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Ward                | xs:string                             | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
+|                     |                                       |              |              | contained within.                        | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/tables/elements/state.rst
+++ b/docs/tables/elements/state.rst
@@ -1,25 +1,25 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+--------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+===========================+==============+==============+==========================================+==========================================+
-| ElectionAdministrationId | xs:IDREF                  | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
-|                          |                           |              |              | administration object.                   | then the implementation is required to   |
-|                          |                           |              |              |                                          | ignore it.                               |
-+--------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers      | :doc:`ExternalIdentifiers | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
-|                          | <external_identifiers>`   |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                          |                           |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+--------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | xs:string                 | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
-|                          |                           |              |              | Alabama.                                 | implementation is required to ignore it. |
-+--------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingLocationId        | xs:IDREF                  | Optional     | Repeats      | Specifies a link to the state's          | If the field is invalid or not present,  |
-|                          |                           |              |              | :doc:`polling locations                  | then the implementation is required to   |
-|                          |                           |              |              | <polling_location>`. If early vote       | ignore it.                               |
-|                          |                           |              |              | centers or ballot drop locations are     |                                          |
-|                          |                           |              |              | state-wide (e.g., anyone in the state    |                                          |
-|                          |                           |              |              | can use them), they can be specified     |                                          |
-|                          |                           |              |              | here, but you are encouraged to only use |                                          |
-|                          |                           |              |              | the :doc:`Precinct <precinct>` element.  |                                          |
-+--------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| ElectionAdministrationId | xs:IDREF                              | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
+|                          |                                       |              |              | administration object.                   | then the implementation is required to   |
+|                          |                                       |              |              |                                          | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
+|                          | </xml/elements/external_identifiers>` |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                          |                                       |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | xs:string                             | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
+|                          |                                       |              |              | Alabama.                                 | implementation is required to ignore it. |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId        | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the state's          | If the field is invalid or not present,  |
+|                          |                                       |              |              | :doc:`polling locations                  | then the implementation is required to   |
+|                          |                                       |              |              | <polling_location>`. If early vote       | ignore it.                               |
+|                          |                                       |              |              | centers or ballot drop locations are     |                                          |
+|                          |                                       |              |              | state-wide (e.g., anyone in the state    |                                          |
+|                          |                                       |              |              | can use them), they can be specified     |                                          |
+|                          |                                       |              |              | here, but you are encouraged to only use |                                          |
+|                          |                                       |              |              | the :doc:`Precinct <precinct>` element.  |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/xml/elements/ballot_measure_contest.rst
+++ b/docs/xml/elements/ballot_measure_contest.rst
@@ -6,7 +6,56 @@ BallotMeasureContest
 The BallotMeasureContest provides information about a ballot measure before the voters, including
 summary statements on each side. Extends :doc:`ContestBase <contest_base>`.
 
-.. include:: ../../tables/elements/ballot_measure_contest.rst
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+========================================+==============+==============+==========================================+==========================================+
+| ConStatement     | :doc:`InternationalizedText            | Optional     | Single       | Specifies a statement in opposition to   | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | the referendum. It does not necessarily  | present, then the implementation is      |
+|                  |                                        |              |              | appear on the ballot.                    | required to ignore it.                   |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EffectOfAbstain  | :doc:`InternationalizedText            | Optional     | Single       | Specifies what effect abstaining (i.e.   | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | not voting) on this proposition will     | present, then the implementation is      |
+|                  |                                        |              |              | have (i.e. whether abstaining is         | required to ignore it.                   |
+|                  |                                        |              |              | considered a vote against it).           |                                          |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FullText         | :doc:`InternationalizedText            | Optional     | Single       | Specifies the full text of the           | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | referendum as it appears on the ballot.  | present, then the implementation is      |
+|                  |                                        |              |              |                                          | required to ignore it.                   |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| InfoUri          | xs:anyURI                              | Optional     | Single       | Specifies a URI that links to additional | If the field is invalid or not present,  |
+|                  |                                        |              |              | information about the referendum.        | then the implementation is required to   |
+|                  |                                        |              |              |                                          | ignore it.                               |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PassageThreshold | :doc:`InternationalizedText            | Optional     | Single       | Specifies the threshold of votes that    | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | the referendum needs in order to pass.   | present, then the implementation is      |
+|                  |                                        |              |              | The default is a simple majority (i.e.   | required to ignore it.                   |
+|                  |                                        |              |              | 50% plus one vote). Other common         |                                          |
+|                  |                                        |              |              | thresholds are "three-fifths" and        |                                          |
+|                  |                                        |              |              | "two-thirds". If there are `competing    |                                          |
+|                  |                                        |              |              | initiatives`_, information about their   |                                          |
+|                  |                                        |              |              | effect on the passage of the             |                                          |
+|                  |                                        |              |              | BallotMeasureContest would go here.      |                                          |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ProStatement     | :doc:`InternationalizedText            | Optional     | Single       | Specifies a statement in favor of the    | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | referendum. It does not necessarily      | present, then the implementation is      |
+|                  |                                        |              |              | appear on the ballot.                    | required to ignore it.                   |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SummaryText      | :doc:`InternationalizedText            | Optional     | Single       | Specifies a short summary of the         | If the element is invalid or not         |
+|                  | <internationalized_text>`              |              |              | referendum that is on the ballot, below  | present, then the implementation is      |
+|                  |                                        |              |              | the title, but above the text.           | required to ignore it.                   |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type             | :doc:`BallotMeasureType                | Optional     | Single       | Specifies the particular type of ballot  | If the field is invalid or not present,  |
+|                  | <../enumerations/ballot_measure_type>` |              |              | measure. Must be one of the valid        | then the implementation is required to   |
+|                  |                                        |              |              | :doc:`BallotMeasureType                  | ignore it.                               |
+|                  |                                        |              |              | <../enumerations/ballot_measure_type>`   |                                          |
+|                  |                                        |              |              | options.                                 |                                          |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType        | xs:string                              | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
+|                  |                                        |              |              | :doc:`BallotMeasureType                  | then the implementation is required to   |
+|                  |                                        |              |              | <../enumerations/ballot_measure_type>`   | ignore it.                               |
+|                  |                                        |              |              | option, when Type is specified as        |                                          |
+|                  |                                        |              |              | "other."                                 |                                          |
++------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/ballot_measure_contest.rst
+++ b/docs/xml/elements/ballot_measure_contest.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 BallotMeasureContest
 ====================
 

--- a/docs/xml/elements/ballot_measure_selection.rst
+++ b/docs/xml/elements/ballot_measure_selection.rst
@@ -7,7 +7,14 @@ Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for
 :doc:`BallotMeasureContest <ballot_measure_contest>` that would appear on the ballot.
 BallotMeasureSelection extends :doc:`BallotSelectionBase <ballot_selection_base>`.
 
-.. include:: ../../tables/elements/ballot_measure_selection.rst
++--------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=============================+==============+==============+==========================================+==========================================+
+| Selection    | :doc:`InternationalizedText | **Required** | Single       | Selection text for a                     | If the element is invalid or not         |
+|              | <internationalized_text>`   |              |              | :doc:`BallotMeasureContest               | present, the implementation is required  |
+|              |                             |              |              | <ballot_measure_contest>`                | to ignore the BallotMeasureSelection     |
+|              |                             |              |              |                                          | containing it.                           |
++--------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/ballot_measure_selection.rst
+++ b/docs/xml/elements/ballot_measure_selection.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 BallotMeasureSelection
 ======================
 

--- a/docs/xml/elements/ballot_selection_base.rst
+++ b/docs/xml/elements/ballot_selection_base.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 BallotSelectionBase
 ===================
 

--- a/docs/xml/elements/ballot_style.rst
+++ b/docs/xml/elements/ballot_style.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 BallotStyle
 ===========
 
@@ -16,4 +18,3 @@ A container for the contests/measures on the ballot.
       <OrderedContestId>oc20355</OrderedContestId>
       <OrderedContestId>oc20449</OrderedContestId>
    </BallotStyle>
-

--- a/docs/xml/elements/ballot_style.rst
+++ b/docs/xml/elements/ballot_style.rst
@@ -5,7 +5,21 @@ BallotStyle
 
 A container for the contests/measures on the ballot.
 
-.. include:: ../../tables/elements/ballot_style.rst
++------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+==============+==============+==============+==========================================+==========================================+
+| ImageUri         | xs:anyURI    | Optional     | Single       | Specifies a URI that returns an image of | If the field is invalid or not present,  |
+|                  |              |              |              | the sample ballot.                       | then the implementation is required to   |
+|                  |              |              |              |                                          | ignore it.                               |
++------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrderedContestId | xs:IDREF     | Optional     | Repeats      | Reference to an :doc:`OrderedContest     | If the field is invalid or not present,  |
+|                  |              |              |              | </xml/elements/ordered_contest>`         | then the implementation is required to   |
+|                  |              |              |              |                                          | ignore it.                               |
++------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyId          | xs:IDREF     | Optional     | Repeats      | Reference to a :doc:`Party <party>`.     | If the field is invalid or not present,  |
+|                  |              |              |              |                                          | then the implementation is required to   |
+|                  |              |              |              |                                          | ignore it.                               |
++------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/candidate.rst
+++ b/docs/xml/elements/candidate.rst
@@ -1,9 +1,11 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Candidate
 =========
 
 The Candidate object represents a candidate in a contest. If a candidate is running in multiple contests, the same
 Candidate object may be used.
-   
+
 .. include:: ../../tables/elements/candidate.rst
 
 .. code-block:: xml

--- a/docs/xml/elements/candidate.rst
+++ b/docs/xml/elements/candidate.rst
@@ -6,7 +6,51 @@ Candidate
 The Candidate object represents a candidate in a contest. If a candidate is running in multiple contests, the same
 Candidate object may be used.
 
-.. include:: ../../tables/elements/candidate.rst
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                                         | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+===================================================+==============+==============+==========================================+==========================================+
+| BallotName          | :doc:`InternationalizedText                       | **Required** | Single       | The candidate's name as it will be       | If the element is invalid or not         |
+|                     | <internationalized_text>`                         |              |              | displayed on the official ballot (e.g.   | present, then the implementation is      |
+|                     |                                                   |              |              | "Ken T. Cuccinelli II").                 | required to ignore the Candidate element |
+|                     |                                                   |              |              |                                          | containing it.                           |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers                         | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>`             |              |              | links to another source of information   | present, then the implementation is      |
+|                     |                                                   |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
+|                     |                                                   |              |              | to a campaign finance system).           |                                          |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FileDate            | xs:date                                           | Optional     | Single       | Date when the candidate filed for the    | If the field is invalid or not present,  |
+|                     |                                                   |              |              | contest.                                 | then the implementation is required to   |
+|                     |                                                   |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsIncumbent         | xs:boolean                                        | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                     |                                                   |              |              | incumbent for the office associated with | then the implementation is required to   |
+|                     |                                                   |              |              | the contest.                             | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsTopTicket         | xs:boolean                                        | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                     |                                                   |              |              | top of a ticket that includes multiple   | then the implementation is required to   |
+|                     |                                                   |              |              | candidates.                              | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyId             | xs:IDREF                                          | Optional     | Single       | Reference to a :doc:`Party <party>`      | If the field is invalid or not present,  |
+|                     |                                                   |              |              | element with additional information      | then the implementation is required to   |
+|                     |                                                   |              |              | about the candidate's affiliated party.  | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PersonId            | xs:IDREF                                          | Optional     | Single       | Reference to a :doc:`Person <person>`    | If the field is invalid or not present,  |
+|                     |                                                   |              |              | element with additional information      | then the implementation is required to   |
+|                     |                                                   |              |              | about the candidate.                     | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PostElectionStatus  | :doc:`CandidatePostElectionStatus                 | Optional     | Single       | Final status of the candidate (e.g.      | If the field is invalid or not present,  |
+|                     | <../enumerations/candidate_post_election_status>` |              |              | winner, withdrawn, etc...).              | then the implementation is required to   |
+|                     |                                                   |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PreElectionStatus   | :doc:`CandidatePreElectionStatus                  | Optional     | Single       | Registration status of the candidate     | If the field is invalid or not present,  |
+|                     | <../enumerations/candidate_pre_election_status>`  |              |              | (e.g. filed, qualified, etc...).         | then the implementation is required to   |
+|                     |                                                   |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SequenceOrder       | xs:integer                                        | Optional     | Single       | The order in which the candidate can be  | If the field is invalid or not present,  |
+|                     |                                                   |              |              | listed on the ballot or in results.      | then the implementation is required to   |
+|                     |                                                   |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/candidate_contest.rst
+++ b/docs/xml/elements/candidate_contest.rst
@@ -6,7 +6,25 @@ CandidateContest
 CandidateContest extends :doc:`ContestBase <contest_base>` and represents a contest among
 candidates.
 
-.. include:: ../../tables/elements/candidate_contest.rst
++----------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag            | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++================+==============+==============+==============+==========================================+==========================================+
+| NumberElected  | xs:integer   | Optional     | Single       | Number of candidates that are elected in | If the field is invalid or not present,  |
+|                |              |              |              | the contest (i.e. "N" of N-of-M).        | then the implementation is required to   |
+|                |              |              |              |                                          | ignore it.                               |
++----------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeId       | xs:IDREF     | Optional     | Repeats      | References an :doc:`Office <office>`     | If the field is invalid or not present,  |
+|                |              |              |              | element, if available, which gives       | then the implementation is required to   |
+|                |              |              |              | additional information about the office. | ignore it.                               |
++----------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrimaryPartyId | xs:IDREF     | Optional     | Single       | References a :doc:`Party <party>`        | If the field is invalid or not present,  |
+|                |              |              |              | element, if the contest is related to a  | then the implementation is required to   |
+|                |              |              |              | particular party.                        | ignore it.                               |
++----------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VotesAllowed   | xs:integer   | Optional     | Single       | Maximum number of votes/write-ins per    | If the field is invalid or not present,  |
+|                |              |              |              | voter in this contest.                   | then the implementation is required to   |
+|                |              |              |              |                                          | ignore it.                               |
++----------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/candidate_contest.rst
+++ b/docs/xml/elements/candidate_contest.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 CandidateContest
 ================
 

--- a/docs/xml/elements/candidate_selection.rst
+++ b/docs/xml/elements/candidate_selection.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 CandidateSelection
 ==================
 
@@ -8,7 +10,7 @@ ballot selection for a candidate contest.
 
 .. code-block:: xml
    :linenos:
-      
+
    <CandidateSelection id="cs10861">
       <CandidateId>can10861a</CandidateId>
       <CandidateId>can10861b</CandidateId>

--- a/docs/xml/elements/candidate_selection.rst
+++ b/docs/xml/elements/candidate_selection.rst
@@ -6,7 +6,27 @@ CandidateSelection
 CandidateSelection extends :doc:`BallotSelectionBase <ballot_selection_base>` and represents a
 ballot selection for a candidate contest.
 
-.. include:: ../../tables/elements/candidate_selection.rst
++--------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++====================+==============+==============+==============+==========================================+==========================================+
+| CandidateId        | xs:IDREF     | Optional     | Repeats      | References a :doc:`Candidate             | If the field is invalid or not present,  |
+|                    |              |              |              | <candidate>` element. The number of      | then the implementation is required to   |
+|                    |              |              |              | candidates that can be references is     | ignore it.                               |
+|                    |              |              |              | unbounded in cases where the ballot      |                                          |
+|                    |              |              |              | selection is for a ticket (e.g.          |                                          |
+|                    |              |              |              | "President/Vice President", "Governor/Lt |                                          |
+|                    |              |              |              | Governor").                              |                                          |
++--------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndorsementPartyId | xs:IDREF     | Optional     | Repeats      | References a :doc:`Party <party>`        | If the field is invalid or not present,  |
+|                    |              |              |              | element, which signifies one or more     | then the implementation is required to   |
+|                    |              |              |              | endorsing parties for the candidate(s).  | ignore it.                               |
++--------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn          | xs:boolean   | Optional     | Single       | Signifies if the particular ballot       | If the field is invalid or not present,  |
+|                    |              |              |              | selection allows for write-in            | then the implementation is required to   |
+|                    |              |              |              | candidates. If true, one or more         | ignore it.                               |
+|                    |              |              |              | write-in candidates are allowed for this |                                          |
+|                    |              |              |              | contest.                                 |                                          |
++--------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/contact_information.rst
+++ b/docs/xml/elements/contact_information.rst
@@ -10,7 +10,45 @@ organizations, etc. ContactInformation is always a sub-element of another object
 ``label``, which allows the feed to refer back to the original label for the information
 (e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
 
-.. include:: ../../tables/elements/contact_information.rst
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+=============================+==============+==============+==========================================+==========================================+
+| AddressLine      | xs:string                   | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|                  |                             |              |              | address. `See usage note.`_              | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Email            | xs:string                   | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|                  |                             |              |              |                                          | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Fax              | xs:string                   | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|                  |                             |              |              |                                          | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours            | :doc:`InternationalizedText | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]** | <internationalized_text>`   |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|                  |                             |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|                  |                             |              |              | structured :doc:`HoursOpen <hours_open>` |                                          |
+|                  |                             |              |              | element. It is strongly encouraged that  |                                          |
+|                  |                             |              |              | data providers move toward contributing  |                                          |
+|                  |                             |              |              | hours in this format)*.                  |                                          |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId      | xs:IDREF                    | Optional     | Single       | References an :doc:`HoursOpen            | If the field is invalid or not present,  |
+|                  |                             |              |              | <hours_open>` element, which lists the   | then the implementation is required to   |
+|                  |                             |              |              | hours of operation for a location.       | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name             | xs:string                   | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|                  |                             |              |              | `See usage note.`_                       | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Phone            | xs:string                   | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|                  |                             |              |              |                                          | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Uri              | xs:anyURI                   | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|                  |                             |              |              | location.                                | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _See usage note.:
 

--- a/docs/xml/elements/contact_information.rst
+++ b/docs/xml/elements/contact_information.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 ContactInformation
 ==================
 
@@ -9,7 +11,6 @@ organizations, etc. ContactInformation is always a sub-element of another object
 (e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
 
 .. include:: ../../tables/elements/contact_information.rst
-
 
 .. _See usage note.:
 

--- a/docs/xml/elements/contest_base.rst
+++ b/docs/xml/elements/contest_base.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 ContestBase
 ===========
 
@@ -7,4 +9,3 @@ and :doc:`RetentionContest <retention_contest>` (NB: the latter because it exten
 :doc:`BallotMeasureContest <ballot_measure_contest>`).
 
 .. include:: ../../tables/elements/contest_base.rst
-

--- a/docs/xml/elements/contest_base.rst
+++ b/docs/xml/elements/contest_base.rst
@@ -8,4 +8,64 @@ A base model for all Contest types: :doc:`BallotMeasureContest <ballot_measure_c
 and :doc:`RetentionContest <retention_contest>` (NB: the latter because it extends
 :doc:`BallotMeasureContest <ballot_measure_contest>`).
 
-.. include:: ../../tables/elements/contest_base.rst
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                     | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=========================+=======================================+==============+==============+==========================================+==========================================+
+| Abbreviation            | xs:string                             | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                         |                                       |              |              |                                          | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSelectionId       | xs:IDREF                              | Optional     | Repeats      | References a particular BallotSelection, | If the field is invalid or not present,  |
+|                         |                                       |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                         |                                       |              |              | that extends :doc:`BallotSelectionBase   | it.                                      |
+|                         |                                       |              |              | </xml/elements/ballot_selection_base>`.  |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSubTitle          | :doc:`InternationalizedText           | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotTitle             | :doc:`InternationalizedText           | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId     | xs:IDREF                              | Optional     | Single       | References an :doc:`ElectoralDistrict    | If the field is invalid or not present,  |
+|                         |                                       |              |              | <electoral_district>` element that       | then the implementation should ignore    |
+|                         |                                       |              |              | represents the geographical scope of the | it.                                      |
+|                         |                                       |              |              | contest.                                 |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectorateSpecification | :doc:`InternationalizedText           | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                         | <internationalized_text>`             |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                         |                                       |              |              | usual, "all registered voters"           | ignore it.                               |
+|                         |                                       |              |              | electorate. This subtag will most often  |                                          |
+|                         |                                       |              |              | be used for primaries and local          |                                          |
+|                         |                                       |              |              | elections. In primaries, voters may have |                                          |
+|                         |                                       |              |              | to be registered as a specific party to  |                                          |
+|                         |                                       |              |              | vote, or there may be special rules for  |                                          |
+|                         |                                       |              |              | which ballot a voter can pull. In some   |                                          |
+|                         |                                       |              |              | local elections, non-citizens can vote.  |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers     | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                         | </xml/elements/external_identifiers>` |              |              | links to another source of information.  | present, then the implementation should  |
+|                         |                                       |              |              |                                          | ignore it.                               |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasRotation             | xs:boolean                            | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                         |                                       |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                    | xs:string                             | Optional     | Single       | Name of the contest, not necessarily how | If the field is invalid or not present,  |
+|                         |                                       |              |              | it appears on the ballot (NB:            | then the implementation should ignore    |
+|                         |                                       |              |              | BallotTitle should be used for this      | it.                                      |
+|                         |                                       |              |              | purpose).                                |                                          |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SequenceOrder           | xs:integer                            | Optional     | Single       | Order in which the candidates are listed | If the field is invalid or not present,  |
+|                         |                                       |              |              | on the ballot.                           | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VoteVariation           | :doc:`VoteVariation                   | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                         | <../enumerations/vote_variation>`     |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                         |                                       |              |              |                                          | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherVoteVariation      | xs:string                             | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                         |                                       |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                         |                                       |              |              | variation can be specified here.         | it.                                      |
++-------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/xml/elements/election.rst
+++ b/docs/xml/elements/election.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Election
 ========
 
@@ -30,4 +32,3 @@ with one Election object.
      <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
      <StateId>st51</StateId>
    </Election>
-

--- a/docs/xml/elements/election.rst
+++ b/docs/xml/elements/election.rst
@@ -10,7 +10,74 @@ the Election specified by this object. It is permissible, and recommended, to co
 contests (e.g., a special election and a general election) that occur on the same day into one feed
 with one Election object.
 
-.. include:: ../../tables/elements/election.rst
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                        | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++============================+=============================+==============+==============+==========================================+==========================================+
+| Date                       | xs:date                     | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
+|                            |                             |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
+|                            |                             |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
+|                            |                             |              |              | the election.                            |                                          |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionType               | :doc:`InternationalizedText | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
+|                            | <internationalized_text>`   |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
+|                            |                             |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StateId                    | xs:IDREF                    | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
+|                            |                             |              |              | where the election is being held.        | implementation is required to ignore the |
+|                            |                             |              |              |                                          | ``Election`` element containing it.      |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsStatewide                | xs:boolean                  | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
+|                            |                             |              |              | statewide.                               | the implementation is required to        |
+|                            |                             |              |              |                                          | default to "yes".                        |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                       | :doc:`InternationalizedText | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
+|                            | <internationalized_text>`   |              |              | optional, this element is highly         | present, then the implementation is      |
+|                            |                             |              |              | recommended).                            | required to ignore it.                   |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RegistrationInfo           | :doc:`InternationalizedText | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
+|                            | <internationalized_text>`   |              |              | for this election either as text or a    | present, then the implementation is      |
+|                            |                             |              |              | URI.                                     | required to ignore it.                   |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AbsenteeBallotInfo         | :doc:`InternationalizedText | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
+|                            | <internationalized_text>`   |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
+|                            |                             |              |              |                                          | required to ignore it.                   |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ResultsUri                 | xs:anyURI                   | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
+|                            |                             |              |              | election may be found                    | then the implementation is required to   |
+|                            |                             |              |              |                                          | ignore it.                               |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingHours               | :doc:`InternationalizedText | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**           | <internationalized_text>`   |              |              | Election Day polling locations are open. | present, then the implementation is      |
+|                            |                             |              |              | If polling hours differ in specific      | required to ignore it.                   |
+|                            |                             |              |              | polling locations, alternative hours may |                                          |
+|                            |                             |              |              | be specified in the                      |                                          |
+|                            |                             |              |              | :doc:`PollingLocation                    |                                          |
+|                            |                             |              |              | <polling_location>` object *(NB: this    |                                          |
+|                            |                             |              |              | element is deprecated in favor of the    |                                          |
+|                            |                             |              |              | more structured :doc:`HoursOpen          |                                          |
+|                            |                             |              |              | <hours_open>` element. It is strongly    |                                          |
+|                            |                             |              |              | encouraged that data providers move      |                                          |
+|                            |                             |              |              | toward contributing hours in this        |                                          |
+|                            |                             |              |              | format)*.                                |                                          |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId                | xs:IDREF                    | Optional     | Single       | References the :doc:`HoursOpen           | If the field is invalid or not present,  |
+|                            |                             |              |              | <hours_open>` element, which lists the   | then the implementation is required to   |
+|                            |                             |              |              | hours of operation for polling           | ignore it.                               |
+|                            |                             |              |              | locations.                               |                                          |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasElectionDayRegistration | xs:boolean                  | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
+|                            |                             |              |              | same day of the election (i.e., the last | then the implementation is required to   |
+|                            |                             |              |              | day of the election). Valid items are    | ignore it.                               |
+|                            |                             |              |              | "yes" and "no".                          |                                          |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RegistrationDeadline       | xs:date                     | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
+|                            |                             |              |              | the election with the possible exception | then the implementation is required to   |
+|                            |                             |              |              | of Election Day registration.            | ignore it.                               |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AbsenteeRequestDeadline    | xs:date                     | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
+|                            |                             |              |              | absentee ballot.                         | then the implementation is required to   |
+|                            |                             |              |              |                                          | ignore it.                               |
++----------------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/election_administration.rst
+++ b/docs/xml/elements/election_administration.rst
@@ -6,7 +6,45 @@ ElectionAdministration
 The Election Administration represents an institution for serving a locality's (or state's) election
 functions.
 
-.. include:: ../../tables/elements/election_administration.rst
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type        | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+==================+==============+==============+==========================================+==========================================+
+| AbsenteeUri         | xs:anyURI        | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
+|                     |                  |              |              | information on absentee voting.          | then the implementation is required to   |
+|                     |                  |              |              |                                          | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AmIRegisteredUri    | xs:anyURI        | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
+|                     |                  |              |              | information on whether an individual is  | then the implementation is required to   |
+|                     |                  |              |              | registered.                              | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Department          | :ref:`Department | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
+|                     | <ea-dep>`        |              |              | particular voter service.                | `Department` in each                     |
+|                     |                  |              |              |                                          | `ElectionAdministration` element. If no  |
+|                     |                  |              |              |                                          | valid `Department` objects are present,  |
+|                     |                  |              |              |                                          | the implementation is required to ignore |
+|                     |                  |              |              |                                          | the `ElectionAdministration` object that |
+|                     |                  |              |              |                                          | contains it/them.                        |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionsUri        | xs:anyURI        | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
+|                     |                  |              |              | administration's website.                | then the implementation is required to   |
+|                     |                  |              |              |                                          | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RegistrationUri     | xs:anyURI        | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
+|                     |                  |              |              | registering to vote.                     | then the implementation is required to   |
+|                     |                  |              |              |                                          | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RulesUri            | xs:anyURI        | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
+|                     |                  |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
+|                     |                  |              |              | of the administration.                   | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| WhatIsOnMyBallotUri | xs:anyURI        | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
+|                     |                  |              |              | what is on an individual's ballot.       | then the implementation is required to   |
+|                     |                  |              |              |                                          | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| WhereDoIVoteUri     | xs:anyURI        | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
+|                     |                  |              |              | information on where an individual votes | then the implementation is required to   |
+|                     |                  |              |              | based on their address.                  | ignore it.                               |
++---------------------+------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _ea-dep:
 
@@ -14,7 +52,23 @@ functions.
 Department
 ----------
 
-.. include:: ../../tables/elements/department.rst
++--------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+==========================+==============+==============+==========================================+==========================================+
+| ContactInformation       | :doc:`ContactInformation | Optional     | Single       | Contact and physical address information | If the element is invalid or not         |
+|                          | <contact_information>`   |              |              | for the election administration body     | present, then the implementation is      |
+|                          |                          |              |              | (see :doc:`ContactInformation            | required to ignore it.                   |
+|                          |                          |              |              | <contact_information>`).                 |                                          |
++--------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionOfficialPersonId | xs:IDREF                 | Optional     | Single       | The individual to contact at the         | If the field is invalid or not present,  |
+|                          |                          |              |              | election administration office. The      | then the implementation is required to   |
+|                          |                          |              |              | specified person should be the           | ignore it.                               |
+|                          |                          |              |              | :doc:`election official <person>`.       |                                          |
++--------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VoterService             | :ref:`VoterService       | Optional     | Repeats      | The types of services and appropriate    | If the element is invalid or not         |
+|                          | <ea-dep-voter-service>`  |              |              | contact individual available to voters.  | present, then the implementation is      |
+|                          |                          |              |              |                                          | required to ignore it.                   |
++--------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _ea-dep-voter-service:
 
@@ -22,7 +76,29 @@ Department
 VoterService
 ------------
 
-.. include:: ../../tables/elements/voter_service.rst
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| ContactInformation       | :doc:`ContactInformation              | Optional     | Single       | The contact for a particular voter       | If the element is invalid or not         |
+|                          | <contact_information>`                |              |              | service.                                 | present, then the implementation is      |
+|                          |                                       |              |              |                                          | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description              | :doc:`InternationalizedText           | Optional     | Single       | Long description of the services         | If the element is invalid or not         |
+|                          | <internationalized_text>`             |              |              | available.                               | present, then the implementation is      |
+|                          |                                       |              |              |                                          | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionOfficialPersonId | xs:IDREF                              | Optional     | Single       | The :doc:`authority <person>` for a      | If the field is invalid or not present,  |
+|                          |                                       |              |              | particular voter service.                | then the implementation is required to   |
+|                          |                                       |              |              |                                          | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                     | :doc:`VoterServiceType                | Optional     | Single       | The type of :doc:`voter service          | If the field is invalid or not present,  |
+|                          | <../enumerations/voter_service_type>` |              |              | <../enumerations/voter_service_type>`.   | then the implementation is required to   |
+|                          |                                       |              |              |                                          | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType                | xs:string                             | Optional     | Single       | If Type is "other", OtherType allows for | If the field is invalid or not present,  |
+|                          |                                       |              |              | cataloging another type of voter         | then the implementation is required to   |
+|                          |                                       |              |              | service.                                 | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/election_administration.rst
+++ b/docs/xml/elements/election_administration.rst
@@ -22,17 +22,17 @@ VoterService
 
 .. code-block:: xml
    :linenos:
-   
+
    <ElectionAdministration id="ea40133">
       <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
       <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
       <Department>
         <ContactInformation label="ci60000">
-	  <AddressLine>Washington Building First Floor</AddressLine>
-	  <AddressLine>1100 Bank Street</AddressLine>
-	  <AddressLine>Richmond, VA 23219</AddressLine>
-	  <Name>State Board of Elections</Name>
-	</ContactInformation>
+          <AddressLine>Washington Building First Floor</AddressLine>
+          <AddressLine>1100 Bank Street</AddressLine>
+          <AddressLine>Richmond, VA 23219</AddressLine>
+          <Name>State Board of Elections</Name>
+        </ContactInformation>
       </Department>
       <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
       <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>

--- a/docs/xml/elements/election_administration.rst
+++ b/docs/xml/elements/election_administration.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 ElectionAdministration
 ======================
 
@@ -8,12 +10,14 @@ functions.
 
 .. _ea-dep:
 
+
 Department
 ----------
 
 .. include:: ../../tables/elements/department.rst
 
 .. _ea-dep-voter-service:
+
 
 VoterService
 ------------

--- a/docs/xml/elements/electoral_district.rst
+++ b/docs/xml/elements/electoral_district.rst
@@ -12,13 +12,13 @@ which precincts link to the ``ElectoralDistrict``.
 
 .. code-block:: xml
    :linenos:
-      
+
    <ElectoralDistrict id="ed60129">
       <ExternalIdentifiers>
         <ExternalIdentifier>
           <Type>ocd-id</Type>
-	  <Value>ocd-division/country:us/state:va</Value>
-	</ExternalIdentifier>
+          <Value>ocd-division/country:us/state:va</Value>
+        </ExternalIdentifier>
         <ExternalIdentifier>
           <Type>fips</Type>
           <Value>51</Value>

--- a/docs/xml/elements/electoral_district.rst
+++ b/docs/xml/elements/electoral_district.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 ElectoralDistrict
 =================
 

--- a/docs/xml/elements/electoral_district.rst
+++ b/docs/xml/elements/electoral_district.rst
@@ -8,7 +8,36 @@ of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congr
 or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
 which precincts link to the ``ElectoralDistrict``.
 
-.. include:: ../../tables/elements/electoral_district.rst
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
+|                     |                                       |              |              |                                          | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | xs:string                             | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
+|                     |                                       |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                       |              |              |                                          | containing it.                           |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number              | xs:integer                            | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
+|                     |                                       |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
+|                     |                                       |              |              | 34th State Senate District). If a number | ignore it.                               |
+|                     |                                       |              |              | is not applicable, instead of leaving    |                                          |
+|                     |                                       |              |              | the field blank, leave this field out of |                                          |
+|                     |                                       |              |              | the object; empty strings are not valid  |                                          |
+|                     |                                       |              |              | for xs:integer fields.                   |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                | :doc:`DistrictType                    | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
+|                     | <../enumerations/district_type>`      |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                       |              |              |                                          | containing it.                           |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType           | xs:string                             | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
+|                     |                                       |              |              | :doc:`DistrictType                       | then the implementation is required to   |
+|                     |                                       |              |              | <../enumerations/district_type>` option  | ignore it.                               |
+|                     |                                       |              |              | when ``Type`` is specified as "other".   |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 

--- a/docs/xml/elements/external_identifiers.rst
+++ b/docs/xml/elements/external_identifiers.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 ExternalIdentifiers
 ===================
 
@@ -25,6 +27,7 @@ found on the objects that support them:
 .. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 
 .. include:: ../../tables/elements/external_identifiers.rst
+
 
 ExternalIdentifier
 ------------------

--- a/docs/xml/elements/external_identifiers.rst
+++ b/docs/xml/elements/external_identifiers.rst
@@ -26,13 +26,43 @@ found on the objects that support them:
 
 .. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 
-.. include:: ../../tables/elements/external_identifiers.rst
++--------------------+-----------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                | Data Type             | Required?    | Repeats?     | Description                              | Error Handling                           |
++====================+=======================+==============+==============+==========================================+==========================================+
+| ExternalIdentifier | `ExternalIdentifier`_ | **Required** | Repeats      | Defines the identifier and the type of   | At least one valid `ExternalIdentifier`_ |
+|                    |                       |              |              | identifier it is (see                    | must be present for                      |
+|                    |                       |              |              | `ExternalIdentifier`_ for complete       | ``ExternalIdentifiers`` to be valid. If  |
+|                    |                       |              |              | information).                            | no valid `ExternalIdentifier`_ is        |
+|                    |                       |              |              |                                          | present, the implementation is required  |
+|                    |                       |              |              |                                          | to ignore the ``ExternalIdentifiers``    |
+|                    |                       |              |              |                                          | element.                                 |
++--------------------+-----------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 ExternalIdentifier
 ------------------
 
-.. include:: ../../tables/elements/external_identifier.rst
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+====================================+==============+==============+==========================================+==========================================+
+| Type         | :doc:`IdentifierType               | **Required** | Single       | Specifies the type of identifier. Must   | If the field is invalid or not present,  |
+|              | <../enumerations/identifier_type>` |              |              | be one of the valid types as defined by  | the implementation is required to ignore |
+|              |                                    |              |              | :doc:`IdentifierType                     | the ``ElectionIdentifier`` containing    |
+|              |                                    |              |              | <../enumerations/identifier_type>`.      | it.                                      |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType    | xs:string                          | Optional     | Single       | Allows for cataloging an                 | If the field is invalid or not present,  |
+|              |                                    |              |              | ``ExternalIdentifier`` type that falls   | then the implementation is required to   |
+|              |                                    |              |              | outside the options listed in            | ignore it.                               |
+|              |                                    |              |              | :doc:`IdentifierType                     |                                          |
+|              |                                    |              |              | <../enumerations/identifier_type>`.      |                                          |
+|              |                                    |              |              | ``Type`` should be set to "other" when   |                                          |
+|              |                                    |              |              | using this field.                        |                                          |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Value        | xs:string                          | **Required** | Single       | Specifies the identifier.                | If the field is invalid or not present,  |
+|              |                                    |              |              |                                          | the implementation is required to ignore |
+|              |                                    |              |              |                                          | the ``ElectionIdentifier`` containing    |
+|              |                                    |              |              |                                          | it.                                      |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/hours_open.rst
+++ b/docs/xml/elements/hours_open.rst
@@ -7,7 +7,15 @@ A structured way of describing the days and hours that a place such as a
 :doc:`Office <office>` or :doc:`PollingLocation <polling_location>` is open, or
 that an event such as an :doc:`Election <election>` is happening.
 
-.. include:: ../../tables/elements/hours_open.rst
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==============+==============+==============+==========================================+==========================================+
+| Schedule     | `Schedule`_  | **Required** | Repeats      | Defines a block of days and hours that a | At least one valid `Schedule`_ must be   |
+|              |              |              |              | place will be open.                      | present for ``HoursOpen`` to be valid.   |
+|              |              |              |              |                                          | If no valid `Schedule`_ is present, the  |
+|              |              |              |              |                                          | implementation is required to ignore the |
+|              |              |              |              |                                          | ``HoursOpen`` element.                   |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 Schedule
@@ -17,7 +25,35 @@ A sub-portion of the schedule. This describes a range of days, along with one or
 more set of open and close times for those days, as well as the options
 describing whether or not appointments are necessary or possible.
 
-.. include:: ../../tables/elements/schedule.rst
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+==============+==============+==============+==========================================+==========================================+
+| Hours               | `Hours`_     | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
+|                     |              |              |              | which the place is open.                 | present, then the implementation is      |
+|                     |              |              |              |                                          | required to ignore it.                   |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOnlyByAppointment | xs:boolean   | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
+|                     |              |              |              | the specified time window with an        | then the implementation is required to   |
+|                     |              |              |              | appointment.                             | ignore it.                               |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOrByAppointment   | xs:boolean   | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
+|                     |              |              |              | hours specified time window and may also | then the implementation is required to   |
+|                     |              |              |              | be open with an appointment.             | ignore it.                               |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsSubjectToChange   | xs:boolean   | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
+|                     |              |              |              | the specified time window, but may be    | then the implementation is required to   |
+|                     |              |              |              | subject to change. People should contact | ignore it.                               |
+|                     |              |              |              | prior to arrival to confirm hours are    |                                          |
+|                     |              |              |              | still accurate.                          |                                          |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate           | xs:date      | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |              |              |              | start and end times and options begin.   | then the implementation is required to   |
+|                     |              |              |              |                                          | ignore it.                               |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate             | xs:date      | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |              |              |              | start and end times and options end.     | then the implementation is required to   |
+|                     |              |              |              |                                          | ignore it.                               |
++---------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 Hours
@@ -26,7 +62,17 @@ Hours
 The open and close time for this place. All times must be fully specified,
 including a timezone offset from UTC.
 
-.. include:: ../../tables/elements/hours.rst
++--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=================+==============+==============+==========================================+==========================================+
+| StartTime    | `TimeWithZone`_ | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                 |              |              |                                          | present, then the implementation is      |
+|              |                 |              |              |                                          | required to ignore it.                   |
++--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndTime      | `TimeWithZone`_ | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                 |              |              |                                          | present, then the implementation is      |
+|              |                 |              |              |                                          | required to ignore it.                   |
++--------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 TimeWithZone

--- a/docs/xml/elements/hours_open.rst
+++ b/docs/xml/elements/hours_open.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 HoursOpen
 =========
 
@@ -6,6 +8,7 @@ A structured way of describing the days and hours that a place such as a
 that an event such as an :doc:`Election <election>` is happening.
 
 .. include:: ../../tables/elements/hours_open.rst
+
 
 Schedule
 --------
@@ -16,6 +19,7 @@ describing whether or not appointments are necessary or possible.
 
 .. include:: ../../tables/elements/schedule.rst
 
+
 Hours
 -----
 
@@ -23,6 +27,7 @@ The open and close time for this place. All times must be fully specified,
 including a timezone offset from UTC.
 
 .. include:: ../../tables/elements/hours.rst
+
 
 TimeWithZone
 ------------

--- a/docs/xml/elements/internationalized_text.rst
+++ b/docs/xml/elements/internationalized_text.rst
@@ -30,7 +30,16 @@ CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can
 
 * :doc:`Source <source>`
 
-.. include:: ../../tables/elements/internationalized_text.rst
++--------------+-------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type         | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===================+==============+==============+==========================================+==========================================+
+| Text         | `LanguageString`_ | **Required** | Repeats      | Contains the translations of a           | At least one valid ``Text`` must be      |
+|              |                   |              |              | particular string of text.               | present for ``InternationalizedText`` to |
+|              |                   |              |              |                                          | be valid. If no valid ``Text`` is        |
+|              |                   |              |              |                                          | present, the implementation is required  |
+|              |                   |              |              |                                          | to ignore the ``InternationalizedText``  |
+|              |                   |              |              |                                          | element.                                 |
++--------------+-------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 LanguageString

--- a/docs/xml/elements/internationalized_text.rst
+++ b/docs/xml/elements/internationalized_text.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 InternationalizedText
 =====================
 
@@ -29,6 +31,7 @@ CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can
 * :doc:`Source <source>`
 
 .. include:: ../../tables/elements/internationalized_text.rst
+
 
 LanguageString
 --------------

--- a/docs/xml/elements/locality.rst
+++ b/docs/xml/elements/locality.rst
@@ -5,7 +5,43 @@ Locality
 
 The Locality object represents the jurisdiction below the :doc:`state <state>` (e.g. county).
 
-.. include:: ../../tables/elements/locality.rst
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| ElectionAdministrationId | xs:IDREF                              | Optional     | Single       | Links to the locality's :doc:`election   | If the field is invalid or not present,  |
+|                          |                                       |              |              | administration                           | then the implementation is required to   |
+|                          |                                       |              |              | <election_administration>` object.       | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :doc:`ExternalIdentifiers             | Optional     | Single       | Another identifier for a locality that   | If the element is invalid or not         |
+|                          | </xml/elements/external_identifiers>` |              |              | links to another dataset (e.g.           | present, then the implementation is      |
+|                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | xs:string                             | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId        | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the locality's       | If the field is invalid or not present,  |
+|                          |                                       |              |              | :doc:`polling locations                  | the implementation is required to ignore |
+|                          |                                       |              |              | <polling_location>`. If early vote       | it. However, the implementation should   |
+|                          |                                       |              |              | centers or ballot drop locations are     | still check to see if there are any      |
+|                          |                                       |              |              | locality-wide, they should be specified  | polling locations associated with this   |
+|                          |                                       |              |              | here.                                    | locality's state.                        |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StateId                  | xs:IDREF                              | **Required** | Single       | References the locality's :doc:`state    | If the field is invalid or not present,  |
+|                          |                                       |              |              | <state>`.                                | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing.         |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                     | :doc:`DistrictType                    | Optional     | Single       | Defines the kind of locality (e.g.       | If the field is invalid or not present,  |
+|                          | <../enumerations/district_type>`      |              |              | county, town, et al.), which is one of   | then the implementation is required to   |
+|                          |                                       |              |              | the various :doc:`DistrictType           | ignore it.                               |
+|                          |                                       |              |              | enumerations                             |                                          |
+|                          |                                       |              |              | <../enumerations/district_type>`.        |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType                | xs:string                             | Optional     | Single       | Allows for defining a type of locality   | If the field is invalid or not present,  |
+|                          |                                       |              |              | that falls outside the options listed in | then the implementation is required to   |
+|                          |                                       |              |              | :doc:`DistrictType                       | ignore it.                               |
+|                          |                                       |              |              | <../enumerations/district_type>`.        |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 

--- a/docs/xml/elements/locality.rst
+++ b/docs/xml/elements/locality.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Locality
 ========
 
@@ -9,7 +11,7 @@ The Locality object represents the jurisdiction below the :doc:`state <state>` (
 
 .. code-block:: xml
    :linenos:
-   
+
    <Locality id="loc70001">
      <ElectionAdministrationId>ea40001</ElectionAdministrationId>
      <ExternalIdentifiers>

--- a/docs/xml/elements/office.rst
+++ b/docs/xml/elements/office.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Office
 ======
 
@@ -5,6 +7,7 @@ Office
 School Board, et al).
 
 .. include:: ../../tables/elements/office.rst
+
 
 Term
 ----

--- a/docs/xml/elements/office.rst
+++ b/docs/xml/elements/office.rst
@@ -6,13 +6,63 @@ Office
 ``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
 School Board, et al).
 
-.. include:: ../../tables/elements/office.rst
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+=======================================+==============+==============+==========================================+==========================================+
+| ContactInformation   | :doc:`ContactInformation              | Optional     | Repeats      | Specifies the contact information for    | If the element is invalid or not         |
+|                      | <contact_information>`                |              |              | the office and/or individual holding the | present, then the implementation is      |
+|                      |                                       |              |              | office.                                  | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId  | xs:IDREF                              | **Required** | Single       | Links to the :doc:`ElectoralDistrict     | If the field is invalid or not present,  |
+|                      |                                       |              |              | <electoral_district>` element associated | the implementation is required to ignore |
+|                      |                                       |              |              | with the office.                         | the ``Office`` element containing it.    |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers  | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
+|                      | </xml/elements/external_identifiers>` |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
+|                      |                                       |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FilingDeadline       | xs:date                               | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
+|                      |                                       |              |              | candidate must have filed for the        | then the implementation is required to   |
+|                      |                                       |              |              | contest for the office.                  | ignore it.                               |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsPartisan           | xs:boolean                            | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
+|                      |                                       |              |              | partisan.                                | then the implementation is required to   |
+|                      |                                       |              |              |                                          | ignore it.                               |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                 | :doc:`InternationalizedText           | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
+|                      | <internationalized_text>`             |              |              |                                          | the implementation is required to ignore |
+|                      |                                       |              |              |                                          | the ``Office`` element containing it.    |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeHolderPersonId | xs:IDREF                              | Optional     | Repeats      | Links to the :doc:`Person <person>`      | If the field is invalid or not present,  |
+|                      |                                       |              |              | element(s) that hold additional          | then the implementation is required to   |
+|                      |                                       |              |              | information about the current office     | ignore it.                               |
+|                      |                                       |              |              | holder(s).                               |                                          |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Term                 | `Term`_                               | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
+|                      |                                       |              |              |                                          | present, then the implementation is      |
+|                      |                                       |              |              |                                          | required to ignore it.                   |
++----------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 Term
 ----
 
-.. include:: ../../tables/elements/term.rst
++--------------+-------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                           | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=====================================+==============+==============+==========================================+==========================================+
+| Type         | :doc:`OfficeTermType                | **Required** | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
+|              | <../enumerations/office_term_type>` |              |              | :doc:`OfficeTermType                     | the implementation is required to ignore |
+|              |                                     |              |              | <../enumerations/office_term_type>` for  | the ``Office`` element containing it.    |
+|              |                                     |              |              | valid values).                           |                                          |
++--------------+-------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate    | xs:date                             | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
+|              |                                     |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                     |              |              |                                          | ignore it.                               |
++--------------+-------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate      | xs:date                             | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
+|              |                                     |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                     |              |              |                                          | ignore it.                               |
++--------------+-------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/ordered_contest.rst
+++ b/docs/xml/elements/ordered_contest.rst
@@ -8,7 +8,25 @@ ballot selections. ``OrderedContest`` elements can be collected within a
 :doc:`BallotStyle <ballot_style>` to accurate depict exactly what will show up on a particular
 ballot in the proper order.
 
-.. include:: ../../tables/elements/ordered_contest.rst
++--------------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+==============+==============+==============+==========================================+==========================================+
+| ContestId                | xs:IDREF     | **Required** | Single       | Links to elements that extend            | If the field is invalid or not present,  |
+|                          |              |              |              | :doc:`ContestBase <contest_base>`.       | the implementation is required to ignore |
+|                          |              |              |              |                                          | the ``OrderedContest`` element           |
+|                          |              |              |              |                                          | containing it.                           |
++--------------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrderedBallotSelectionId | xs:IDREF     | Optional     | Repeats      | Links to elements that extend            | If the field is invalid or not present,  |
+|                          |              |              |              | :doc:`BallotSelectionBase                | the implementation is required to ignore |
+|                          |              |              |              | <ballot_selection_base>`.                | it. If no ``OrderedBallotSelectionId``   |
+|                          |              |              |              |                                          | elements are present, the presumed order |
+|                          |              |              |              |                                          | of the selection will be the order of    |
+|                          |              |              |              |                                          | :doc:`BallotSelectionBase                |
+|                          |              |              |              |                                          | <ballot_selection_base>`-extended        |
+|                          |              |              |              |                                          | elements referenced by the underlying    |
+|                          |              |              |              |                                          | :doc:`ContestBase                        |
+|                          |              |              |              |                                          | <contest_base>`-extended elements.       |
++--------------------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/ordered_contest.rst
+++ b/docs/xml/elements/ordered_contest.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 OrderedContest
 ==============
 

--- a/docs/xml/elements/party.rst
+++ b/docs/xml/elements/party.rst
@@ -5,7 +5,29 @@ Party
 
 This element describes a political party and the metadata associated with them.
 
-.. include:: ../../tables/elements/party.rst
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| Abbreviation        | xs:string                             | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
+|                     |                                       |              |              |                                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Color               | `HtmlColorString`_                    | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
+|                     |                                       |              |              | party, for use in maps and other         | present, then the implementation is      |
+|                     |                                       |              |              | displays.                                | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
+|                     |                                       |              |              | campaign finance system, etc).           | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LogoUri             | xs:anyURI                             | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
+|                     |                                       |              |              | displays.                                | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | :doc:`InternationalizedText           | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
+|                     | <internationalized_text>`             |              |              |                                          | present, then the implementation is      |
+|                     |                                       |              |              |                                          | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 HtmlColorString

--- a/docs/xml/elements/party.rst
+++ b/docs/xml/elements/party.rst
@@ -1,9 +1,12 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Party
 =====
 
 This element describes a political party and the metadata associated with them.
 
 .. include:: ../../tables/elements/party.rst
+
 
 HtmlColorString
 ---------------

--- a/docs/xml/elements/party_contest.rst
+++ b/docs/xml/elements/party_contest.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 PartyContest
 ============
 

--- a/docs/xml/elements/party_selection.rst
+++ b/docs/xml/elements/party_selection.rst
@@ -6,4 +6,11 @@ PartySelection
 This element extends :doc:`BallotSelectionBase <ballot_selection_base>` to
 support contests in which the selections can be groups of one or more parties.
 
-.. include:: ../../tables/elements/party_selection.rst
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==============+==============+==============+==========================================+==========================================+
+| PartyId      | xs:IDREF     | **Required** | Repeats      | One or more :doc:`Party <party>` IDs     | If one or more parties referenced are    |
+|              |              |              |              | which collectively represent a ballot    | invalid or not present, the              |
+|              |              |              |              | selection.                               | implementation is required to ignore the |
+|              |              |              |              |                                          | PartySelection containing it.            |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/xml/elements/party_selection.rst
+++ b/docs/xml/elements/party_selection.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 PartySelection
 ==============
 
@@ -5,4 +7,3 @@ This element extends :doc:`BallotSelectionBase <ballot_selection_base>` to
 support contests in which the selections can be groups of one or more parties.
 
 .. include:: ../../tables/elements/party_selection.rst
-

--- a/docs/xml/elements/person.rst
+++ b/docs/xml/elements/person.rst
@@ -18,7 +18,7 @@ or elected official. These elements reference ``Person``:
    <Person id="per50001">
       <ContactInformation label="ci60002">
         <Email>rwashburne@albemarle.org</Email>
-	<Phone>4349724173</Phone>
+        <Phone>4349724173</Phone>
       </ContactInformation>
       <FirstName>RICHARD</FirstName>
       <LastName>WASHBURNE</LastName>

--- a/docs/xml/elements/person.rst
+++ b/docs/xml/elements/person.rst
@@ -12,7 +12,66 @@ or elected official. These elements reference ``Person``:
 
 * :doc:`Office <office>`
 
-.. include:: ../../tables/elements/person.rst
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++====================+=============================+==============+==============+==========================================+==========================================+
+| ContactInformation | :doc:`ContactInformation    | Optional     | Repeats      | Specifies contact information for the    | If the element is invalid or not         |
+|                    | <contact_information>`      |              |              | person.                                  | present, then the implementation is      |
+|                    |                             |              |              |                                          | required to ignore it.                   |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateOfBirth        | xs:date                     | Optional     | Single       | Represents the individual's date of      | If the field is invalid or not present,  |
+|                    |                             |              |              | birth.                                   | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FirstName          | xs:string                   | Optional     | Single       | Represents an individual's first name.   | If the field is invalid or not present,  |
+|                    |                             |              |              |                                          | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FullName           | :doc:`InternationalizedText | Optional     | Single       | Specifies a person's full name (**NB:**  | If the element is invalid or not         |
+|                    | <internationalized_text>`   |              |              | this information is                      | present, then the implementation is      |
+|                    |                             |              |              | :doc:`InternationalizedText              | required to ignore it.                   |
+|                    |                             |              |              | <internationalized_text>` because it     |                                          |
+|                    |                             |              |              | sometimes appears on ballots in multiple |                                          |
+|                    |                             |              |              | languages).                              |                                          |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LastName           | xs:string                   | Optional     | Single       | Represents an individual's last name.    | If the field is invalid or not present,  |
+|                    |                             |              |              |                                          | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| MiddleName         | xs:string                   | Optional     | Repeats      | Represents any number of names between   | If the field is invalid or not present,  |
+|                    |                             |              |              | an individual's first and last names     | then the implementation is required to   |
+|                    |                             |              |              | (e.g. John **Ronald Reuel** Tolkien).    | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Nickname           | xs:string                   | Optional     | Single       | Represents an individual's nickname.     | If the field is invalid or not present,  |
+|                    |                             |              |              |                                          | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyId            | xs:IDREF                    | Optional     | Single       | Refers to the associated :doc:`Party     | If the field is invalid or not present,  |
+|                    |                             |              |              | <party>`.                                | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Prefix             | xs:string                   | Optional     | Single       | Specifies a prefix associated with a     | If the field is invalid or not present,  |
+|                    |                             |              |              | person (e.g. Dr.).                       | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Profession         | :doc:`InternationalizedText | Optional     | Single       | Specifies a person's profession (**NB:** | If the element is invalid or not         |
+|                    | <internationalized_text>`   |              |              | this information is                      | present, then the implementation is      |
+|                    |                             |              |              | :doc:`InternationalizedText              | required to ignore it.                   |
+|                    |                             |              |              | <internationalized_text>` because it     |                                          |
+|                    |                             |              |              | sometimes appears on ballots in multiple |                                          |
+|                    |                             |              |              | languages).                              |                                          |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Suffix             | xs:string                   | Optional     | Single       | Specifies a suffix associated with a     | If the field is invalid or not present,  |
+|                    |                             |              |              | person (e.g. Jr.).                       | then the implementation is required to   |
+|                    |                             |              |              |                                          | ignore it.                               |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Title              | :doc:`InternationalizedText | Optional     | Single       | A title associated with a person         | If the element is invalid or not         |
+|                    | <internationalized_text>`   |              |              | (**NB:** this information is             | present, then the implementation is      |
+|                    |                             |              |              | :doc:`InternationalizedText              | required to ignore it.                   |
+|                    |                             |              |              | <internationalized_text>` because it     |                                          |
+|                    |                             |              |              | sometimes appears on ballots in multiple |                                          |
+|                    |                             |              |              | languages).                              |                                          |
++--------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/person.rst
+++ b/docs/xml/elements/person.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Person
 ======
 

--- a/docs/xml/elements/polling_location.rst
+++ b/docs/xml/elements/polling_location.rst
@@ -5,7 +5,50 @@ PollingLocation
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
-.. include:: ../../tables/elements/polling_location.rst
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+=============================+==============+==============+==========================================+==========================================+
+| AddressLine      | xs:string                   | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
+|                  |                             |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
+|                  |                             |              |              |                                          | valid. If no valid ``AddressLine`` is    |
+|                  |                             |              |              |                                          | present, the implementation is required  |
+|                  |                             |              |              |                                          | to ignore the ``PollingLocation``        |
+|                  |                             |              |              |                                          | element containing it.                   |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions       | :doc:`InternationalizedText | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                  | <internationalized_text>`   |              |              | locating the polling location.           | present, then the implementation is      |
+|                  |                             |              |              |                                          | required to ignore it.                   |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours            | :doc:`InternationalizedText | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]** | <internationalized_text>`   |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                  |                             |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                  |                             |              |              | the more structured :doc:`HoursOpen      |                                          |
+|                  |                             |              |              | <hours_open>` element. It is strongly    |                                          |
+|                  |                             |              |              | encouraged that data providers move      |                                          |
+|                  |                             |              |              | toward contributing hours in this        |                                          |
+|                  |                             |              |              | format).                                 |                                          |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId      | xs:IDREF                    | Optional     | Single       | Links to an :doc:`HoursOpen              | If the field is invalid or not present,  |
+|                  |                             |              |              | <hours_open>` element, which is a        | then the implementation is required to   |
+|                  |                             |              |              | schedule of dates and hours during which | ignore it.                               |
+|                  |                             |              |              | the polling location is available.       |                                          |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsDropBox        | xs:boolean                  | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                  |                             |              |              | drop box.                                | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsEarlyVoting    | xs:boolean                  | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                  |                             |              |              | early vote site.                         | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng           | `LatLng`_                   | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                  |                             |              |              | this polling location.                   | present, then the implementation is      |
+|                  |                             |              |              |                                          | required to ignore it.                   |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PhotoUri         | xs:anyURI                   | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                  |                             |              |              | polling location.                        | then the implementation is required to   |
+|                  |                             |              |              |                                          | ignore it.                               |
++------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 LatLng
@@ -14,7 +57,20 @@ LatLng
 The latitude and longitude of a polling location in `WGS 84`_ format. Both
 latitude and longitude values are measured in decimal degrees.
 
-.. include:: ../../tables/elements/lat_lng.rst
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==============+==============+==============+==========================================+==========================================+
+| Latitude     | xs:float     | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
+|              |              |              |              |                                          | implementation is required to ignore it. |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Longitude    | xs:float     | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
+|              |              |              |              |                                          | implementation is required to ignore it. |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Source       | xs:string    | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
+|              |              |              |              | from location name to lat/lng. For       | then the implementation is required to   |
+|              |              |              |              | example, this could be the name of a     | ignore it.                               |
+|              |              |              |              | geocoding service.                       |                                          |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
 

--- a/docs/xml/elements/polling_location.rst
+++ b/docs/xml/elements/polling_location.rst
@@ -1,9 +1,12 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 PollingLocation
 ===============
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
 .. include:: ../../tables/elements/polling_location.rst
+
 
 LatLng
 ------
@@ -29,4 +32,3 @@ latitude and longitude values are measured in decimal degrees.
         <Source>Google Maps</Source>
       </LatLng>
    </PollingLocation>
-

--- a/docs/xml/elements/precinct.rst
+++ b/docs/xml/elements/precinct.rst
@@ -10,7 +10,63 @@ attribute does not have to be static across feeds for one election, the combinat
 feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
 non-required fields is fine).
 
-.. include:: ../../tables/elements/precinct.rst
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| BallotStyleId       | xs:IDREF                              | Optional     | Single       | Links to the :doc:`ballot style          | If the field is invalid or not present,  |
+|                     |                                       |              |              | <ballot_style>`, which a person who      | then the implementation is required to   |
+|                     |                                       |              |              | lives in this precinct will vote.        | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId | xs:IDREF                              | Optional     | Repeats      | Links to an :doc:`electoral district     | If the field is invalid or not present,  |
+|                     |                                       |              |              | <electoral_district>` (e.g.,             | then the implementation is required to   |
+|                     |                                       |              |              | congressional district, state house      | ignore it.                               |
+|                     |                                       |              |              | district, school board district) to      |                                          |
+|                     |                                       |              |              | which the precinct belongs. **Highly     |                                          |
+|                     |                                       |              |              | Recommended** if candidate information   |                                          |
+|                     |                                       |              |              | is to be provided. Multiple allowed and  |                                          |
+|                     |                                       |              |              | recommended to specify the geography of  |                                          |
+|                     |                                       |              |              | multiple electoral districts. If an      |                                          |
+|                     |                                       |              |              | electoral district splits a precinct,    |                                          |
+|                     |                                       |              |              | use the `PrecinctSplitName` object and   |                                          |
+|                     |                                       |              |              | do not specify that particular electoral |                                          |
+|                     |                                       |              |              | district in this object.                 |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
+|                     | </xml/elements/external_identifiers>` |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                     |                                       |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsMailOnly          | xs:boolean                            | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
+|                     |                                       |              |              | mail-only elections.                     | implementation is required to assume     |
+|                     |                                       |              |              |                                          | `IsMailOnly` is false.                   |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LocalityId          | xs:IDREF                              | **Required** | Single       | Links to the :doc:`locality <locality>`  | If the field is invalid or not present,  |
+|                     |                                       |              |              | that comprises the precinct.             | the implementation is required to ignore |
+|                     |                                       |              |              |                                          | the precinct element containing it.      |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | xs:string                             | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid or not present,  |
+|                     |                                       |              |              | if no name exists).                      | the implementation is required to ignore |
+|                     |                                       |              |              |                                          | the precinct element containing it.      |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number              | xs:string                             | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
+|                     |                                       |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
+|                     |                                       |              |              | legal). Should be used if the `Name`     | ignore it.                               |
+|                     |                                       |              |              | field is populated by a name and not a   |                                          |
+|                     |                                       |              |              | number.                                  |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId   | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the precinct's       | If the field is invalid or not present,  |
+|                     |                                       |              |              | :doc:`polling location                   | then the implementation is required to   |
+|                     |                                       |              |              | <polling_location>` object(s). Multiple  | ignore it.                               |
+|                     |                                       |              |              | `PollingLocationId` tags may be          |                                          |
+|                     |                                       |              |              | specified.                               |                                          |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrecinctSplitName   | xs:string                             | Optional     | Single       | Refers to name of the associated         | If the field is invalid or not present,  |
+|                     |                                       |              |              | precinct split.                          | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Ward                | xs:string                             | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
+|                     |                                       |              |              | contained within.                        | then the implementation is required to   |
+|                     |                                       |              |              |                                          | ignore it.                               |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 

--- a/docs/xml/elements/precinct.rst
+++ b/docs/xml/elements/precinct.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Precinct
 ========
 
@@ -14,7 +16,7 @@ non-required fields is fine).
 
 .. code-block:: xml
    :linenos:
-   
+
    <Precinct id="pre90111">
       <BallotStyleId>bs00010</BallotStyleId>
       <ElectoralDistrictId>ed60129</ElectoralDistrictId>

--- a/docs/xml/elements/retention_contest.rst
+++ b/docs/xml/elements/retention_contest.rst
@@ -6,7 +6,18 @@ RetentionContest
 ``RetentionContest`` extends :doc:`BallotMeasureContest <ballot_measure_contest>` and represents a
 contest where a candidate is retained in a position (e.g. a judge).
 
-.. include:: ../../tables/elements/retention_contest.rst
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==============+==============+==============+==========================================+==========================================+
+| CandidateId  | xs:IDREF     | **Required** | Single       | Links to the :doc:`Candidate             | If the field is invalid or not present,  |
+|              |              |              |              | <candidate>` being retained.             | the implementation is required to ignore |
+|              |              |              |              |                                          | the ``RetentionContest`` element         |
+|              |              |              |              |                                          | containing it.                           |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeId     | xs:IDREF     | Optional     | Single       | Links to the information about the       | If the field is invalid or not present,  |
+|              |              |              |              | office.                                  | then the implementation is required to   |
+|              |              |              |              |                                          | ignore it.                               |
++--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/retention_contest.rst
+++ b/docs/xml/elements/retention_contest.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 RetentionContest
 ================
 

--- a/docs/xml/elements/source.rst
+++ b/docs/xml/elements/source.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 Source
 ======
 
@@ -10,7 +12,7 @@ the only required object in the feed file, and only one source object is allowed
 
 .. code-block:: xml
    :linenos:
-   
+
    <Source id="src1">
       <DateTime>2013-10-24T14:25:28</DateTime>
       <Description>

--- a/docs/xml/elements/source.rst
+++ b/docs/xml/elements/source.rst
@@ -6,7 +6,41 @@ Source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-.. include:: ../../tables/elements/source.rst
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag             | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++=================+=============================+==============+==============+==========================================+==========================================+
+| Name            | xs:string                   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                 |                             |              |              | that is providing the information.       | implementation is required to ignore the |
+|                 |                             |              |              |                                          | ``Source`` element containing it.        |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VipId           | xs:string                   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                 |                             |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                 |                             |              |              |                                          | ``Source`` element containing it.        |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateTime        | xs:dateTime                 | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                 |                             |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                 |                             |              |              | to be in the timezone local to the       |                                          |
+|                 |                             |              |              | organization.                            |                                          |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description     | :doc:`InternationalizedText | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                 | <internationalized_text>`   |              |              | organization providing the data and what | present, then the implementation is      |
+|                 |                             |              |              | data is in the feed.                     | required to ignore it.                   |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrganizationUri | xs:string                   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                 |                             |              |              | organization publishing the data.        | then the implementation is required to   |
+|                 |                             |              |              |                                          | ignore it.                               |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FeedContactId   | xs:IDREF                    | Optional     | Single       | Reference to the :doc:`person <person>`  | If the field is invalid or not present,  |
+|                 |                             |              |              | who will respond to inquiries about the  | then the implementation is required to   |
+|                 |                             |              |              | information contained within the file.   | ignore it.                               |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| TouUri          | xs:anyURI                   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                 |                             |              |              | Use for the information in this file can | then the implementation is required to   |
+|                 |                             |              |              | be found.                                | ignore it.                               |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Version         | xs:string                   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                 |                             |              |              |                                          | implementation is required to ignore it. |
++-----------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
 

--- a/docs/xml/elements/state.rst
+++ b/docs/xml/elements/state.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 State
 =====
 

--- a/docs/xml/elements/state.rst
+++ b/docs/xml/elements/state.rst
@@ -15,9 +15,9 @@ recommended to be the state's FIPS code, along with the prefix "st".
       <ElectionAdministrationId>ea40133</ElectionAdministrationId>
       <ExternalIdentifiers>
         <ExternalIdentifier>
-	  <Type>ocd-id</Type>
-	  <Value>ocd-division/country:us/state:va</Value>
-	</ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va</Value>
+        </ExternalIdentifier>
       </ExternalIdentifiers>
       <Name>Virginia</Name>
    </State>

--- a/docs/xml/elements/state.rst
+++ b/docs/xml/elements/state.rst
@@ -6,7 +6,29 @@ State
 The State object includes state-wide election information. The ID attribute is
 recommended to be the state's FIPS code, along with the prefix "st".
 
-.. include:: ../../tables/elements/state.rst
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| ElectionAdministrationId | xs:IDREF                              | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
+|                          |                                       |              |              | administration object.                   | then the implementation is required to   |
+|                          |                                       |              |              |                                          | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :doc:`ExternalIdentifiers             | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
+|                          | </xml/elements/external_identifiers>` |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                          |                                       |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | xs:string                             | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
+|                          |                                       |              |              | Alabama.                                 | implementation is required to ignore it. |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationId        | xs:IDREF                              | Optional     | Repeats      | Specifies a link to the state's          | If the field is invalid or not present,  |
+|                          |                                       |              |              | :doc:`polling locations                  | then the implementation is required to   |
+|                          |                                       |              |              | <polling_location>`. If early vote       | ignore it.                               |
+|                          |                                       |              |              | centers or ballot drop locations are     |                                          |
+|                          |                                       |              |              | state-wide (e.g., anyone in the state    |                                          |
+|                          |                                       |              |              | can use them), they can be specified     |                                          |
+|                          |                                       |              |              | here, but you are encouraged to only use |                                          |
+|                          |                                       |              |              | the :doc:`Precinct <precinct>` element.  |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 

--- a/docs/xml/elements/street_segment.rst
+++ b/docs/xml/elements/street_segment.rst
@@ -8,7 +8,88 @@ geography (i.e., segment) is contained within. The start address house number mu
 end address house number unless the segment consists of only one address, in which case these values
 are equal.
 
-.. include:: ../../tables/elements/street_segment.rst
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+=============================+==============+==============+==========================================+==========================================+
+| AddressDirection     | xs:string                   | Optional     | Single       | Specifies the (inter-)cardinal direction | If the field is invalid or not present,  |
+|                      |                             |              |              | of the entire address. An example is     | then the implementation is required to   |
+|                      |                             |              |              | "NE" for the address "100 E Capitol St   | ignore it.                               |
+|                      |                             |              |              | NE."                                     |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City                 | xs:string                   | **Required** | Single       | The city specifies the city or town of   | If the field is invalid, then the        |
+|                      |                             |              |              | the address.                             | implementation is required to ignore it. |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IncludesAllAddresses | xs:boolean                  | Optional     | Single       | Specifies if the segment covers every    | If the field is invalid or not present,  |
+|                      |                             |              |              | address on this street. If this is       | then the implementation is required to   |
+|                      |                             |              |              | *true*, then the values of               | ignore it.                               |
+|                      |                             |              |              | **StartHouseNumber** and                 |                                          |
+|                      |                             |              |              | **EndHouseNumber** should be ignored.    |                                          |
+|                      |                             |              |              | The value of **OddEvenBoth** must be     |                                          |
+|                      |                             |              |              | *both*.                                  |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OddEvenBoth          | :doc:`OebEnum               | **Required** | Single       | Specifies whether the odd side of the    | If the field is not present or invalid,  |
+|                      | <../enumerations/oeb_enum>` |              |              | street (in terms of house numbers), the  | the implementation is required to ignore |
+|                      |                             |              |              | even side, or both are in included in    | the StreetSegment containing it.         |
+|                      |                             |              |              | the street segment.                      |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrecinctId           | xs:IDREF                    | Optional     | Single       | References the :doc:`precinct            | If the field is not present or invalid,  |
+|                      |                             |              |              | <precinct>` that contains the entire     | the implementation is required to ignore |
+|                      |                             |              |              | street segment.                          | the StreetSegment element containing it. |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartHouseNumber     | xs:integer                  | Optional     | Single       | The house number at which the street     | Unless **IncludesAllAddresses** is true, |
+|                      |                             |              |              | segment starts. This value is necessary  | if the field is not present or invalid,  |
+|                      |                             |              |              | for the street segment to make any       | the implementation is required to ignore |
+|                      |                             |              |              | sense. Unless **IncludesAllAddresses**   | the StreetSegment element containing it. |
+|                      |                             |              |              | is true, this value must be less than or | If the **StartHouseNumber** is greater   |
+|                      |                             |              |              | equal to **EndHouseNumber**. If          | than the **EndHouseNumber**, the         |
+|                      |                             |              |              | **IncludesAllAddresses** is true, this   | implementation should ignore the element |
+|                      |                             |              |              | value is ignored.                        | containing them.                         |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndHouseNumber       | xs:integer                  | Optional     | Single       | The house number at which the street     | Unless **IncludesAllAddresses** is true, |
+|                      |                             |              |              | segment ends. This value is necessary    | if the field is not present or invalid,  |
+|                      |                             |              |              | for the street segment to make any       | the implementation is required to ignore |
+|                      |                             |              |              | sense. Unless **IncludesAllAddresses**   | the StreetSegment element containing it. |
+|                      |                             |              |              | is true, it must be greater than or      | If the **EndHouseNumber** is less than   |
+|                      |                             |              |              | equal to **StartHouseNumber**. If        | the **StartHouseNumber**, the            |
+|                      |                             |              |              | **IncludesAllAddresses** is true, this   | implementation should ignore the element |
+|                      |                             |              |              | value is ignored.                        | containing it.                           |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State                | xs:string                   | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
+|                      |                             |              |              | abbreviation of the address.             | implementation is required to ignore it. |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StreetDirection      | xs:string                   | Optional     | Single       | Specifies the (inter-)cardinal direction | If the field is invalid or not present,  |
+|                      |                             |              |              | of the street address (e.g., the "E" in  | then the implementation is required to   |
+|                      |                             |              |              | "100 E Capitol St NE").                  | ignore it.                               |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StreetName           | xs:string                   | **Required** | Single       | Represents the name of the street for    | If the field is invalid, then the        |
+|                      |                             |              |              | the address. A special wildcard, "*",    | implementation is required to ignore it. |
+|                      |                             |              |              | denotes every street in the given        |                                          |
+|                      |                             |              |              | city/town. It optionally may contain     |                                          |
+|                      |                             |              |              | street direction, street suffix or       |                                          |
+|                      |                             |              |              | address direction (e.g., both "Capitol"  |                                          |
+|                      |                             |              |              | and "E Capitol St NE" are acceptable for |                                          |
+|                      |                             |              |              | the address "100 E Capitol St NE"),      |                                          |
+|                      |                             |              |              | however this is not preferred. Preferred |                                          |
+|                      |                             |              |              | is street name alone (e.g. "Capitol").   |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StreetSuffix         | xs:string                   | Optional     | Single       | Represents the abbreviated,              | If the field is invalid or not present,  |
+|                      |                             |              |              | non-directional suffix to the street     | then the implementation is required to   |
+|                      |                             |              |              | name. An example is "St" for the address | ignore it.                               |
+|                      |                             |              |              | "100 E Capitol St NE."                   |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| UnitNumber           | xs:string                   | Optional     | Repeats      | The apartment/unit number for a street   | If the field is invalid or not present,  |
+|                      |                             |              |              | segment. If this value is present then   | then the implementation is required to   |
+|                      |                             |              |              | **StartHouseNumber** must be equal to    | ignore it.                               |
+|                      |                             |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                             |              |              | used if **IncludesAllAddresses** is      |                                          |
+|                      |                             |              |              | true.                                    |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip                  | xs:string                   | **Required** | Single       | Specifies the zip code of the address.   | If the field is invalid, then the        |
+|                      |                             |              |              | It may be 5 or 9 digits, and it may      | implementation is required to ignore it. |
+|                      |                             |              |              | include a hyphen ('-'). It is required   |                                          |
+|                      |                             |              |              | as it helps with geocoding, which is     |                                          |
+|                      |                             |              |              | crucial for distributors.                |                                          |
++----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:

--- a/docs/xml/elements/street_segment.rst
+++ b/docs/xml/elements/street_segment.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 StreetSegment
 =============
 

--- a/docs/xml/enumerations/ballot_measure_type.rst
+++ b/docs/xml/enumerations/ballot_measure_type.rst
@@ -11,6 +11,23 @@ guidelines. Ultimately it is up to the state or local election official to
 choose the value which best describes the ballot measure(s) in their
 jurisdiction.
 
-.. include:: ../../tables/enumerations/ballot_measure_type.rst
++----------------+----------------------------------------------------+
+| Tag            | Description                                        |
++================+====================================================+
+| ballot-measure | A catch-all for generic types of                   |
+|                | non-candidate-based contests.                      |
++----------------+----------------------------------------------------+
+| initiative     | These are usually citizen-driven measures to be    |
+|                | placed on the ballot. These could include both     |
+|                | statutory changes and constitutional amendments.   |
++----------------+----------------------------------------------------+
+| referendum     | These could include measures to repeal existing    |
+|                | acts of legislation, legislative referrals, and    |
+|                | legislatively-referred state constitutional        |
+|                | amendments.                                        |
++----------------+----------------------------------------------------+
+| other          | Anything that does not fall into the above         |
+|                | categories.                                        |
++----------------+----------------------------------------------------+
 
 .. _Wikipedia: http://en.wikipedia.org/wiki/Initiatives_and_referendums_in_the_United_States

--- a/docs/xml/enumerations/ballot_measure_type.rst
+++ b/docs/xml/enumerations/ballot_measure_type.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 BallotMeasureType
 =================
 
@@ -9,9 +11,6 @@ guidelines. Ultimately it is up to the state or local election official to
 choose the value which best describes the ballot measure(s) in their
 jurisdiction.
 
-
 .. include:: ../../tables/enumerations/ballot_measure_type.rst
 
-
 .. _Wikipedia: http://en.wikipedia.org/wiki/Initiatives_and_referendums_in_the_United_States
-

--- a/docs/xml/enumerations/candidate_post_election_status.rst
+++ b/docs/xml/enumerations/candidate_post_election_status.rst
@@ -1,5 +1,6 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 CandidatePostElectionStatus
 ===========================
 
 .. include:: ../../tables/enumerations/candidate_post_election_status.rst
-

--- a/docs/xml/enumerations/candidate_post_election_status.rst
+++ b/docs/xml/enumerations/candidate_post_election_status.rst
@@ -3,4 +3,16 @@
 CandidatePostElectionStatus
 ===========================
 
-.. include:: ../../tables/enumerations/candidate_post_election_status.rst
++--------------------+----------------------------------------------------+
+| Tag                | Description                                        |
++====================+====================================================+
+| advanced-to-runoff | For contests in which the top *N* candidates       |
+|                    | advance to the next round.                         |
++--------------------+----------------------------------------------------+
+| projected-winner   | A candidate is expected to win, but official       |
+|                    | results are not yet complete.                      |
++--------------------+----------------------------------------------------+
+| winner             | The candidate has officially won.                  |
++--------------------+----------------------------------------------------+
+| withdrawn          | The candidate has withdrawn from the contest.      |
++--------------------+----------------------------------------------------+

--- a/docs/xml/enumerations/candidate_pre_election_status.rst
+++ b/docs/xml/enumerations/candidate_pre_election_status.rst
@@ -3,4 +3,16 @@
 CandidatePreElectionStatus
 ==========================
 
-.. include:: ../../tables/enumerations/candidate_pre_election_status.rst
++--------------+----------------------------------------------------+
+| Tag          | Description                                        |
++==============+====================================================+
+| filed        | The candidate has filed for office but not yet     |
+|              | been qualified.                                    |
++--------------+----------------------------------------------------+
+| qualified    | The candidate has qualified for the contest.       |
++--------------+----------------------------------------------------+
+| withdrawn    | The candidate has withdrawn from the contest (but  |
+|              | may still be on the ballot).                       |
++--------------+----------------------------------------------------+
+| write-in     |                                                    |
++--------------+----------------------------------------------------+

--- a/docs/xml/enumerations/candidate_pre_election_status.rst
+++ b/docs/xml/enumerations/candidate_pre_election_status.rst
@@ -1,6 +1,6 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 CandidatePreElectionStatus
 ==========================
 
-   
 .. include:: ../../tables/enumerations/candidate_pre_election_status.rst
-

--- a/docs/xml/enumerations/district_type.rst
+++ b/docs/xml/enumerations/district_type.rst
@@ -9,7 +9,56 @@ district or jurisdiction in your state or county. For example, "town" and
 "township" may mean different things -- or not be defined at all -- in your
 state, so please use the definition which best matches your local meaning.
 
-.. include:: ../../tables/enumerations/district_type.rst
++----------------+----------------------------------------------------+
+| Tag            | Description                                        |
++================+====================================================+
+| city           | A city.                                            |
++----------------+----------------------------------------------------+
+| city-council   | A specific seat/jurisdiction for a city, town, or  |
+|                | village council.                                   |
++----------------+----------------------------------------------------+
+| congressional  | A United States congressional district.            |
++----------------+----------------------------------------------------+
+| county         | A county.                                          |
++----------------+----------------------------------------------------+
+| county-council | A county council district, either in its entirety  |
+|                | or for a specific seat.                            |
++----------------+----------------------------------------------------+
+| judicial       | A judicial district.                               |
++----------------+----------------------------------------------------+
+| municipality   | A civil division which is not a town, city,        |
+|                | village, or county.                                |
++----------------+----------------------------------------------------+
+| national       | The United States.                                 |
++----------------+----------------------------------------------------+
+| school         | A school district.                                 |
++----------------+----------------------------------------------------+
+| special        | A `special-purpose district`_ that exist separate  |
+|                | from general-purpose districts.                    |
++----------------+----------------------------------------------------+
+| state          | A state, district, commonwealth, or U.S.           |
+|                | territory.                                         |
++----------------+----------------------------------------------------+
+| state-house    | The lower house of a state legislature.            |
++----------------+----------------------------------------------------+
+| state-senate   | The upper house of a state legislature.            |
++----------------+----------------------------------------------------+
+| town           | A town_.                                           |
++----------------+----------------------------------------------------+
+| township       | A township, which may be different than a town.    |
+|                | See the `Wikipedia article`_.                      |
++----------------+----------------------------------------------------+
+| utility        | A non-water public or municipal utility district.  |
++----------------+----------------------------------------------------+
+| village        | A village district.                                |
++----------------+----------------------------------------------------+
+| ward           | A ward.                                            |
++----------------+----------------------------------------------------+
+| water          | A water district.                                  |
++----------------+----------------------------------------------------+
+| other          | Any district not described above. Use the          |
+|                | *OtherType* field to describe it.                  |
++----------------+----------------------------------------------------+
 
 .. _`special-purpose district`: http://en.wikipedia.org/wiki/Special-purpose_district
 .. _town: http://en.wikipedia.org/wiki/Town#United_States

--- a/docs/xml/enumerations/district_type.rst
+++ b/docs/xml/enumerations/district_type.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 DistrictType
 ============
 
@@ -6,7 +8,7 @@ Please use the enumeration value which most accurately reflects the type of
 district or jurisdiction in your state or county. For example, "town" and
 "township" may mean different things -- or not be defined at all -- in your
 state, so please use the definition which best matches your local meaning.
- 
+
 .. include:: ../../tables/enumerations/district_type.rst
 
 .. _`special-purpose district`: http://en.wikipedia.org/wiki/Special-purpose_district

--- a/docs/xml/enumerations/identifier_type.rst
+++ b/docs/xml/enumerations/identifier_type.rst
@@ -3,7 +3,26 @@
 IdentifierType
 ==============
 
-.. include:: ../../tables/enumerations/identifier_type.rst
++----------------+----------------------------------------------------+
+| Tag            | Description                                        |
++================+====================================================+
+| fips           | Federal Information Processing Standards codes for |
+|                | states_, counties_, and cities_.                   |
++----------------+----------------------------------------------------+
+| local-level    | An identifier generated or used by local           |
+|                | governments or organizations.                      |
++----------------+----------------------------------------------------+
+| national-level | An identifier generated or used by national        |
+|                | organizations.                                     |
++----------------+----------------------------------------------------+
+| ocd-id         | An `Open Civic Data Division Identifier`_.         |
++----------------+----------------------------------------------------+
+| state-level    | An identifier generated or used by state           |
+|                | governments or organizations.                      |
++----------------+----------------------------------------------------+
+| other          | Any identifier which doesn't fall into any of the  |
+|                | above categories.                                  |
++----------------+----------------------------------------------------+
 
 .. _states: http://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code
 .. _counties: http://en.wikipedia.org/wiki/FIPS_county_code

--- a/docs/xml/enumerations/identifier_type.rst
+++ b/docs/xml/enumerations/identifier_type.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 IdentifierType
 ==============
 

--- a/docs/xml/enumerations/oeb_enum.rst
+++ b/docs/xml/enumerations/oeb_enum.rst
@@ -3,4 +3,12 @@
 OebEnum
 =======
 
-.. include:: ../../tables/enumerations/oeb_enum.rst
++--------------+----------------------------------------------------+
+| Tag          | Description                                        |
++==============+====================================================+
+| both         | Both even and odd addresses within the range.      |
++--------------+----------------------------------------------------+
+| even         | Only even-numbered addresses within the range.     |
++--------------+----------------------------------------------------+
+| odd          | Only odd-numbered addresses within the range.      |
++--------------+----------------------------------------------------+

--- a/docs/xml/enumerations/oeb_enum.rst
+++ b/docs/xml/enumerations/oeb_enum.rst
@@ -1,6 +1,6 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 OebEnum
 =======
 
-   
 .. include:: ../../tables/enumerations/oeb_enum.rst
-

--- a/docs/xml/enumerations/office_term_type.rst
+++ b/docs/xml/enumerations/office_term_type.rst
@@ -3,4 +3,12 @@
 OfficeTermType
 ==============
 
-.. include:: ../../tables/enumerations/office_term_type.rst
++----------------+----------------------------------------------------+
+| Tag            | Description                                        |
++================+====================================================+
+| full-term      | This election is for an office for which the       |
+|                | existing term has been completed.                  |
++----------------+----------------------------------------------------+
+| unexpired-term | This election is for an office for which the       |
+|                | original term is not yet complete.                 |
++----------------+----------------------------------------------------+

--- a/docs/xml/enumerations/office_term_type.rst
+++ b/docs/xml/enumerations/office_term_type.rst
@@ -1,6 +1,6 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 OfficeTermType
 ==============
 
-   
 .. include:: ../../tables/enumerations/office_term_type.rst
-

--- a/docs/xml/enumerations/vote_variation.rst
+++ b/docs/xml/enumerations/vote_variation.rst
@@ -11,7 +11,52 @@ ranked choice voting), we constrain "majority" to 1-of-m.  We do this to
 eliminate any source of ambiguity when a single enumeration value needs
 to be assigned to a contest.
 
-.. include:: ../../tables/enumerations/vote_variation.rst
++----------------+----------------------------------------------------+
+| Tag            | Description                                        |
++================+====================================================+
+| 1-of-m         | A method where each voter can select up to one     |
+|                | option.                                            |
++----------------+----------------------------------------------------+
+| approval       | `Approval voting`_, where each voter can select as |
+|                | many options as desired.                           |
++----------------+----------------------------------------------------+
+| borda          | `Borda count`_, where each voter can rank the      |
+|                | options, and the rankings are assigned point       |
+|                | values.                                            |
++----------------+----------------------------------------------------+
+| cumulative     | `Cumulative voting`_, where each voter can         |
+|                | distribute their vote to up to *N* options.        |
++----------------+----------------------------------------------------+
+| majority       | A 1-of-m method where the winner needs more than   |
+|                | 50% of the vote to be elected.                     |
++----------------+----------------------------------------------------+
+| n-of-m         | A method where each voter can select up to *N*     |
+|                | options.                                           |
++----------------+----------------------------------------------------+
+| plurality      | A 1-of-m method where the option with the most     |
+|                | votes is elected, regardless of whether the option |
+|                | has more than 50% of the vote.                     |
++----------------+----------------------------------------------------+
+| proportional   | A `proportional representation`_ method (other     |
+|                | than STV), which is any system that elects winners |
+|                | in proportion to the total vote.                   |
++----------------+----------------------------------------------------+
+| range          | `Range voting`_, where each voter can select a     |
+|                | score for each option.                             |
++----------------+----------------------------------------------------+
+| rcv            | `Ranked choice voting`_ (RCV), where each voter    |
+|                | can rank the options, and the ballots are counted  |
+|                | in rounds.  Also known as instant-runoff voting    |
+|                | (IRV) and the single transferable vote (STV).      |
++----------------+----------------------------------------------------+
+| super-majority | A 1-of-m method where the winner needs more than   |
+|                | some predetermined fraction of the vote to be      |
+|                | elected, where the fraction is more than 50% (e.g. |
+|                | three-fifths or two-thirds).                       |
++----------------+----------------------------------------------------+
+| other          | Used when the vote variation type is not included  |
+|                | in this enumeration.                               |
++----------------+----------------------------------------------------+
 
 .. _`Approval voting`: http://en.wikipedia.org/wiki/Approval_voting
 .. _`Borda count`: http://en.wikipedia.org/wiki/Borda_count

--- a/docs/xml/enumerations/vote_variation.rst
+++ b/docs/xml/enumerations/vote_variation.rst
@@ -1,3 +1,5 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 VoteVariation
 =============
 
@@ -8,7 +10,6 @@ even though there are majority voting methods that are not "1-of-m" (e.g.
 ranked choice voting), we constrain "majority" to 1-of-m.  We do this to
 eliminate any source of ambiguity when a single enumeration value needs
 to be assigned to a contest.
-
 
 .. include:: ../../tables/enumerations/vote_variation.rst
 

--- a/docs/xml/enumerations/voter_service_type.rst
+++ b/docs/xml/enumerations/voter_service_type.rst
@@ -1,6 +1,6 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
 VoterServiceType
 ================
 
-    
 .. include:: ../../tables/enumerations/voter_service_type.rst
-

--- a/docs/xml/enumerations/voter_service_type.rst
+++ b/docs/xml/enumerations/voter_service_type.rst
@@ -3,4 +3,20 @@
 VoterServiceType
 ================
 
-.. include:: ../../tables/enumerations/voter_service_type.rst
++--------------------+----------------------------------------------------+
+| Tag                | Description                                        |
++====================+====================================================+
+| absentee-ballots   | This department handles the dispatch, tracking,    |
+|                    | and return of absentee ballots.                    |
++--------------------+----------------------------------------------------+
+| overseas-voting    | The department for overseas, military, and other   |
+|                    | outside-the-U.S. voters.                           |
++--------------------+----------------------------------------------------+
+| polling-places     | This deparment handles the selection and           |
+|                    | management of polling places.                      |
++--------------------+----------------------------------------------------+
+| voter-registration | The deparment that manages voter registration.     |
++--------------------+----------------------------------------------------+
+| other              | Any other service not covered by the above         |
+|                    | descriptions.                                      |
++--------------------+----------------------------------------------------+

--- a/docs/yaml/elements/ballot_measure_contest.yaml
+++ b/docs/yaml/elements/ballot_measure_contest.yaml
@@ -1,4 +1,36 @@
-name: BallotMeasureContest
+_name: BallotMeasureContest
+description: |-
+  The BallotMeasureContest provides information about a ballot measure before the voters, including
+  summary statements on each side. Extends :doc:`ContestBase <contest_base>`.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <BallotMeasureContest id="bmc30001">
+        <BallotSelectionId>bms30001a</BallotSelectionId>
+        <BallotSelectionId>bms30001b</BallotSelectionId>
+        <BallotTitle>
+           <Text language="en">State of the State</Text>
+           <Text language="es">Estado del Estado.</Text>
+        </BallotTitle>
+        <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+        <Name>Referendum on Virginia</Name>
+        <ConStatement label="bmc30001con">
+           <Text language="en">This is no good.</Text>
+           <Text language="es">Esto no es bueno.</Text>
+        </ConStatement>
+        <EffectOfAbstain label="bmc30001abs">
+           <Text language="en">Nothing will happen.</Text>
+           <Text language="es">Nada pasará.</Text>
+        </EffectOfAbstain>
+        <ProStatement label="bmc30001pro">
+           <Text language="en">Everything will be great.</Text>
+           <Text language="es">Todo va a estar bien.</Text>
+        </ProStatement>
+        <Type>referendum</Type>
+     </BallotMeasureContest>
+
+  .. _competing initiatives: http://ballotpedia.org/Laws_governing_the_initiative_process_in_California#Competing_initiatives
 tags:
 - _name: ConStatement
   description: Specifies a statement in opposition to the referendum. It does not

--- a/docs/yaml/elements/ballot_measure_selection.yaml
+++ b/docs/yaml/elements/ballot_measure_selection.yaml
@@ -1,4 +1,24 @@
-name: BallotMeasureSelection
+_name: BallotMeasureSelection
+description: |-
+  Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for a
+  :doc:`BallotMeasureContest <ballot_measure_contest>` that would appear on the ballot.
+  BallotMeasureSelection extends :doc:`BallotSelectionBase <ballot_selection_base>`.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <BallotMeasureSelection id="bms30001a">
+        <Selection label="bms30001at">
+           <Text language="en">Yes</Text>
+           <Text language="es">Sí</Text>
+        </Selection>
+     </BallotMeasureSelection>
+     <BallotMeasureSelection id="bms30001b">
+        <Selection label="bms30001bt">
+           <Text language="en">No</Text>
+           <Text language="es">No</Text>
+        </Selection>
+     </BallotMeasureSelection>
 tags:
 - _name: Selection
   description: Selection text for a :doc:`BallotMeasureContest <ballot_measure_contest>`

--- a/docs/yaml/elements/ballot_selection_base.yaml
+++ b/docs/yaml/elements/ballot_selection_base.yaml
@@ -1,0 +1,6 @@
+_name: BallotSelectionBase
+description: |-
+  A base model for all ballot selection types:
+  :doc:`BallotMeasureSelection <ballot_measure_selection>`,
+  :doc:`CandidateSelection <candidate_selection>`, and :doc:`PartySelection <party_selection>`.
+  Besides an id attribute, it has no additional fields.

--- a/docs/yaml/elements/ballot_style.yaml
+++ b/docs/yaml/elements/ballot_style.yaml
@@ -18,7 +18,7 @@ tags:
   error_then: =must-ignore
   type: xs:anyURI
 - _name: OrderedContestId
-  description: Reference to an :doc:`OrderedContest <ordered_contest>`
+  description: Reference to an :doc:`OrderedContest </xml/elements/ordered_contest>`
   error_then: =must-ignore
   repeating: true
   type: xs:IDREF

--- a/docs/yaml/elements/ballot_style.yaml
+++ b/docs/yaml/elements/ballot_style.yaml
@@ -1,4 +1,17 @@
-name: BallotStyle
+_name: BallotStyle
+description: A container for the contests/measures on the ballot.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <BallotStyle id="bs00000">
+        <OrderedContestId>oc20003</OrderedContestId>
+        <OrderedContestId>oc20004</OrderedContestId>
+        <OrderedContestId>oc20005</OrderedContestId>
+        <OrderedContestId>oc20025</OrderedContestId>
+        <OrderedContestId>oc20355</OrderedContestId>
+        <OrderedContestId>oc20449</OrderedContestId>
+     </BallotStyle>
 tags:
 - _name: ImageUri
   description: Specifies a URI that returns an image of the sample ballot.

--- a/docs/yaml/elements/candidate.yaml
+++ b/docs/yaml/elements/candidate.yaml
@@ -1,4 +1,18 @@
-name: Candidate
+_name: Candidate
+description: |-
+  The Candidate object represents a candidate in a contest. If a candidate is running in multiple contests, the same
+  Candidate object may be used.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <Candidate id="can10961">
+        <BallotName>
+          <Text language="en">Ken T. Cuccinelli II</Text>
+        </BallotName>
+        <PartyId>par0001</PartyId>
+        <PersonId>per10961</PersonId>
+     </Candidate>
 tags:
 - _name: BallotName
   description: The candidate's name as it will be displayed on the official ballot

--- a/docs/yaml/elements/candidate_contest.yaml
+++ b/docs/yaml/elements/candidate_contest.yaml
@@ -1,4 +1,24 @@
-name: CandidateContest
+_name: CandidateContest
+description: |-
+  CandidateContest extends :doc:`ContestBase <contest_base>` and represents a contest among
+  candidates.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <CandidateContest id="cc20003">
+        <BallotSelectionId>cs10961</BallotSelectionId>
+        <BallotSelectionId>cs10962</BallotSelectionId>
+        <BallotSelectionId>cs10963</BallotSelectionId>
+        <BallotTitle>
+          <Text language="en">Governor of Virginia</Text>
+        </BallotTitle>
+        <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+        <Name>Governor</Name>
+        <NumberElected>1</NumberElected>
+        <OfficeId>off0000</OfficeId>
+        <VotesAllowed>1</VotesAllowed>
+     </CandidateContest>
 tags:
 - _name: NumberElected
   description: Number of candidates that are elected in the contest (i.e. "N" of N-of-M).

--- a/docs/yaml/elements/candidate_selection.yaml
+++ b/docs/yaml/elements/candidate_selection.yaml
@@ -1,4 +1,16 @@
-name: CandidateSelection
+_name: CandidateSelection
+description: |-
+  CandidateSelection extends :doc:`BallotSelectionBase <ballot_selection_base>` and represents a
+  ballot selection for a candidate contest.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <CandidateSelection id="cs10861">
+        <CandidateId>can10861a</CandidateId>
+        <CandidateId>can10861b</CandidateId>
+        <EndorsementPartyId>par0001</EndorsementPartyId>
+     </CandidateSelection>
 tags:
 - _name: CandidateId
   description: References a :doc:`Candidate <candidate>` element. The number of candidates

--- a/docs/yaml/elements/contact_information.yaml
+++ b/docs/yaml/elements/contact_information.yaml
@@ -1,4 +1,57 @@
-name: ContactInformation
+_name: ContactInformation
+description: |-
+  For defining contact information about objects such as persons, boards of authorities,
+  organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+  :doc:`ElectionAdministration <election_administration>`, :doc:`Office <office>`,
+  :doc:`Person <person>`, :doc:`Source <source>`). ContactInformation has an optional attribute
+  ``label``, which allows the feed to refer back to the original label for the information
+  (e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+post: |-
+  .. _See usage note.:
+
+  ``Name`` and ``AddressLine`` Usage Note
+  ---------------------------------------
+
+  The ``Name`` and ``AddressLine`` fields should be chosen so that a display
+  or mailing address can be constructed programmatically by joining the
+  ``Name`` and ``AddressLine`` fields together.  For example, for the
+  following address::
+
+      Department of Elections
+      1 Dr. Carlton B. Goodlett Place, Room 48
+      San Francisco, CA 94102
+
+  The name could be "Department of Elections" and the first address line
+  could be "1 Dr. Carlton B. Goodlett Place, Room 48."
+
+  However, VIP does not yet support the representation of mailing addresses
+  whose "name" portion spans more than one line, for example::
+
+      California Secretary of State
+      Elections Division
+      1500 11th Street
+      Sacramento, CA 95814
+
+  For addresses like the above, we recommend choosing a name like, "California
+  Secretary of State, Elections Division" with "1500 11th Street" as the
+  first address line. This would result in a programmatically constructed
+  address like the following::
+
+      California Secretary of State, Elections Division
+      1500 11th Street
+      Sacramento, CA 95814
+
+  .. code-block:: xml
+     :linenos:
+
+     <ContactInformation label="ci10861a">
+        <AddressLine>1600 Pennsylvania Ave</AddressLine>
+        <AddressLine>Washington, DC 20006</AddressLine>
+        <Email>president@whitehouse.gov</Email>
+        <Phone>202-456-1111</Phone>
+        <Phone annotation="TDD">202-456-6213</Phone>
+        <Uri>http://www.whitehouse.gov</Uri>
+     </ContactInformation>
 tags:
 - _name: AddressLine
   description: The "location" portion of a mailing address. `See usage note.`_

--- a/docs/yaml/elements/contest_base.yaml
+++ b/docs/yaml/elements/contest_base.yaml
@@ -11,7 +11,7 @@ tags:
   type: xs:string
 - _name: BallotSelectionId
   description: References a particular BallotSelection, which could be of any selection
-    type that extends :doc:`BallotSelectionBase <ballot_selection_base>`.
+    type that extends :doc:`BallotSelectionBase </xml/elements/ballot_selection_base>`.
   error_then: =should-ignore
   repeating: true
   type: xs:IDREF

--- a/docs/yaml/elements/contest_base.yaml
+++ b/docs/yaml/elements/contest_base.yaml
@@ -1,4 +1,9 @@
-name: ContestBase
+_name: ContestBase
+description: |-
+  A base model for all Contest types: :doc:`BallotMeasureContest <ballot_measure_contest>`,
+  :doc:`CandidateContest <candidate_contest>`, :doc:`PartyContest <party_contest>`,
+  and :doc:`RetentionContest <retention_contest>` (NB: the latter because it extends
+  :doc:`BallotMeasureContest <ballot_measure_contest>`).
 tags:
 - _name: Abbreviation
   description: An abbreviation for the contest.

--- a/docs/yaml/elements/department.yaml
+++ b/docs/yaml/elements/department.yaml
@@ -1,4 +1,5 @@
-name: Department
+_name: Department
+post: '.. _ea-dep-voter-service:'
 tags:
 - _name: ContactInformation
   description: Contact and physical address information for the election administration

--- a/docs/yaml/elements/election.yaml
+++ b/docs/yaml/elements/election.yaml
@@ -1,4 +1,32 @@
-name: Election
+_name: Election
+description: |-
+  The Election object represents an Election Day, which usually consists of many individual contests
+  and/or referenda. A feed must contain **exactly one** Election object. All relationships in the
+  feed (e.g., street segment to precinct to polling location) are assumed to relate only to
+  the Election specified by this object. It is permissible, and recommended, to combine unrelated
+  contests (e.g., a special election and a general election) that occur on the same day into one feed
+  with one Election object.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <Election id="ele30000">
+       <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
+       <Date>2013-11-05</Date>
+       <ElectionType>
+         <Text language="en">General</Text>
+         <Text language="es">Generales</Text>
+       </ElectionType>
+       <HasElectionDayRegistration>false</HasElectionDayRegistration>
+       <HoursOpenId>hours0001</HoursOpenId>
+       <IsStatewide>true</IsStatewide>
+       <Name>
+         <Text language="en">2013 Statewide General</Text>
+       </Name>
+       <RegistrationDeadline>2013-10-15</RegistrationDeadline>
+       <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
+       <StateId>st51</StateId>
+     </Election>
 tags:
 - _name: Date
   description: Specifies when the election is being held. The `Date` is considered

--- a/docs/yaml/elements/election_administration.yaml
+++ b/docs/yaml/elements/election_administration.yaml
@@ -1,4 +1,11 @@
-name: ElectionAdministration
+_name: ElectionAdministration
+_sub_types:
+- Department
+- VoterService
+description: |-
+  The Election Administration represents an institution for serving a locality's (or state's) election
+  functions.
+post: '.. _ea-dep:'
 tags:
 - _name: AbsenteeUri
   description: Specifies the web address for information on absentee voting.

--- a/docs/yaml/elements/electoral_district.yaml
+++ b/docs/yaml/elements/electoral_district.yaml
@@ -1,4 +1,29 @@
-name: ElectoralDistrict
+_name: ElectoralDistrict
+description: |-
+  The ``ElectoralDistrict`` object represents the geographic area in which contests are held. Examples
+  of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congressional District",
+  or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
+  which precincts link to the ``ElectoralDistrict``.
+post: |-
+  .. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+  .. code-block:: xml
+     :linenos:
+
+     <ElectoralDistrict id="ed60129">
+        <ExternalIdentifiers>
+          <ExternalIdentifier>
+            <Type>ocd-id</Type>
+            <Value>ocd-division/country:us/state:va</Value>
+          </ExternalIdentifier>
+          <ExternalIdentifier>
+            <Type>fips</Type>
+            <Value>51</Value>
+          </ExternalIdentifier>
+        </ExternalIdentifiers>
+        <Name>Commonwealth of Virginia</Name>
+        <Type>state</Type>
+     </ElectoralDistrict>
 tags:
 - _name: ExternalIdentifiers
   description: Other identifiers that link to external datasets (e.g. `OCD-IDs`_)

--- a/docs/yaml/elements/external_identifier.yaml
+++ b/docs/yaml/elements/external_identifier.yaml
@@ -1,4 +1,28 @@
-name: ExternalIdentifier
+_name: ExternalIdentifier
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <ExternalIdentifiers>
+        <ExternalIdentifier>
+           <Type>ocd-id</Type>
+           <Value>ocd-division/country:us/state:nc/county:durham</Value>
+        </ExternalIdentifier>
+        <ExternalIdentifier>
+           <Type>FIPS</Type>
+           <Value>37063</Value>
+        </ExternalIdentifier>
+        <ExternalIdentifier>
+           <Type>OTHER</Type>
+           <OtherType>GNIS</OtherType>
+           <Value>1008550</Value>
+        </ExternalIdentifier>
+        <external_identifer>
+           <Type>OTHER</Type>
+           <OtherType>census</OtherType>
+           <Value>99063</Value>
+        </ExternalIdentifier>
+     </ExternalIdentifiers>
 tags:
 - _name: Type
   description: Specifies the type of identifier. Must be one of the valid types as

--- a/docs/yaml/elements/external_identifiers.yaml
+++ b/docs/yaml/elements/external_identifiers.yaml
@@ -1,4 +1,29 @@
-name: ExternalIdentifiers
+_name: ExternalIdentifiers
+_sub_types:
+- ExternalIdentifier
+description: |-
+  The ``ExternalIdentifiers`` element allows VIP data to connect with external datasets (e.g.
+  candidates with campaign finance datasets, electoral geographies with `OCD-IDs`_ that allow for
+  greater connectivity with additional datasets, etc...). Examples for ``ExternalIdentifiers`` can be
+  found on the objects that support them:
+
+  * :doc:`Candidate <candidate>`
+
+  * Any element that extends :doc:`ContestBase <contest_base>`
+
+  * :doc:`ElectoralDistrict <electoral_district>`
+
+  * :doc:`Locality <locality>`
+
+  * :doc:`Office <office>`
+
+  * :doc:`Party <party>`
+
+  * :doc:`Precinct <precinct>`
+
+  * :doc:`State <state>`
+
+  .. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
 tags:
 - _name: ExternalIdentifier
   description: Defines the identifier and the type of identifier it is (see `ExternalIdentifier`_

--- a/docs/yaml/elements/hours.yaml
+++ b/docs/yaml/elements/hours.yaml
@@ -1,4 +1,7 @@
-name: Hours
+_name: Hours
+description: |-
+  The open and close time for this place. All times must be fully specified,
+  including a timezone offset from UTC.
 tags:
 - _name: StartTime
   description: The time at which this place opens.

--- a/docs/yaml/elements/hours_open.yaml
+++ b/docs/yaml/elements/hours_open.yaml
@@ -1,4 +1,12 @@
-name: HoursOpen
+_name: HoursOpen
+_sub_types:
+- Schedule
+- Hours
+- TimeWithZone
+description: |-
+  A structured way of describing the days and hours that a place such as a
+  :doc:`Office <office>` or :doc:`PollingLocation <polling_location>` is open, or
+  that an event such as an :doc:`Election <election>` is happening.
 tags:
 - _name: Schedule
   description: Defines a block of days and hours that a place will be open.

--- a/docs/yaml/elements/html_color_string.yaml
+++ b/docs/yaml/elements/html_color_string.yaml
@@ -1,0 +1,17 @@
+_name: HtmlColorString
+description: |-
+  A restricted string pattern for a six-character hex code representing an HTML
+  color string. The pattern is:
+
+  ``[0-9a-f]{6}``
+
+  .. code-block:: xml
+     :linenos:
+
+     <Party id="par0001">
+       <Abbreviation>REP</Abbreviation>
+       <Color>e91d0e</Color>
+       <Name>
+         <Text language="en">Republican</Text>
+       </Name>
+     </Party>

--- a/docs/yaml/elements/internationalized_text.yaml
+++ b/docs/yaml/elements/internationalized_text.yaml
@@ -1,4 +1,33 @@
-name: InternationalizedText
+_name: InternationalizedText
+_sub_types:
+- LanguageString
+description: |-
+  ``InternationalizedText`` allows for support of multiple languages for a string.
+  ``InternationalizedText`` has an optional attribute ``label``, which allows the feed to refer
+  back to the original label for the information (e.g. if the contact information came from a
+  CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can be seen in:
+
+  * Any element that extends :doc:`ContestBase <contest_base>`
+
+  * Any element that extends :doc:`BallotSelectionBase <ballot_selection_base>`
+
+  * :doc:`Candidate <candidate>`
+
+  * :doc:`ContactInformation <contact_information>`
+
+  * :doc:`Election <election>`
+
+  * :doc:`ElectionAdministration <election_administration>`
+
+  * :doc:`Office <office>`
+
+  * :doc:`Party <party>`
+
+  * :doc:`Person <person>`
+
+  * :doc:`PollingLocation <polling_location>`
+
+  * :doc:`Source <source>`
 tags:
 - _name: Text
   description: Contains the translations of a particular string of text.

--- a/docs/yaml/elements/language_string.yaml
+++ b/docs/yaml/elements/language_string.yaml
@@ -1,0 +1,15 @@
+_name: LanguageString
+description: |-
+  ``LanguageString`` extends xs:string and can contain text from any language. ``LanguageString``
+  has one required attribute, ``language``, that must contain the 2-character `language code`_ for the
+  type of language ``LanguageString`` contains.
+
+  .. _`language code`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+
+  .. code-block:: xml
+     :linenos:
+
+     <BallotTitle>
+        <Text language="en">Retention of Supreme Court Justice</Text>
+        <Text language="es">La retención de juez de la Corte Suprema</Text>
+     </BallotTitle>

--- a/docs/yaml/elements/lat_lng.yaml
+++ b/docs/yaml/elements/lat_lng.yaml
@@ -1,4 +1,24 @@
-name: LatLng
+_name: LatLng
+description: |-
+  The latitude and longitude of a polling location in `WGS 84`_ format. Both
+  latitude and longitude values are measured in decimal degrees.
+post: |-
+  .. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
+
+  .. code-block:: xml
+     :linenos:
+
+     <PollingLocation id="pl81274">
+        <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
+        <AddressLine>2775 Hydraulic Rd</AddressLine>
+        <AddressLine>Charlottesville, VA 229018917</AddressLine>
+        <HoursOpenId>hours0001</HoursOpenId>
+        <LatLng>
+          <Latitude>38.0754627</Latitude>
+          <Longitude>-78.5014875</Longitude>
+          <Source>Google Maps</Source>
+        </LatLng>
+     </PollingLocation>
 tags:
 - _name: Latitude
   description: The latitude of the polling location.

--- a/docs/yaml/elements/locality.yaml
+++ b/docs/yaml/elements/locality.yaml
@@ -1,4 +1,24 @@
-name: Locality
+_name: Locality
+description: The Locality object represents the jurisdiction below the :doc:`state
+  <state>` (e.g. county).
+post: |-
+  .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+  .. code-block:: xml
+     :linenos:
+
+     <Locality id="loc70001">
+       <ElectionAdministrationId>ea40001</ElectionAdministrationId>
+       <ExternalIdentifiers>
+         <ExternalIdentifier>
+           <Type>ocd-id</Type>
+           <Value>ocd-division/country:us/state:va/county:albemarle</Value>
+         </ExternalIdentifier>
+       </ExternalIdentifiers>
+       <Name>ALBEMARLE COUNTY</Name>
+       <StateId>st51</StateId>
+       <Type>county</Type>
+     </Locality>
 tags:
 - _name: ElectionAdministrationId
   description: Links to the locality's :doc:`election administration <election_administration>`

--- a/docs/yaml/elements/office.yaml
+++ b/docs/yaml/elements/office.yaml
@@ -1,4 +1,9 @@
-name: Office
+_name: Office
+_sub_types:
+- Term
+description: |-
+  ``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
+  School Board, et al).
 tags:
 - _name: ContactInformation
   description: Specifies the contact information for the office and/or individual

--- a/docs/yaml/elements/ordered_contest.yaml
+++ b/docs/yaml/elements/ordered_contest.yaml
@@ -1,4 +1,19 @@
-name: OrderedContest
+_name: OrderedContest
+description: |-
+  ``OrderedContest`` encapsulates links to the information that comprises a contest and potential
+  ballot selections. ``OrderedContest`` elements can be collected within a
+  :doc:`BallotStyle <ballot_style>` to accurate depict exactly what will show up on a particular
+  ballot in the proper order.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <OrderedContest id="oc20003abc">
+        <ContestId>cc20003</ContestId>
+        <OrderedBallotSelectionId>cs10961</OrderedBallotSelectionId>
+        <OrderedBallotSelectionId>cs10962</OrderedBallotSelectionId>
+        <OrderedBallotSelectionId>cs10963</OrderedBallotSelectionId>
+     </OrderedContest>
 tags:
 - _name: ContestId
   description: Links to elements that extend :doc:`ContestBase <contest_base>`.

--- a/docs/yaml/elements/party.yaml
+++ b/docs/yaml/elements/party.yaml
@@ -1,4 +1,8 @@
-name: Party
+_name: Party
+_sub_types:
+- HtmlColorString
+description: This element describes a political party and the metadata associated
+  with them.
 tags:
 - _name: Abbreviation
   description: An abbreviation for the party name.

--- a/docs/yaml/elements/party_contest.yaml
+++ b/docs/yaml/elements/party_contest.yaml
@@ -1,0 +1,7 @@
+_name: PartyContest
+description: |-
+  An extension of :doc:`ContestBase <contest_base>` which describes a contest in
+  which the possible ballot selections are of type :doc:`PartySelection
+  <party_selection>`. These could include contests in which straight-party
+  selections are allowed, or party-list contests (although these are more common
+  outside of the United States).

--- a/docs/yaml/elements/party_selection.yaml
+++ b/docs/yaml/elements/party_selection.yaml
@@ -1,4 +1,7 @@
-name: PartySelection
+_name: PartySelection
+description: |-
+  This element extends :doc:`BallotSelectionBase <ballot_selection_base>` to
+  support contests in which the selections can be groups of one or more parties.
 tags:
 - _name: PartyId
   description: One or more :doc:`Party <party>` IDs which collectively represent a

--- a/docs/yaml/elements/person.yaml
+++ b/docs/yaml/elements/person.yaml
@@ -1,4 +1,30 @@
-name: Person
+_name: Person
+description: |-
+  ``Person`` defines information about a person. The person may be a candidate, election administrator,
+  or elected official. These elements reference ``Person``:
+
+  * :doc:`Candidate <candidate>`
+
+  * :doc:`ElectionAdministration <election_administration>`
+
+  * :doc:`Office <office>`
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <Person id="per50001">
+        <ContactInformation label="ci60002">
+          <Email>rwashburne@albemarle.org</Email>
+          <Phone>4349724173</Phone>
+        </ContactInformation>
+        <FirstName>RICHARD</FirstName>
+        <LastName>WASHBURNE</LastName>
+        <MiddleName>J.</MiddleName>
+        <Nickname>JAKE</Nickname>
+        <Title>
+          <Text language="en">General Registrar Physical</Text>
+        </Title>
+     </Person>
 tags:
 - _name: ContactInformation
   description: Specifies contact information for the person.

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -1,4 +1,8 @@
-name: PollingLocation
+_name: PollingLocation
+_sub_types:
+- LatLng
+description: The PollingLocation object represents a site where voters cast or drop
+  off ballots.
 tags:
 - _name: AddressLine
   description: Represents the various parts of an address to a polling location.

--- a/docs/yaml/elements/precinct.yaml
+++ b/docs/yaml/elements/precinct.yaml
@@ -1,4 +1,28 @@
-name: Precinct
+_name: Precinct
+description: |-
+  The Precinct object represents a precinct, which is contained within a Locality. While the id
+  attribute does not have to be static across feeds for one election, the combination of
+  :doc:`Source.VipId <source>`, :doc:`Locality.Name <locality>`, :doc:`Precinct.Ward <precinct>`,
+  :doc:`Precinct.Name <precinct>`, and :doc:`Precinct.Number <precinct>` should remain constant across
+  feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
+  non-required fields is fine).
+post: |-
+  .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+  .. code-block:: xml
+     :linenos:
+
+     <Precinct id="pre90111">
+        <BallotStyleId>bs00010</BallotStyleId>
+        <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+        <ElectoralDistrictId>ed60311</ElectoralDistrictId>
+        <ElectoralDistrictId>ed60054</ElectoralDistrictId>
+        <IsMailOnly>false</IsMailOnly>
+        <LocalityId>loc70001</LocalityId>
+        <Name>203 - GEORGETOWN</Name>
+        <Number>0203</Number>
+        <PollingLocationId>pl81274</PollingLocationId>
+     </Precinct>
 tags:
 - _name: BallotStyleId
   description: Links to the :doc:`ballot style <ballot_style>`, which a person who

--- a/docs/yaml/elements/retention_contest.yaml
+++ b/docs/yaml/elements/retention_contest.yaml
@@ -1,4 +1,23 @@
-name: RetentionContest
+_name: RetentionContest
+description: |-
+  ``RetentionContest`` extends :doc:`BallotMeasureContest <ballot_measure_contest>` and represents a
+  contest where a candidate is retained in a position (e.g. a judge).
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <RetentionContest id="rc40001">
+        <BallotSelectionId>rc40001a</BallotSelectionId>
+        <BallotSelectionId>rc40001b</BallotSelectionId>
+        <BallotTitle>
+           <Text language="en">Retention of Supreme Court Justice</Text>
+           <Text language="es">La retención de juez de la Corte Suprema</Text>
+        </BallotTitle>
+        <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+        <Name>Judicial Retention, Supreme Court</Name>
+        <CandidateId>can14444</CandidateId>
+        <OfficeId>off20006</OfficeId>
+     </RetentionContest>
 tags:
 - _name: CandidateId
   description: Links to the :doc:`Candidate <candidate>` being retained.

--- a/docs/yaml/elements/schedule.yaml
+++ b/docs/yaml/elements/schedule.yaml
@@ -1,4 +1,8 @@
-name: Schedule
+_name: Schedule
+description: |-
+  A sub-portion of the schedule. This describes a range of days, along with one or
+  more set of open and close times for those days, as well as the options
+  describing whether or not appointments are necessary or possible.
 tags:
 - _name: Hours
   description: Blocks of hours in the date range in which the place is open.

--- a/docs/yaml/elements/source.yaml
+++ b/docs/yaml/elements/source.yaml
@@ -1,4 +1,23 @@
-name: Source
+_name: Source
+description: |-
+  The Source object represents the organization that is publishing the information. This object is
+  the only required object in the feed file, and only one source object is allowed to be present.
+post: |-
+  .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
+
+  .. code-block:: xml
+     :linenos:
+
+     <Source id="src1">
+        <DateTime>2013-10-24T14:25:28</DateTime>
+        <Description>
+           <Text language="en">SBE is the official source for Virginia data</Text>
+        </Description>
+        <Name>State Board of Elections, Commonwealth of Virginia</Name>
+        <OrganizationUri>http://www.sbe.virginia.gov/</OrganizationUri>
+        <VipId>51</VipId>
+        <Version>5.0</Version>
+     </Source>
 tags:
 - _name: Name
   description: Specifies the name of the organization that is providing the information.

--- a/docs/yaml/elements/state.yaml
+++ b/docs/yaml/elements/state.yaml
@@ -1,4 +1,23 @@
-name: State
+_name: State
+description: |-
+  The State object includes state-wide election information. The ID attribute is
+  recommended to be the state's FIPS code, along with the prefix "st".
+post: |-
+  .. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+  .. code-block:: xml
+     :linenos:
+
+     <State id="st51">
+        <ElectionAdministrationId>ea40133</ElectionAdministrationId>
+        <ExternalIdentifiers>
+          <ExternalIdentifier>
+            <Type>ocd-id</Type>
+            <Value>ocd-division/country:us/state:va</Value>
+          </ExternalIdentifier>
+        </ExternalIdentifiers>
+        <Name>Virginia</Name>
+     </State>
 tags:
 - _name: ElectionAdministrationId
   description: Links to the state's election administration object.

--- a/docs/yaml/elements/street_segment.yaml
+++ b/docs/yaml/elements/street_segment.yaml
@@ -1,4 +1,34 @@
-name: StreetSegment
+_name: StreetSegment
+description: |-
+  A Street Segment objection represents a portion of a street and the links to the precinct that this
+  geography (i.e., segment) is contained within. The start address house number must be less than the
+  end address house number unless the segment consists of only one address, in which case these values
+  are equal.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <StreetSegment id="ss999999">
+        <City>Charlottesville</City>
+        <IncludesAllAddresses>true</IncludesAllAddresses>
+        <OddEvenBoth>both</OddEvenBoth>
+        <PrecinctId>pre99999</PrecinctId>
+        <State>VA</State>
+        <StreetName>CHAPEL HILL</StreetName>
+        <StreetSuffix>RD</StreetSuffix>
+        <Zip>22901</Zip>
+     </StreetSegment>
+     <StreetSegment id="ss309904">
+        <City>GREENWOOD</City>
+        <OddEvenBoth>both</OddEvenBoth>
+        <PrecinctId>pre92145</PrecinctId>
+        <StartHouseNumber>1</StartHouseNumber>
+        <EndHouseNumber>201</EndHouseNumber>
+        <State>VA</State>
+        <StreetName>MISTY MOUNTAIN</StreetName>
+        <StreetSuffix>RD</StreetSuffix>
+        <Zip>22943</Zip>
+     </StreetSegment>
 tags:
 - _name: AddressDirection
   description: Specifies the (inter-)cardinal direction of the entire address. An

--- a/docs/yaml/elements/term.yaml
+++ b/docs/yaml/elements/term.yaml
@@ -1,4 +1,19 @@
-name: Term
+_name: Term
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <Office id="off0000">
+       <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+       <FilingDeadline>2013-01-01</FilingDeadline>
+       <IsPartisan>false</IsPartisan>
+       <Name>
+         <Text language="en">Governor</Text>
+       </Name>
+       <Term>
+         <Type>full-term</Type>
+       </Term>
+     </Office>
 tags:
 - _name: Type
   description: Specifies the type of office term (see :doc:`OfficeTermType <../enumerations/office_term_type>`

--- a/docs/yaml/elements/time_with_zone.yaml
+++ b/docs/yaml/elements/time_with_zone.yaml
@@ -1,0 +1,24 @@
+_name: TimeWithZone
+description: |-
+  A string pattern restricting the value to a time with an included offset from
+  UTC. The pattern is
+
+  ``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
+
+  .. code-block:: xml
+     :linenos:
+
+     <HoursOpen id="hours0001">
+       <Schedule>
+         <Hours>
+           <StartTime>06:00:00-05:00</StartTime>
+           <EndTime>12:00:00-05:00</EndTime>
+         </Hours>
+         <Hours>
+           <StartTime>13:00:00-05:00</StartTime>
+           <EndTime>19:00:00-05:00</EndTime>
+         </Hours>
+         <StartDate>2013-11-05</StartDate>
+         <EndDate>2013-11-05</EndDate>
+       </Schedule>
+     </HoursOpen>

--- a/docs/yaml/elements/voter_service.yaml
+++ b/docs/yaml/elements/voter_service.yaml
@@ -1,4 +1,25 @@
-name: VoterService
+_name: VoterService
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <ElectionAdministration id="ea40133">
+        <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
+        <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
+        <Department>
+          <ContactInformation label="ci60000">
+            <AddressLine>Washington Building First Floor</AddressLine>
+            <AddressLine>1100 Bank Street</AddressLine>
+            <AddressLine>Richmond, VA 23219</AddressLine>
+            <Name>State Board of Elections</Name>
+          </ContactInformation>
+        </Department>
+        <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
+        <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
+        <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
+        <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
+        <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
+     </ElectionAdministration>
 tags:
 - _name: ContactInformation
   description: The contact for a particular voter service.

--- a/docs/yaml/enumerations/ballot_measure_type.yaml
+++ b/docs/yaml/enumerations/ballot_measure_type.yaml
@@ -1,4 +1,13 @@
-name: BallotMeasureType
+_name: BallotMeasureType
+description: |-
+  A list of the various types of ballot measures. States may have different legal
+  definitions of each type; Wikipedia_ has more details about each type.  These
+  values are to help states with multiple types of non-candidate-based contests
+  distinguish between each type; as such, the definitions in this table are simple
+  guidelines. Ultimately it is up to the state or local election official to
+  choose the value which best describes the ballot measure(s) in their
+  jurisdiction.
+post: '.. _Wikipedia: http://en.wikipedia.org/wiki/Initiatives_and_referendums_in_the_United_States'
 tags:
 - _name: ballot-measure
   description: A catch-all for generic types of non-candidate-based contests.

--- a/docs/yaml/enumerations/candidate_post_election_status.yaml
+++ b/docs/yaml/enumerations/candidate_post_election_status.yaml
@@ -1,4 +1,4 @@
-name: CandidatePostElectionStatus
+_name: CandidatePostElectionStatus
 tags:
 - _name: advanced-to-runoff
   description: For contests in which the top *N* candidates advance to the next round.

--- a/docs/yaml/enumerations/candidate_pre_election_status.yaml
+++ b/docs/yaml/enumerations/candidate_pre_election_status.yaml
@@ -1,4 +1,4 @@
-name: CandidatePreElectionStatus
+_name: CandidatePreElectionStatus
 tags:
 - _name: filed
   description: The candidate has filed for office but not yet been qualified.

--- a/docs/yaml/enumerations/district_type.yaml
+++ b/docs/yaml/enumerations/district_type.yaml
@@ -1,4 +1,14 @@
-name: DistrictType
+_name: DistrictType
+description: |-
+  Enumeration describing the set of possible jurisdiction and district types.
+  Please use the enumeration value which most accurately reflects the type of
+  district or jurisdiction in your state or county. For example, "town" and
+  "township" may mean different things -- or not be defined at all -- in your
+  state, so please use the definition which best matches your local meaning.
+post: |-
+  .. _`special-purpose district`: http://en.wikipedia.org/wiki/Special-purpose_district
+  .. _town: http://en.wikipedia.org/wiki/Town#United_States
+  .. _`Wikipedia article`: http://en.wikipedia.org/wiki/Town#United_States
 tags:
 - _name: city
   description: A city.

--- a/docs/yaml/enumerations/identifier_type.yaml
+++ b/docs/yaml/enumerations/identifier_type.yaml
@@ -1,4 +1,9 @@
-name: IdentifierType
+_name: IdentifierType
+post: |-
+  .. _states: http://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code
+  .. _counties: http://en.wikipedia.org/wiki/FIPS_county_code
+  .. _cities: http://geonames.usgs.gov/domestic/fips55codedef.html
+  .. _`Open Civic Data Division Identifier`: http://docs.opencivicdata.org/en/latest/proposals/0002.html
 tags:
 - _name: fips
   description: Federal Information Processing Standards codes for states_, counties_,

--- a/docs/yaml/enumerations/oeb_enum.yaml
+++ b/docs/yaml/enumerations/oeb_enum.yaml
@@ -1,4 +1,4 @@
-name: OebEnum
+_name: OebEnum
 tags:
 - _name: both
   description: Both even and odd addresses within the range.

--- a/docs/yaml/enumerations/office_term_type.yaml
+++ b/docs/yaml/enumerations/office_term_type.yaml
@@ -1,4 +1,4 @@
-name: OfficeTermType
+_name: OfficeTermType
 tags:
 - _name: full-term
   description: This election is for an office for which the existing term has been

--- a/docs/yaml/enumerations/vote_variation.yaml
+++ b/docs/yaml/enumerations/vote_variation.yaml
@@ -1,4 +1,19 @@
-name: VoteVariation
+_name: VoteVariation
+description: |-
+  Note that the descriptions below describe what the enumeration names
+  stand for in the context of the VIP spec, rather than provide general
+  definitions of the election terms that the names correspond to.  For example,
+  even though there are majority voting methods that are not "1-of-m" (e.g.
+  ranked choice voting), we constrain "majority" to 1-of-m.  We do this to
+  eliminate any source of ambiguity when a single enumeration value needs
+  to be assigned to a contest.
+post: |-
+  .. _`Approval voting`: http://en.wikipedia.org/wiki/Approval_voting
+  .. _`Borda count`: http://en.wikipedia.org/wiki/Borda_count
+  .. _`Cumulative voting`: http://en.wikipedia.org/wiki/Cumulative_voting
+  .. _`proportional representation`: https://en.wikipedia.org/wiki/Proportional_representation
+  .. _`Range voting`: http://en.wikipedia.org/wiki/Range_voting
+  .. _`Ranked choice voting`: http://http://en.wikipedia.org/wiki/Ranked_Choice_Voting
 tags:
 - _name: 1-of-m
   description: A method where each voter can select up to one option.

--- a/docs/yaml/enumerations/voter_service_type.yaml
+++ b/docs/yaml/enumerations/voter_service_type.yaml
@@ -1,4 +1,4 @@
-name: VoterServiceType
+_name: VoterServiceType
 tags:
 - _name: absentee-ballots
   description: This department handles the dispatch, tracking, and return of absentee

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
@@ -4283,4 +4282,3 @@
   <script src="https://vip-website-assets.s3.amazonaws.com/core/js/vendor/prism.js"></script>
 </body>
 </html>
->>>>>>> 368f1abfa1cc54cdec64e97e24ecd439405a6c59

--- a/scripts/vip.py
+++ b/scripts/vip.py
@@ -83,9 +83,9 @@ def command_rest2yaml(ns):
         parsing.rest_file_to_yaml(parent_dir, path)
 
 
-def command_update_tables(ns):
+def command_update_rest(ns):
     """Run the update_tables command."""
-    rest.update_table_files(ns.type_name)
+    rest.update_rest_files(ns.type_name)
 
 
 def command_scratch(ns):
@@ -132,14 +132,14 @@ def create_parser():
     parser.add_argument('path', metavar='PATH', nargs='?',
         help="a path to a YAML file. Defaults to all files.")
 
-    parser = make_subparser(sub, "update_tables",
-        help=("update all reST tables from the data in the YAML files."))
+    parser = make_subparser(sub, "update_rest",
+        help=("update all reST files from the YAML files."))
     parser.add_argument('type_name', metavar='TYPE_NAME', nargs='?',
         help=('the name of a type (e.g. "HoursOpen"). '
               "Defaults to all types."))
 
     parser = make_subparser(sub, "rest2yaml",
-        help=("rewrite all reST files to use tables generated from YAML files. "
+        help=("parse reST files and update the corresponding YAML files. "
               "This command only needs to be run on the repo once. "
               "After that, this command can be permanently deleted."))
     parser.add_argument('path', metavar='PATH', nargs='?',
@@ -166,7 +166,7 @@ def main(argv=None):
     """
     if argv is None:
         argv = sys.argv[1:]
-    logging.basicConfig(level='DEBUG')
+    logging.basicConfig(level='DEBUG', style="{", format="vippy: [{levelname}] {message}")
     common.configure_yaml()
     parser = create_parser()
     ns = parser.parse_args(argv)  # an argparse.Namespace object.

--- a/scripts/vip.py
+++ b/scripts/vip.py
@@ -84,7 +84,7 @@ def command_rest2yaml(ns):
 
 
 def command_update_rest(ns):
-    """Run the update_tables command."""
+    """Run the update_rest command."""
     rest.update_rest_files(ns.type_name)
 
 

--- a/scripts/vippy/common.py
+++ b/scripts/vippy/common.py
@@ -298,9 +298,9 @@ class DataType(object):
         file_name = os.path.basename(rel_path)
         snake_name, ext = os.path.splitext(file_name)
 
-        type_name = type_yaml['name']
+        type_name = type_yaml['_name']
         type_data = copy.deepcopy(type_yaml)
-        tags = type_data['tags']
+        tags = type_data.get('tags', [])
         for tag in tags:
             tag['containing_type'] = type_name
 
@@ -321,17 +321,31 @@ class DataType(object):
 
     @property
     def name(self):
-        return self.data['name']
+        return self.data['_name']
+
+    @property
+    def sub_types(self):
+        return self.data.get('_sub_types', [])
 
     @property
     def tags(self):
-        return self.data['tags']
+        return self.data.get('tags')
 
     @property
     def table_path(self):
         """Return a path relative to the repo root."""
+        if not self.tags:
+            return
+        return self.get_rest_path(TABLES_DIR)
+
+    @property
+    def rest_path(self):
+        """Return a path relative to the repo root."""
+        return self.get_rest_path(XML_DIR)
+
+    def get_rest_path(self, dir_path):
         rel_path = self.rel_path
         root, ext = os.path.splitext(rel_path)
         rest_rel_path = "{0}.rst".format(root)
-        path = os.path.join(TABLES_DIR, rest_rel_path)
+        path = os.path.join(dir_path, rest_rel_path)
         return path

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -15,7 +15,7 @@ _log = logging.getLogger()
 
 MIN_COLUMN_WIDTH = 12
 
-TABLE_COMMENT = """\
+REST_HEADER = """\
 .. This file is auto-generated.  Do not edit it by hand!
 
 """
@@ -116,7 +116,76 @@ def make_table(all_types, data_type):
     return table
 
 
-def update_table_files(type_name=None):
+def write_rest_file(path, rest):
+    rest = REST_HEADER + rest
+    common.write_file(path, rest)
+
+
+def update_table_file(all_types, data_type):
+    if not data_type.tags:
+        _log.debug("table not needed for: {0}".format(data_type))
+        return
+    rest = make_table(all_types, data_type)
+    rest_path = data_type.table_path
+    write_rest_file(rest_path, rest)
+
+
+def add_rest_section(rest, new_rest):
+    return rest + "{0}\n\n".format(new_rest)
+
+
+def make_type_rest(all_types, data_type, header_char):
+    """
+    Arguments:
+      header_char: "=" or "-".
+    """
+    type_name = data_type.name
+    rest = "{0}\n{1}\n\n".format(type_name, len(type_name) * header_char)
+
+    yaml_data = data_type.yaml
+
+    description = yaml_data.get('description')
+    if description:
+        rest = add_rest_section(rest, description)
+
+    if data_type.table_path:
+        table_path = data_type.table_path
+        rel_table_path = os.path.relpath(table_path, start="docs")
+        new_rest = ".. include:: ../../{0}".format(rel_table_path)
+        rest = add_rest_section(rest, new_rest)
+
+    post = yaml_data.get('post')
+    if post:
+        rest = add_rest_section(rest, post)
+
+    for sub_type_name in data_type.sub_types:
+        sub_type = common.get_type(all_types, sub_type_name)
+        sub_rest = make_type_rest(all_types, sub_type, header_char="-")
+        # Separate types with an additional line.
+        rest += "\n" + sub_rest
+
+    return rest
+
+
+def update_rest_file(all_types, data_type):
+    type_name = data_type.name
+    for parent_type in all_types.values():
+        if type_name in parent_type.sub_types:
+            _log.debug("skipping rest file for: {0} ({1})".format(type_name, parent_type.name))
+            return
+
+    rest_path = data_type.rest_path
+    _log.debug("updating: {0}".format(rest_path))
+
+    rest = make_type_rest(all_types, data_type, header_char="=")
+
+    # Make sure the file ends in a single newline.
+    rest = rest.strip() + "\n"
+
+    write_rest_file(rest_path, rest)
+
+
+def update_rest_files(type_name=None):
     all_types = common.read_types()
     if type_name is None:
         type_names = sorted(all_types.keys())
@@ -124,14 +193,10 @@ def update_table_files(type_name=None):
         type_names = [type_name]
 
     for type_name in type_names:
+        _log.debug("updating rest files for type: {0}".format(type_name))
         data_type = common.get_type(all_types, type_name)
-        table = make_table(all_types, data_type)
-        text = TABLE_COMMENT + table
-        rest_path = data_type.table_path
-        dir_path = os.path.dirname(rest_path)
-        if not os.path.exists(dir_path):
-            os.makedirs(dir_path)
-        common.write_file(rest_path, text)
+        update_table_file(all_types, data_type)
+        update_rest_file(all_types, data_type)
 
 
 def analyze_types():

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -30,7 +30,7 @@ TYPE_NAME_TO_REST = {
     'Department': ':ref:`Department <ea-dep>`',
     'DistrictType': ':doc:`DistrictType <../enumerations/district_type>`',
     'ExternalIdentifier': '`ExternalIdentifier`_',
-    'ExternalIdentifiers': ':doc:`ExternalIdentifiers <external_identifiers>`',
+    'ExternalIdentifiers': ':doc:`ExternalIdentifiers </xml/elements/external_identifiers>`',
     'Hours': '`Hours`_',
     'HtmlColorString': '`HtmlColorString`_',
     'IdentifierType': ':doc:`IdentifierType <../enumerations/identifier_type>`',

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -111,7 +111,7 @@ def make_table_formatter(all_types, data_type):
 def make_table(all_types, data_type):
     formatter = make_table_formatter(all_types, data_type)
     lines = formatter.make_table(data_type)
-    table = "\n".join(lines) + "\n"
+    table = "\n".join(lines)
 
     return table
 
@@ -125,7 +125,7 @@ def update_table_file(all_types, data_type):
     if not data_type.tags:
         _log.debug("table not needed for: {0}".format(data_type))
         return
-    rest = make_table(all_types, data_type)
+    rest = make_table(all_types, data_type) + "\n"
     rest_path = data_type.table_path
     write_rest_file(rest_path, rest)
 
@@ -148,11 +148,9 @@ def make_type_rest(all_types, data_type, header_char):
     if description:
         rest = add_rest_section(rest, description)
 
-    if data_type.table_path:
-        table_path = data_type.table_path
-        rel_table_path = os.path.relpath(table_path, start="docs")
-        new_rest = ".. include:: ../../{0}".format(rel_table_path)
-        rest = add_rest_section(rest, new_rest)
+    if data_type.tags:
+        table_rest = make_table(all_types, data_type)
+        rest = add_rest_section(rest, table_rest)
 
     post = yaml_data.get('post')
     if post:


### PR DESCRIPTION
This PR addresses issue #300.

A note on this PR: this PR only generates the reST files for the XML docs and not the CSV docs.  The CSV docs are a large copy-paste of the XML docs, so it will take a bit more work to know how they differ from the XML docs.  Adding support for the CSV docs will likely mean adding an additional field to the YAML for the CSV example, etc, and then tweaking the script that generates the reST.
