### PR TITLE
Bump schema version to 5.1.2

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -5,7 +5,7 @@
      https://github.com/votinginfoproject/vip-specification
      for history and more infor.
   -->
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="5.1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="5.1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <!-- Enumeration types. -->
   <xs:simpleType name="BallotMeasureType">


### PR DESCRIPTION
To match [the release](https://github.com/votinginfoproject/vip-specification/commit/ca654a207a50826452c192e71c5af14fded1abe9) from September.