### PR TITLE
Remove old 4.0 schema, update to 5.1.2

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -1,532 +1,705 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:kml="http://www.opengis.net/kml/2.2">
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
-	<xs:import namespace="http://www.opengis.net/kml/2.2" schemaLocation="http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd"/>
-    <xs:element name="vip_object">
-        <xs:complexType>
-            <xs:choice maxOccurs="unbounded">
-                <xs:element name="source" minOccurs="1" maxOccurs="1">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string"/>
-                            <xs:element name="vip_id" type="xs:integer"/>
-                            <xs:element name="datetime" type="xs:dateTime"/>
-                            <xs:element name="description" type="xs:string" minOccurs="0"/>
-                            <xs:element name="organization_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="feed_contact_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="tou_url" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="election" minOccurs="1">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="date" type="xs:date" maxOccurs="1"/>
-                            <xs:element name="election_type" type="electionTypeEnum" minOccurs="0"  maxOccurs="1"/>
-                            <xs:element name="name" type="xs:string" minOccurs="0"  maxOccurs="1"/>
-							<xs:element name="division_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="state_id" type="xs:string"  maxOccurs="1"/>
-                            <xs:element name="statewide" type="yesNoEnum" minOccurs="0"  maxOccurs="1"/>
-                            <xs:element name="registration_info" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="absentee_ballot_info" type="xs:string" minOccurs="0"  maxOccurs="1"/>
-                            <xs:element name="results_url" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="polling_hours" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="election_day_registration" type="yesNoEnum" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="registration_deadline" type="xs:date" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="absentee_request_deadline" type="xs:date" minOccurs="0" maxOccurs="1"/>
-                            <xs:element name="uocava_mail_deadline" type="xs:date" minOccurs="0" maxOccurs="1"/>
-                        </xs:sequence>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="state">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="name" type="xs:string"/>
-                            <xs:element name="abbreviation" type="xs:string"/>
-                            <xs:element name="region" type="xs:string" minOccurs="0"/>
-                            <xs:element name="election_administration_id" type="xs:string" minOccurs="0"/>
-							<xs:element name="locality" type="localityType" minOccurs="0" maxOccurs="unbounded"/>
-                            <xs:element name="early_vote_site_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="locality" type="localityType" minOccurs="0" maxOccurs="unbounded"/>
+<!--
+     Working version of VIP schema based on 5.0 for comments.
+     See
+     https://github.com/votinginfoproject/vip-specification
+     for history and more infor.
+  -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="5.1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-                <xs:element name="precinct" type="precinctType" minOccurs="0" maxOccurs="unbounded"/>
+  <!-- Enumeration types. -->
+  <xs:simpleType name="BallotMeasureType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ballot-measure" />
+      <xs:enumeration value="initiative" />
+      <xs:enumeration value="referendum" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="precinct_split" type="precinct_splitType" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:simpleType name="CandidatePostElectionStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="advanced-to-runoff" />
+      <xs:enumeration value="projected-winner" />
+      <xs:enumeration value="winner" />
+      <xs:enumeration value="withdrawn" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="contest" type="contestType" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:simpleType name="CandidatePreElectionStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="filed" />
+      <xs:enumeration value="qualified" />
+      <xs:enumeration value="withdrawn" />
+      <xs:enumeration value="write-in" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="candidate" type="candidateType" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:simpleType name="DistrictType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="borough" />
+      <xs:enumeration value="city" />
+      <xs:enumeration value="city-council" />
+      <xs:enumeration value="congressional" />
+      <xs:enumeration value="county" />
+      <xs:enumeration value="county-council" />
+      <xs:enumeration value="judicial" />
+      <xs:enumeration value="municipality" />
+      <xs:enumeration value="national" />
+      <xs:enumeration value="school" />
+      <xs:enumeration value="special" />
+      <xs:enumeration value="state" />
+      <xs:enumeration value="state-house" />
+      <xs:enumeration value="state-senate" />
+      <xs:enumeration value="town" />
+      <xs:enumeration value="township" />
+      <xs:enumeration value="utility" />
+      <xs:enumeration value="village" />
+      <xs:enumeration value="ward" />
+      <xs:enumeration value="water" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="referendum" type="referendumType" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:simpleType name="IdentifierType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fips" />
+      <xs:enumeration value="local-level" />
+      <xs:enumeration value="national-level" />
+      <xs:enumeration value="ocd-id" />
+      <xs:enumeration value="state-level" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="ballot_response" type="ballot_responseType" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:simpleType name="OebEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="both" />
+      <xs:enumeration value="even" />
+      <xs:enumeration value="odd" />
+    </xs:restriction>
+  </xs:simpleType>
 
-                <xs:element name="election_administration">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string" minOccurs="0"/>
-                            <xs:element name="eo_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="ovc_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="physical_address" type="simpleAddressType" minOccurs="0"/>
-                            <xs:element name="mailing_address" type="simpleAddressType" minOccurs="0"/>
-                            <xs:element minOccurs="0" name="phone" type="xs:string" />
-                            <xs:element minOccurs="0" name="email" type="xs:string" />
-                            <xs:element name="elections_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="registration_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="am_i_registered_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="absentee_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="where_do_i_vote_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="what_is_on_my_ballot_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="rules_url" type="xs:string" minOccurs="0"/>
-                            <xs:element name="voter_services" type="xs:string" minOccurs="0"/>
-                            <xs:element name="hours" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="election_official">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string"/>
-                            <xs:element name="title" type="xs:string" minOccurs="0"/>
-                            <xs:element name="phone" type="xs:string" minOccurs="0"/>
-                            <xs:element name="fax" type="xs:string" minOccurs="0"/>
-                            <xs:element name="email" type="xs:string" minOccurs="0"/>
-                            <xs:element name="election_administration_id" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="polling_location">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string" minOccurs="0"/>
-                            <xs:element name="address" type="simpleAddressType"/>
-                            <xs:element name="directions" type="xs:string" minOccurs="0"/>
-                            <xs:element name="polling_hours" type="xs:string" minOccurs="0"/>
-                            <xs:element name="photo_url" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="early_vote_site">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string" minOccurs="0"/>
-                            <xs:element name="address" type="simpleAddressType"/>
-                            <xs:element name="directions" type="xs:string" minOccurs="0"/>
-                            <xs:element name="voter_services" type="xs:string" minOccurs="0"/>
-                            <xs:element name="start_date" type="xs:date" minOccurs="0"/>
-                            <xs:element name="end_date" type="xs:date" minOccurs="0"/>
-                            <xs:element name="days_times_open" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="electoral_district">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="name" type="xs:string"/>
-                            <xs:element name="type" type="xs:string" minOccurs="0"/>
-                            <xs:element name="number" type="xs:integer" minOccurs="0"/>
-                            <xs:element name="description" type="xs:string" minOccurs="0"/>
-                        </xs:sequence>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="ballot">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="referendum_id" minOccurs="0" maxOccurs="unbounded">
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:string">
-                                            <xs:attribute name="sort_order" type="xs:integer"/>
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="contest_id" minOccurs="0" maxOccurs="unbounded">
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:string">
-                                            <xs:attribute name="sort_order" type="xs:integer"/>
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="custom_ballot_id" type="xs:string" minOccurs="0"/>
-                              <xs:element minOccurs="0" name="write_in" type="yesNoEnum" />
-                            <xs:element name="image_url" type="xs:string" minOccurs="0"/>
-                        </xs:sequence>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="ballot_style">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="election_id" type="xs:string"/>
-                            <xs:element name="contest_id" type="xs:string" minOccurs="0"/>					
-                            <xs:element name="referendum_id" type="xs:string" minOccurs="0"/>					
-                            <xs:element name="sort_order" type="xs:string" minOccurs="0"/>
-                            <xs:element name="candidate_id" minOccurs="0">
-                                <xs:complexType>
-                                    <xs:simpleContent>
-                                        <xs:extension base="xs:string">
-                                            <xs:attribute name="sort_order" type="xs:integer"/>
-                                        </xs:extension>
-                                    </xs:simpleContent>
-                                </xs:complexType>
-                            </xs:element>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                        <xs:attribute name="name" type="xs:string" use="optional"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="precinct_split_electoral_district">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="precinct_split_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="precinct_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="electoral_district_id" type="xs:string"/>
-                        </xs:all>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="precinct_split_ballot_style">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="precinct_split_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="precinct_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="ballot_style_id" type="xs:string"/>
-                        </xs:all>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="party">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="name" type="xs:string"/>
-                            <xs:element name="major_party" type="yesNoEnum" minOccurs="0"/>
-                            <xs:element name="abbreviation" type="xs:string" minOccurs="0"/>
-                            <xs:element name="initial" type="xs:string" minOccurs="0"/>
-                            <xs:element name="sort_order" type="xs:integer" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                
-                <xs:element name="custom_ballot">
-                    <xs:complexType>
-                        <xs:choice maxOccurs="unbounded">
-                            <xs:element name="heading" type="xs:string"/>
-                            <xs:sequence maxOccurs="unbounded">
-                                <xs:element name="ballot_response_id">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:integer">
-                                                <xs:attribute name="sort_order" type="xs:integer"/>
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:choice>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="street_segment">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="start_house_number" type="xs:integer"/>
-                            <xs:element name="end_house_number" type="xs:integer"/>
-                            <xs:element name="odd_even_both" type="oebEnum"/>
-                            <xs:element name="start_apartment_number" type="xs:integer" minOccurs="0"/>
-                            <xs:element name="end_apartment_number" type="xs:integer" minOccurs="0"/>
-                            <xs:element name="non_house_address" type="detailAddressType" minOccurs="0"/>
-                            <xs:element name="city" type="xs:string" minOccurs="0"/>
-                            <xs:element name="zip" type="xs:string" minOccurs="0"/>
-                            <xs:element name="state_id" type="xs:string" minOccurs="0"/>
-                            <xs:element name="precinct_id" type="xs:string"/>
-                            <xs:element name="precinct_split_id" type="xs:string" minOccurs="0"/>
-                        </xs:all>
-                        <xs:attribute name="id" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="contest_result" type="contest_resultType" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="ballot_line_result" type="ballot_line_resultType" minOccurs="0" maxOccurs="unbounded"/>
-                </xs:choice>
-            <xs:attribute name="schemaVersion" type="xs:decimal" use="required" fixed="5.0"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:complexType name="detailAddressType">
-        <xs:all>
-            <xs:element name="house_number" type="xs:integer" minOccurs="0"/>
-            <xs:element name="house_number_prefix" type="xs:string" minOccurs="0"/>
-            <xs:element name="house_number_suffix" type="xs:string" minOccurs="0"/>
-            <xs:element name="street_direction" type="xs:string" minOccurs="0"/>
-            <xs:element name="street_name" type="xs:string"/>
-            <xs:element name="street_suffix" type="xs:string" minOccurs="0"/>
-            <xs:element name="address_direction" type="xs:string" minOccurs="0"/>
-            <xs:element name="apartment" type="xs:string" minOccurs="0"/>
-            <xs:element name="city" type="xs:string"/>
-            <xs:element name="state" type="xs:string"/>
-            <xs:element name="zip" type="xs:string"/>
-        </xs:all>
-    </xs:complexType>
-    <xs:complexType name="simpleAddressType">
-        <xs:all>
-            <xs:element name="location_name" type="xs:string" minOccurs="0"/>
-            <xs:element name="line1" type="xs:string"/>
-            <xs:element name="line2" type="xs:string" minOccurs="0"/>
-            <xs:element name="line3" type="xs:string" minOccurs="0"/>
-            <xs:element name="city" type="xs:string"/>
-            <xs:element name="state" type="xs:string"/>
-            <xs:element name="zip" type="xs:string"/>
-            <xs:element name="gis_xy" type="xs:string" minOccurs="0"/>
-        </xs:all>
-    </xs:complexType>
-    <xs:complexType name="votesWithCertification">
-        <xs:simpleContent>
-            <xs:extension base="xs:integer">
-                <xs:attribute name="certification" type="certificationEnum"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <xs:simpleType name="certificationEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="unofficial_partial"/>
-            <xs:enumeration value="unofficial_complete"/>
-            <xs:enumeration value="certified"/>
-            <xs:enumeration value="Unofficial_partial"/>
-            <xs:enumeration value="Unofficial_complete"/>
-            <xs:enumeration value="Unofficial_Partial"/>
-            <xs:enumeration value="Unofficial_Complete"/>
-            <xs:enumeration value="Certified"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="yesNoEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="yes"/>
-            <xs:enumeration value="no"/>
-            <xs:enumeration value="Yes"/>
-            <xs:enumeration value="No"/>
-            <xs:enumeration value="YES"/>
-            <xs:enumeration value="NO"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="electionTypeEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="general"/>
-            <xs:enumeration value="primary-open"/>
-            <xs:enumeration value="primary-closed"/>
-            <xs:enumeration value="special"/>
-            <xs:enumeration value="other"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="jurisdictionTypeEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="precinct"/>
-            <xs:enumeration value="locality"/>
-            <xs:enumeration value="state"/>
-            <xs:enumeration value="precinct-split"/>
-            <xs:enumeration value="other"/>
-        </xs:restriction>
-    </xs:simpleType>
-	<xs:simpleType name="oebEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="odd"/>
-            <xs:enumeration value="even"/>
-            <xs:enumeration value="both"/>
-            <xs:enumeration value="Odd"/>
-            <xs:enumeration value="Even"/>
-            <xs:enumeration value="Both"/>
-            <xs:enumeration value="ODD"/>
-            <xs:enumeration value="EVEN"/>
-            <xs:enumeration value="BOTH"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="voteTypeEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="in-precinct-opscan"/>
-            <xs:enumeration value="in-precinct-dre"/>
-            <xs:enumeration value="earlyvote-opscan"/>
-            <xs:enumeration value="earlyvote-dre"/>
-            <xs:enumeration value="absentee-central"/>
-			<xs:enumeration value="other-central"/>
-			<xs:enumeration value="absentee-in-precinct"/>
-            <xs:enumeration value="provisional"/>
-            <xs:enumeration value="unspecified"/>
-            <xs:enumeration value="unknown"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:complexType name="localityType">
+  <xs:simpleType name="OfficeTermType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="full-term" />
+      <xs:enumeration value="unexpired-term" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="VoteVariation">
+    <!-- While this will part of v5.0 of VIP, long-term this will likely get
+     replaced by whatever comes out of the NIST "Voting Methods
+     Mathematical Models" Working Group
+    -->
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="1-of-m" />
+      <xs:enumeration value="approval" />
+      <xs:enumeration value="borda" />
+      <xs:enumeration value="cumulative" />
+      <xs:enumeration value="majority" />
+      <xs:enumeration value="n-of-m" />
+      <xs:enumeration value="plurality" />
+      <xs:enumeration value="proportional" />
+      <xs:enumeration value="range" />
+      <xs:enumeration value="rcv" />
+      <xs:enumeration value="super-majority" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="VoterServiceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="absentee-ballots" />
+      <xs:enumeration value="overseas-voting" />
+      <xs:enumeration value="polling-places" />
+      <xs:enumeration value="voter-registration" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Non-enumeration simple types. -->
+  <xs:simpleType name="HtmlColorString">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-f]{6}" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ShortString">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="16" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TimeWithZone">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Complex types. -->
+  <!--
+      AnnotatedString: a type representing a string with a purpose specified.
+    -->
+  <xs:complexType name="AnnotatedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="annotation" type="ShortString" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!--
+      AnnotatedURI: a type representing a URI with a purpose specified.
+    -->
+  <xs:complexType name="AnnotatedURI">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attribute name="annotation" type="ShortString" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="BallotMeasureContest">
+    <xs:complexContent>
+      <xs:extension base="ContestBase">
         <xs:sequence>
-            <xs:element name="name" type="xs:string"/>
-            <xs:element name="state_id" type="xs:string"/>
-            <xs:element name="type" type="xs:string"/>
-            <xs:element name="parent_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="election_administration_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="early_vote_site_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element minOccurs="0" maxOccurs="unbounded" name="pollbook_type" type="xs:string" />
-            <xs:element name="precinct" type="precinctType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="Polygon" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="MultiGeometry" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="ConStatement" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="EffectOfAbstain" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="FullText" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="InfoUri" type="xs:anyURI" minOccurs="0" />
+          <xs:element name="PassageThreshold" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="ProStatement" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="SummaryText" type="InternationalizedText" minOccurs="0" />
+          <xs:element name="Type" type="BallotMeasureType" minOccurs="0" />
+          <xs:element name="OtherType" type="xs:string" minOccurs="0" />
         </xs:sequence>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="precinctType">
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- Generic string for a ballot measure (referendum) selection -->
+  <xs:complexType name="BallotMeasureSelection">
+    <xs:complexContent>
+      <xs:extension base="BallotSelectionBase">
         <xs:sequence>
-            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="number" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="locality_id" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="electoral_district_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="ward" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="mail_only" type="yesNoEnum" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="polling_location_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="early_vote_site_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="ballot_style_image_url" type="xs:string" minOccurs="0"/>
-            <xs:element name="precinct_split" type="precinct_splitType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="polling_location" type="polling_locationType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="registered_voters" type="xs:integer" maxOccurs="1" minOccurs="0"  />
-			<xs:element name="Polygon" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="MultiGeometry" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="precinct_splitType">
+          <xs:element name="Selection" type="InternationalizedText" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="BallotSelectionBase" abstract="true">
+    <xs:sequence>
+      <xs:element name="SequenceOrder" type="xs:integer" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="BallotStyle">
+    <xs:sequence>
+      <xs:element name="ImageUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="OrderedContestIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="PartyIds" type="xs:IDREFS" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="Candidate">
+    <xs:sequence>
+      <xs:element name="BallotName" type="InternationalizedText" />
+      <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="FileDate" type="xs:date" minOccurs="0" />
+      <xs:element name="IsIncumbent" type="xs:boolean" minOccurs="0" />
+      <xs:element name="IsTopTicket" type="xs:boolean" minOccurs="0" />
+      <xs:element name="PartyId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="PersonId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="PostElectionStatus" type="CandidatePostElectionStatus" minOccurs="0" />
+      <xs:element name="PreElectionStatus" type="CandidatePreElectionStatus" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="CandidateContest">
+    <xs:complexContent>
+      <xs:extension base="ContestBase">
         <xs:sequence>
-            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="precinct_id" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="electoral_district_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="polling_location_id" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="ballot_style_image_url" type="xs:string" minOccurs="0"/>
-			<xs:element name="registered_voters" type="xs:integer" maxOccurs="1" minOccurs="0"  />
-			<xs:element name="Polygon" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="MultiGeometry" xmlns="http://www.opengis.net/kml/2.2" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="polling_locationType">
-        <xs:all>
-            <xs:element name="address" type="simpleAddressType" />
-            <xs:element minOccurs="0" name="directions" type="xs:string" />
-            <xs:element minOccurs="0" name="polling_hours" type="xs:string" />
-            <xs:element minOccurs="0" name="photo_url" type="xs:string" />
-        </xs:all>
-        <xs:attribute name="id" type="xs:string" use="required" />
-    </xs:complexType>
-    <xs:complexType name="contestType">
-        <xs:choice maxOccurs="unbounded">
-            <xs:element name="election_id" type="xs:string" maxOccurs="1"/>
-            <xs:element name="electoral_district_id" type="xs:string"/>
-            <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="partisan" type="yesNoEnum" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="primary_party_id" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="electorate_specifications" type="xs:string" minOccurs="0"/>
-            <xs:element name="special" type="yesNoEnum" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="office" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="filing_closed_date" type="xs:date" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="term" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="number_elected" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="number_voting_for" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="ballot_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="ballot_placement" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="write_in" type="yesNoEnum" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="candidate" type="candidateType" minOccurs="0"/>
-			<xs:element name="referendum" type="referendumType" minOccurs="0" />
-			<xs:element name="contest_result" type="contest_resultType" minOccurs="0" />
-        </xs:choice>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="candidateType">
-        <xs:choice maxOccurs="unbounded">
-            <xs:element name="name" type="xs:string"/>
-            <xs:element minOccurs="0" name="incumbent" type="yesNoEnum" />
-            <xs:element name="last_name" type="xs:string"/>
-            <xs:element name="party_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="candidate_url" type="xs:string" minOccurs="0"/>
-            <xs:element name="biography" type="xs:string" minOccurs="0"/>
-            <xs:element name="phone" type="xs:string" minOccurs="0"/>
-            <xs:element name="photo_url" type="xs:string" minOccurs="0"/>
-            <xs:element name="filed_mailing_address" type="simpleAddressType" minOccurs="0"/>
-            <xs:element name="email" type="xs:string" minOccurs="0"/>
-            <xs:element name="candidate_status" type="xs:string" minOccurs="0"/>
-            <xs:element name="sort_order" type="xs:integer" minOccurs="0"/>
-        </xs:choice>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="referendumType">
-        <xs:choice maxOccurs="unbounded">
-            <xs:element name="title" type="xs:string"/>
-            <xs:element name="subtitle" type="xs:string" minOccurs="0"/>
-            <xs:element name="brief" type="xs:string" minOccurs="0"/>
-            <xs:element name="text" type="xs:string"/>
-            <xs:element name="pro_statement" type="xs:string" minOccurs="0"/>
-            <xs:element name="con_statement" type="xs:string" minOccurs="0"/>
-            <xs:element name="passage_threshold" type="xs:string" minOccurs="0"/>
-            <xs:element name="effect_of_abstain" type="xs:string" minOccurs="0"/>
-            <xs:element name="electoral_district_id" type="xs:string" minOccurs="0" />
-            <xs:element name="ballot_placement" type="xs:integer" minOccurs="0"/>
-			<xs:element name="contest_result" type="contest_resultType" minOccurs="0" />
-            <xs:element name="ballot_response_id">
-                <xs:complexType>
-                    <xs:simpleContent>
-                        <xs:extension base="xs:integer">
-                            <xs:attribute name="sort_order" type="xs:integer"/>
-                        </xs:extension>
-                    </xs:simpleContent>
-                </xs:complexType>
+          <xs:element name="NumberElected" type="xs:integer" minOccurs="0" />
+          <xs:element name="OfficeIds" type="xs:IDREFS" minOccurs="0" />
+          <xs:element name="PrimaryPartyIds" type="xs:IDREFS" minOccurs="0" />
+          <xs:element name="VotesAllowed" type="xs:integer" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="CandidateSelection">
+    <xs:complexContent>
+      <xs:extension base="BallotSelectionBase">
+        <xs:sequence>
+          <xs:element name="CandidateIds" type="xs:IDREFS" />
+          <xs:element name="EndorsementPartyIds" type="xs:IDREFS" minOccurs="0" />
+          <xs:element name="IsWriteIn" type="xs:boolean" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="ContactInformation">
+    <xs:sequence>
+      <xs:element name="AddressLine" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Directions" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="Email" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Fax" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
+      <!-- Note: The "Hours" element is being deprecated and will be removed
+           in future versions of VIP.
+        -->
+      <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="LatLng" type="LatLng" minOccurs="0" />
+      <!-- This can be a person or place name. -->
+      <xs:element name="Name" type="xs:string" minOccurs="0" />
+      <xs:element name="Phone" type="AnnotatedString" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Uri" type="AnnotatedURI" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="label" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="ContestBase" abstract="true">
+    <xs:sequence>
+      <xs:element name="Abbreviation" type="xs:string" minOccurs="0" />
+      <xs:element name="BallotSelectionIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="BallotSubTitle" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="BallotTitle" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="ElectoralDistrictId" type="xs:IDREF" />
+      <xs:element name="ElectorateSpecification" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="HasRotation" type="xs:boolean" minOccurs="0" />
+      <xs:element name="Name" type="xs:string" />
+      <xs:element name="SequenceOrder" type="xs:integer" minOccurs="0" />
+      <xs:element name="VoteVariation" type="VoteVariation" minOccurs="0" />
+      <xs:element name="OtherVoteVariation" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="ElectionAdministration">
+    <xs:sequence>
+      <xs:element name="AbsenteeUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="AmIRegisteredUri" type="xs:anyURI" minOccurs="0" />
+      <!-- A locality may have more than one department with each handling different services. -->
+      <xs:element name="Department" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
+            <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
+            <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:all>
+                  <!--
+                      The contact information below can be used to override or
+                      add specific fields to the base Departmental contact information if
+                      the service has different information.  For example, if the voter
+                      service has its own phone number, the ContactInformation object
+                      below can be an object containing only a Phone element.
+                    -->
+                  <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
+                  <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
+                  <!--
+                      This is for use if a certain person handles the particular service,
+                      for example a contact person for overseas voting.
+                    -->
+                  <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
+                  <xs:element name="Type" type="VoterServiceType" minOccurs="0" />
+                  <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+                </xs:all>
+                <xs:attribute name="label" type="xs:string" />
+              </xs:complexType>
             </xs:element>
-            <xs:element name="ballot_response" type="ballot_responseType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:choice>
-        <xs:attribute name="id" type="xs:string" use="required"/>
+          </xs:sequence>
+          <xs:attribute name="label" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ElectionsUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="RegistrationUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="RulesUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="WhatIsOnMyBallotUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="WhereDoIVoteUri" type="xs:anyURI" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="ElectoralDistrict">
+    <xs:sequence>
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="Name" type="xs:string" />
+      <xs:element name="Number" type="xs:integer" minOccurs="0" />
+      <xs:element name="Type" type="DistrictType" />
+      <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="ExternalIdentifiers">
+    <xs:sequence>
+      <xs:element name="ExternalIdentifier" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:all>
+            <xs:element name="Type" type="IdentifierType" />
+            <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+            <xs:element name="Value" type="xs:string" />
+          </xs:all>
+          <xs:attribute name="label" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="label" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="HoursOpen">
+    <xs:sequence>
+      <xs:element name="Schedule" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Hours" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="StartTime" type="TimeWithZone" maxOccurs="1" />
+                  <xs:element name="EndTime" type="TimeWithZone" maxOccurs="1" />
+                </xs:sequence>
+                <xs:attribute name="label" type="xs:string" />
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="IsOnlyByAppointment" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="IsOrByAppointment" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="IsSubjectToChange" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+            <xs:element name="StartDate" type="xs:date" minOccurs="0" />
+            <xs:element name="EndDate" type="xs:date" minOccurs="0" />
+          </xs:sequence>
+          <xs:attribute name="label" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <!--
+      InternationalizedText: a type representing a word or block of text
+      translated into one or more languages.
+
+      For example, an instance of:
+
+        <xs:element name="Office" type="InternationalizedText" />
+
+      could be:
+
+        <Office label="office_mayor">
+          <Text language="en">Mayor</Text>
+          <Text language="es">Alcalde</Text>
+          <Text language="zh">市長</Text>
+        </Office>
+
+      The optional "label" attribute can be used to name the text being
+      translated.  For example, if the translations come from a comma-delimited
+      flat file, the label for the corresponding row in the flat file could be
+      stored in this attribute for tracking purposes.  In the above example, the
+      element could have come from a flat file with row:
+
+        office_mayor,Mayor,Alcalde,市長
+    -->
+  <xs:complexType name="InternationalizedText">
+    <xs:sequence>
+      <xs:element name="Text" type="LanguageString" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="label" type="xs:string" />
+  </xs:complexType>
+
+  <!--
+      LanguageString: a type representing a string with a language specified.
+    -->
+  <xs:complexType name="LanguageString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="language" type="xs:language" use="required" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="LatLng">
+    <xs:sequence>
+      <xs:element name="Latitude" type="xs:float" maxOccurs="1" />
+      <xs:element name="Longitude" type="xs:float" maxOccurs="1" />
+      <xs:element name="Source" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="label" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="Locality">
+    <xs:sequence>
+      <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="Name" type="xs:string" />
+      <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="StateId" type="xs:IDREF" />
+      <xs:element name="Type" type="DistrictType" minOccurs="0" />
+      <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="Office">
+    <xs:sequence>
+      <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="ElectoralDistrictId" type="xs:IDREF" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="FilingDeadline" type="xs:date" minOccurs="0" />
+      <xs:element name="IsPartisan" type="xs:boolean" minOccurs="0" />
+      <xs:element name="Name" type="InternationalizedText" />
+      <xs:element name="OfficeHolderPersonIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="Term" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="StartDate" type="xs:date" minOccurs="0" />
+            <xs:element name="EndDate" type="xs:date" minOccurs="0" />
+            <xs:element name="Type" type="OfficeTermType" minOccurs="0" />
+          </xs:sequence>
+          <xs:attribute name="label" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="OrderedContest">
+    <xs:sequence>
+      <xs:element name="ContestId" type="xs:IDREF" />
+      <xs:element name="OrderedBallotSelectionIds" type="xs:IDREFS" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="Party">
+    <xs:sequence>
+      <xs:element name="Abbreviation" type="xs:string" minOccurs="0" />
+      <xs:element name="Color" type="HtmlColorString" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="IsWriteIn" type="xs:boolean" minOccurs="0" />
+      <xs:element name="LogoUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="Name" type="InternationalizedText" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="PartyContest">
+    <xs:complexContent>
+      <xs:extension base="ContestBase" />
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="PartySelection">
+    <xs:complexContent>
+      <xs:extension base="BallotSelectionBase">
+        <xs:sequence>
+          <xs:element name="PartyIds" type="xs:IDREFS" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Person">
+    <xs:sequence>
+      <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="DateOfBirth" type="xs:date" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="FirstName" type="xs:string" minOccurs="0" />
+      <xs:element name="FullName" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="Gender" type="xs:string" minOccurs="0" />
+      <xs:element name="LastName" type="xs:string" minOccurs="0" />
+      <xs:element name="MiddleName" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Nickname" type="xs:string" minOccurs="0" />
+      <xs:element name="PartyId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="Prefix" type="xs:string" minOccurs="0" />
+      <xs:element name="Profession" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="Suffix" type="xs:string" minOccurs="0" />
+      <xs:element name="Title" type="InternationalizedText" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="PollingLocation">
+    <xs:sequence>
+      <!-- It is intentional that an address is required. -->
+      <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
+      <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
+      <!--
+           Note: The "Hours" element is being deprecated and will be removed
+           in future versions of VIP.
+        -->
+      <xs:element name="Hours" type="InternationalizedText" minOccurs="0" />
+      <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="IsDropBox" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+      <xs:element name="IsEarlyVoting" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+      <xs:element name="LatLng" type="LatLng" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="PhotoUri" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="Precinct">
+    <xs:sequence>
+      <xs:element name="BallotStyleId" type="xs:IDREF" minOccurs="0" maxOccurs="1" />
+      <xs:element name="ElectoralDistrictIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+      <xs:element name="LocalityId" type="xs:IDREF" minOccurs="1" maxOccurs="1" />
+      <xs:element name="Name" type="xs:string" minOccurs="1" maxOccurs="1" />
+      <xs:element name="Number" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
+      <xs:element name="PrecinctSplitName" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="RetentionContest">
+    <xs:complexContent>
+      <xs:extension base="BallotMeasureContest">
+        <xs:sequence>
+          <xs:element name="CandidateId" type="xs:IDREF" />
+          <xs:element name="OfficeId" type="xs:IDREF" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="State">
+    <xs:sequence>
+      <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
+      <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
+      <xs:element name="Name" type="xs:string" />
+      <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="StreetSegment">
+    <xs:sequence>
+      <xs:element name="AddressDirection" type="xs:string" minOccurs="0" />
+      <xs:element name="City" type="xs:string" />
+      <xs:element name="IncludesAllAddresses" type="xs:boolean" minOccurs="0" />
+      <xs:element name="IncludesAllStreets" type="xs:boolean" minOccurs="0" />
+      <xs:element name="OddEvenBoth" type="OebEnum" minOccurs="0" />
+      <xs:element name="PrecinctId" type="xs:IDREF" />
+      <xs:element name="StartHouseNumber" type="xs:integer" minOccurs="0" />
+      <xs:element name="EndHouseNumber" type="xs:integer" minOccurs="0" />
+      <xs:element name="State" type="xs:string" />
+      <xs:element name="StreetDirection" type="xs:string" minOccurs="0" />
+      <xs:element name="StreetName" type="xs:string" minOccurs="0"/>
+      <xs:element name="StreetSuffix" type="xs:string" minOccurs="0" />
+      <xs:element name="UnitNumber" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Zip" type="xs:string" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <!-- Root element. -->
+  <xs:element name="VipObject">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+
+        <!-- This replaces the "referendum" element in VIP -->
+        <xs:element name="BallotMeasureContest" type="BallotMeasureContest" />
+
+        <!-- Generic string for a ballot measure (referendum) selection -->
+        <xs:element name="BallotMeasureSelection" type="BallotMeasureSelection" />
+
+        <xs:element name="BallotSelection" type="BallotSelectionBase" />
+
+        <xs:element name="BallotStyle" type="BallotStyle" />
+
+        <xs:element name="Candidate" type="Candidate" />
+
+        <xs:element name="CandidateContest" type="CandidateContest" />
+
+        <xs:element name="CandidateSelection" type="CandidateSelection" />
+
+        <xs:element name="Contest" type="ContestBase" />
+
+        <xs:element name="Election" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="AbsenteeBallotInfo" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="AbsenteeRequestDeadline" type="xs:date" minOccurs="0" />
+              <xs:element name="Date" type="xs:date" />
+              <xs:element name="ElectionType" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="HasElectionDayRegistration" type="xs:boolean" minOccurs="0" />
+              <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
+              <xs:element name="IsStatewide" type="xs:boolean" minOccurs="0" />
+              <xs:element name="Name" type="InternationalizedText" minOccurs="0" />
+              <!--
+                   Note: The "PollingHours" element is being deprecated
+                   and will be removed in future versions of VIP.
+                -->
+              <xs:element name="PollingHours" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="RegistrationDeadline" type="xs:date" minOccurs="0" />
+              <xs:element name="RegistrationInfo" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="ResultsUri" type="xs:anyURI" minOccurs="0" />
+              <xs:element name="StateId" type="xs:IDREF" />
+            </xs:all>
+            <xs:attribute name="id" type="xs:ID" use="required" />
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="ElectionAdministration" type="ElectionAdministration" />
+
+        <xs:element name="ElectoralDistrict" type="ElectoralDistrict" />
+
+        <xs:element name="HoursOpen" type="HoursOpen" />
+
+        <xs:element name="Locality" type="Locality" />
+
+        <xs:element name="Office" type="Office" />
+
+        <xs:element name="OrderedContest" type="OrderedContest" />
+
+        <xs:element name="Party" type="Party" />
+
+        <xs:element name="PartyContest" type="PartyContest" />
+
+        <xs:element name="PartySelection" type="PartySelection" />
+
+        <xs:element name="Person" type="Person" />
+
+        <xs:element name="PollingLocation" type="PollingLocation" />
+
+        <xs:element name="Precinct" type="Precinct" />
+
+        <xs:element name="RetentionContest" type="RetentionContest" />
+
+        <xs:element name="Source" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="DateTime" type="xs:dateTime" />
+              <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="FeedContactInformation" type="ContactInformation" minOccurs="0" />
+              <xs:element name="Name" type="xs:string" />
+              <xs:element name="OrganizationUri" type="xs:anyURI" minOccurs="0" />
+              <xs:element name="TermsOfUseUri" type="xs:anyURI" minOccurs="0" />
+              <xs:element name="VipId" type="xs:string" />
+            </xs:all>
+            <xs:attribute name="id" type="xs:ID" use="required" />
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="State" type="State" />
+
+        <xs:element name="StreetSegment" type="StreetSegment" />
+
+      </xs:choice>
+      <xs:attribute name="schemaVersion" type="xs:decimal" use="required" fixed="5.1" />
     </xs:complexType>
-    <xs:complexType name="ballot_responseType">
-        <xs:all>
-            <xs:element name="text" type="xs:string"/>
-            <xs:element name="sort_order" type="xs:integer" minOccurs="0"/>
-        </xs:all>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="contest_resultType">
-        <xs:choice maxOccurs="unbounded">
-            <xs:element name="contest_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="referendum_id" type="xs:string" minOccurs="0" />
-            <xs:element name="jurisdiction_id" type="xs:string"/>
-			<xs:element name="jurisdiction_type" type="jurisdictionTypeEnum"/>
-            <xs:element name="vote_type" type="voteTypeEnum"/>
-            <xs:element name="entire_district" type="yesNoEnum"/>
-            <xs:element name="total_votes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="total_valid_votes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="overvotes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="blank_votes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="accepted_provisional_votes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="rejected_votes" type="xs:integer" minOccurs="0"/>
-            <xs:element name="machine_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="ballot_line_result" type="ballot_line_resultType" minOccurs="0"/>
-        </xs:choice>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-        <xs:attribute name="certification" type="certificationEnum" use="required"/>
-    </xs:complexType>
-    <xs:complexType name="ballot_line_resultType">
-        <xs:all>
-            <xs:element name="contest_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="referendum_id" type="xs:string" minOccurs="0" />
-            <xs:element name="jurisdiction_id" type="xs:string"/>
-			<xs:element name="jurisdiction_type" type="jurisdictionTypeEnum"/>
-            <xs:element name="vote_type" type="voteTypeEnum"/>
-            <xs:element name="entire_district" type="yesNoEnum"/>
-            <xs:element name="candidate_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="ballot_response_id" type="xs:string" minOccurs="0"/>
-            <xs:element name="votes" type="xs:integer"/>
-            <xs:element name="victorious" type="yesNoEnum" minOccurs="0"/>
-        </xs:all>
-        <xs:attribute name="id" type="xs:string" use="required"/>
-        <xs:attribute name="certification" type="certificationEnum" use="required"/>
-    </xs:complexType>
+  </xs:element>
 </xs:schema>


### PR DESCRIPTION
When we write 5.1 XML, we begin with:
`<VipObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
schemaVersion="5.1"
xsi:noNamespaceSchemaLocation="http://votinginfoproject.github.com/vip-specification/vip_spec.xsd">`

This was (quietly) pointing to a 4.0 schema, but that doesn't work!