### PR TITLE
Add IsWriteIn to Party

### DIFF
--- a/docs/built_rst/tables/elements/party.rst
+++ b/docs/built_rst/tables/elements/party.rst
@@ -15,6 +15,15 @@
 |                     |                                         |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
 |                     |                                         |              |              | campaign finance system, etc).           | required to ignore it.                   |
 +---------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn           | ``xs:boolean``                          | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
+|                     |                                         |              |              | that is officially recognized by a       | then the implementation is required to   |
+|                     |                                         |              |              | local, state, or federal organization,   | ignore it.                               |
+|                     |                                         |              |              | or is a "write-in" in jurisdictions      |                                          |
+|                     |                                         |              |              | which allow candidates to free-form      |                                          |
+|                     |                                         |              |              | enter their political affiliation. If    |                                          |
+|                     |                                         |              |              | this field is not present then it is     |                                          |
+|                     |                                         |              |              | assumed to be false.                     |                                          |
++---------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | LogoUri             | ``xs:anyURI``                           | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
 |                     |                                         |              |              | displays.                                | then the implementation is required to   |
 |                     |                                         |              |              |                                          | ignore it.                               |

--- a/docs/built_rst/xml/elements/party.rst
+++ b/docs/built_rst/xml/elements/party.rst
@@ -22,6 +22,15 @@ This element describes a political party and the metadata associated with them. 
 |                     |                                         |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
 |                     |                                         |              |              | campaign finance system, etc).           | required to ignore it.                   |
 +---------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn           | ``xs:boolean``                          | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
+|                     |                                         |              |              | that is officially recognized by a       | then the implementation is required to   |
+|                     |                                         |              |              | local, state, or federal organization,   | ignore it.                               |
+|                     |                                         |              |              | or is a "write-in" in jurisdictions      |                                          |
+|                     |                                         |              |              | which allow candidates to free-form      |                                          |
+|                     |                                         |              |              | enter their political affiliation. If    |                                          |
+|                     |                                         |              |              | this field is not present then it is     |                                          |
+|                     |                                         |              |              | assumed to be false.                     |                                          |
++---------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | LogoUri             | ``xs:anyURI``                           | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
 |                     |                                         |              |              | displays.                                | then the implementation is required to   |
 |                     |                                         |              |              |                                          | ignore it.                               |

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1667,6 +1667,15 @@ This element describes a political party and the metadata associated with them. 
 |                     |                                          |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
 |                     |                                          |              |              | campaign finance system, etc).           | required to ignore it.                   |
 +---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn           | ``xs:boolean``                           | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
+|                     |                                          |              |              | that is officially recognized by a       | then the implementation is required to   |
+|                     |                                          |              |              | local, state, or federal organization,   | ignore it.                               |
+|                     |                                          |              |              | or is a "write-in" in jurisdictions      |                                          |
+|                     |                                          |              |              | which allow candidates to free-form      |                                          |
+|                     |                                          |              |              | enter their political affiliation. If    |                                          |
+|                     |                                          |              |              | this field is not present then it is     |                                          |
+|                     |                                          |              |              | assumed to be false.                     |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | LogoUri             | ``xs:anyURI``                            | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
 |                     |                                          |              |              | displays.                                | then the implementation is required to   |
 |                     |                                          |              |              |                                          | ignore it.                               |

--- a/docs/yaml/elements/party.yaml
+++ b/docs/yaml/elements/party.yaml
@@ -20,6 +20,13 @@ tags:
     a campaign finance system, etc).
   error_then: =must-ignore
   type: ExternalIdentifiers
+- _name: IsWriteIn
+  description: Signals if this political party is one that is officially recognized
+    by a local, state, or federal organization, or is a "write-in" in jurisdictions
+    which allow candidates to free-form enter their political affiliation. If this
+    field is not present then it is assumed to be false.
+  error_then: =must-ignore
+  type: xs:boolean
 - _name: LogoUri
   description: Web address of a logo to use in displays.
   error_then: =must-ignore

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -219,6 +219,13 @@
       <Text language="en">Party Preference: None</Text>
     </Name>
   </Party>
+  <Party id="par0007">
+    <Abbreviation>SSP</Abbreviation>
+    <IsWriteIn>true</IsWriteIn>
+    <Name>
+      <Text language="en">Slightly Silly Party</Text>
+    </Name>
+  </Party>
 
   <!-- The various electoral districts for which there are offices/contests in this election. -->
   <ElectoralDistrict id="ed60129">
@@ -589,7 +596,7 @@
     <VotesAllowed>1</VotesAllowed>
   </CandidateContest>
   <CandidateContest id="cc20262">
-    <BallotSelectionIds>cs10079 cs10080</BallotSelectionIds>
+    <BallotSelectionIds>cs10079 cs10080 cs10081</BallotSelectionIds>
     <BallotTitle>
       <Text language="en">Member Board of Supervisors</Text>
     </BallotTitle>
@@ -932,7 +939,7 @@
     <FirstName>Robert</FirstName>
     <LastName>Sarvis</LastName>
     <MiddleName>C.</MiddleName>
-    <PartyId>par0002</PartyId>
+    <PartyId>par0006</PartyId>
   </Person>
   <CandidateSelection id="cs10963">
     <CandidateIds>can10963</CandidateIds>
@@ -1210,6 +1217,27 @@
     <MiddleName>L.</MiddleName>
     <Nickname>Cindi</Nickname>
     <PartyId>par0001</PartyId>
+  </Person>
+  <CandidateSelection id="cs10081">
+    <CandidateIds>can10081</CandidateIds>
+  </CandidateSelection>
+  <Candidate id="can10081">
+    <BallotName>
+      <Text language="en">Kevin Phillips-Bong</Text>
+    </BallotName>
+    <PartyId>par0007</PartyId>
+    <PersonId>per10081</PersonId>
+  </Candidate>
+  <Person id="per10081">
+    <ContactInformation label="ci10081">
+      <AddressLine>4 Hanover House</AddressLine>
+      <AddressLine>14 Hanover Square</AddressLine>
+      <AddressLine>London W1S 1HP</AddressLine>
+      <Uri>http://www.montypython.com</Uri>
+    </ContactInformation>
+    <FirstName>Kevin</FirstName>
+    <LastName>Phillips-Bong</LastName>
+    <PartyId>par0007</PartyId>
   </Person>
   <CandidateSelection id="cs10075">
     <CandidateIds>can10075</CandidateIds>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -483,6 +483,7 @@
       <xs:element name="Abbreviation" type="xs:string" minOccurs="0" />
       <xs:element name="Color" type="HtmlColorString" minOccurs="0" />
       <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="IsWriteIn" type="xs:boolean" minOccurs="0" />
       <xs:element name="LogoUri" type="xs:anyURI" minOccurs="0" />
       <xs:element name="Name" type="InternationalizedText" />
     </xs:sequence>


### PR DESCRIPTION
Adds a field to signal if a political party is an officially recognized one, or a 'write-in' party from a jurisdiction which allows free-form entry of political affiliation.

Addresses #332.

Paging @indymag and @pstenbjorn 