### PR TITLE
Update CandidateContest and CandidateSelection documentation

### DIFF
--- a/docs/built_rst/tables/elements/candidate_contest.rst
+++ b/docs/built_rst/tables/elements/candidate_contest.rst
@@ -10,7 +10,18 @@
 | OfficeIds      | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
 |                |                |              |              | :ref:`multi-xml-office` elements, if     | then the implementation is required to   |
 |                |                |              |              | available, which give additional         | ignore it.                               |
-|                |                |              |              | information about the offices.           |                                          |
+|                |                |              |              | information about the offices. **Note:** |                                          |
+|                |                |              |              | the order of the office IDs **must** be  |                                          |
+|                |                |              |              | in the same order as the candidates      |                                          |
+|                |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
+|                |                |              |              | the various `BallotSelectionIds`         |                                          |
+|                |                |              |              | reference                                |                                          |
+|                |                |              |              | :ref:`multi-xml-candidate-selection`     |                                          |
+|                |                |              |              | elements which reference the candidate   |                                          |
+|                |                |              |              | for President first and Vice-President   |                                          |
+|                |                |              |              | second, the `OfficeIds` should reference |                                          |
+|                |                |              |              | the office of President first and the    |                                          |
+|                |                |              |              | office of Vice-President second.         |                                          |
 +----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PrimaryPartyId | ``xs:IDREF``   | Optional     | Single       | References a :ref:`multi-xml-party`      | If the field is invalid or not present,  |
 |                |                |              |              | element, if the contest is related to a  | then the implementation is required to   |

--- a/docs/built_rst/xml/elements/candidate_contest.rst
+++ b/docs/built_rst/xml/elements/candidate_contest.rst
@@ -18,7 +18,18 @@ candidates.
 | OfficeIds      | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
 |                |                |              |              | :ref:`multi-xml-office` elements, if     | then the implementation is required to   |
 |                |                |              |              | available, which give additional         | ignore it.                               |
-|                |                |              |              | information about the offices.           |                                          |
+|                |                |              |              | information about the offices. **Note:** |                                          |
+|                |                |              |              | the order of the office IDs **must** be  |                                          |
+|                |                |              |              | in the same order as the candidates      |                                          |
+|                |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
+|                |                |              |              | the various `BallotSelectionIds`         |                                          |
+|                |                |              |              | reference                                |                                          |
+|                |                |              |              | :ref:`multi-xml-candidate-selection`     |                                          |
+|                |                |              |              | elements which reference the candidate   |                                          |
+|                |                |              |              | for President first and Vice-President   |                                          |
+|                |                |              |              | second, the `OfficeIds` should reference |                                          |
+|                |                |              |              | the office of President first and the    |                                          |
+|                |                |              |              | office of Vice-President second.         |                                          |
 +----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PrimaryPartyId | ``xs:IDREF``   | Optional     | Single       | References a :ref:`multi-xml-party`      | If the field is invalid or not present,  |
 |                |                |              |              | element, if the contest is related to a  | then the implementation is required to   |
@@ -33,9 +44,7 @@ candidates.
    :linenos:
 
    <CandidateContest id="cc20003">
-      <BallotSelectionId>cs10961</BallotSelectionId>
-      <BallotSelectionId>cs10962</BallotSelectionId>
-      <BallotSelectionId>cs10963</BallotSelectionId>
+      <BallotSelectionIds>cs10961 cs10962 cs10963</BallotSelectionIds>
       <BallotTitle>
         <Text language="en">Governor of Virginia</Text>
       </BallotTitle>

--- a/docs/built_rst/xml/elements/candidate_selection.rst
+++ b/docs/built_rst/xml/elements/candidate_selection.rst
@@ -35,7 +35,6 @@ ballot selection for a candidate contest.
    :linenos:
 
    <CandidateSelection id="cs10861">
-      <CandidateId>can10861a</CandidateId>
-      <CandidateId>can10861b</CandidateId>
-      <EndorsementPartyId>par0001</EndorsementPartyId>
+      <CandidateIds>can10861a can10861b</CandidateIds>
+      <EndorsementPartyIds>par0001</EndorsementPartyIds>
    </CandidateSelection>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -248,9 +248,8 @@ ballot selection for a candidate contest.
    :linenos:
 
    <CandidateSelection id="cs10861">
-      <CandidateId>can10861a</CandidateId>
-      <CandidateId>can10861b</CandidateId>
-      <EndorsementPartyId>par0001</EndorsementPartyId>
+      <CandidateIds>can10861a can10861b</CandidateIds>
+      <EndorsementPartyIds>par0001</EndorsementPartyIds>
    </CandidateSelection>
 
 
@@ -650,7 +649,18 @@ candidates.
 | OfficeIds      | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
 |                |                |              |              | :ref:`single-xml-office` elements, if    | then the implementation is required to   |
 |                |                |              |              | available, which give additional         | ignore it.                               |
-|                |                |              |              | information about the offices.           |                                          |
+|                |                |              |              | information about the offices. **Note:** |                                          |
+|                |                |              |              | the order of the office IDs **must** be  |                                          |
+|                |                |              |              | in the same order as the candidates      |                                          |
+|                |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
+|                |                |              |              | the various `BallotSelectionIds`         |                                          |
+|                |                |              |              | reference                                |                                          |
+|                |                |              |              | :ref:`single-xml-candidate-selection`    |                                          |
+|                |                |              |              | elements which reference the candidate   |                                          |
+|                |                |              |              | for President first and Vice-President   |                                          |
+|                |                |              |              | second, the `OfficeIds` should reference |                                          |
+|                |                |              |              | the office of President first and the    |                                          |
+|                |                |              |              | office of Vice-President second.         |                                          |
 +----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PrimaryPartyId | ``xs:IDREF``   | Optional     | Single       | References a :ref:`single-xml-party`     | If the field is invalid or not present,  |
 |                |                |              |              | element, if the contest is related to a  | then the implementation is required to   |
@@ -665,9 +675,7 @@ candidates.
    :linenos:
 
    <CandidateContest id="cc20003">
-      <BallotSelectionId>cs10961</BallotSelectionId>
-      <BallotSelectionId>cs10962</BallotSelectionId>
-      <BallotSelectionId>cs10963</BallotSelectionId>
+      <BallotSelectionIds>cs10961 cs10962 cs10963</BallotSelectionIds>
       <BallotTitle>
         <Text language="en">Governor of Virginia</Text>
       </BallotTitle>

--- a/docs/yaml/elements/candidate_contest.yaml
+++ b/docs/yaml/elements/candidate_contest.yaml
@@ -7,9 +7,7 @@ post: |-
      :linenos:
 
      <CandidateContest id="cc20003">
-        <BallotSelectionId>cs10961</BallotSelectionId>
-        <BallotSelectionId>cs10962</BallotSelectionId>
-        <BallotSelectionId>cs10963</BallotSelectionId>
+        <BallotSelectionIds>cs10961 cs10962 cs10963</BallotSelectionIds>
         <BallotTitle>
           <Text language="en">Governor of Virginia</Text>
         </BallotTitle>
@@ -26,7 +24,12 @@ tags:
   type: xs:integer
 - _name: OfficeIds
   description: References a set of :ref:`$$$-office` elements, if available, which
-    give additional information about the offices.
+    give additional information about the offices. **Note:** the order of the office
+    IDs **must** be in the same order as the candidates listed in `BallotSelectionIds`.
+    E.g., if the various `BallotSelectionIds` reference :ref:`$$$-candidate-selection`
+    elements which reference the candidate for President first and Vice-President
+    second, the `OfficeIds` should reference the office of President first and the
+    office of Vice-President second.
   error_then: =must-ignore
   type: xs:IDREFS
 - _name: PrimaryPartyId

--- a/docs/yaml/elements/candidate_selection.yaml
+++ b/docs/yaml/elements/candidate_selection.yaml
@@ -7,9 +7,8 @@ post: |-
      :linenos:
 
      <CandidateSelection id="cs10861">
-        <CandidateId>can10861a</CandidateId>
-        <CandidateId>can10861b</CandidateId>
-        <EndorsementPartyId>par0001</EndorsementPartyId>
+        <CandidateIds>can10861a can10861b</CandidateIds>
+        <EndorsementPartyIds>par0001</EndorsementPartyIds>
      </CandidateSelection>
 tags:
 - _name: CandidateIds


### PR DESCRIPTION
Specify that the ordering of Offices in CandidateContest.OfficeIds matches the ordering of Candidates in CandidateContest.CandidateIds.

This addresses issue #291.