### PR TITLE
Increase precision of LatLng elements.

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -514,8 +514,8 @@
       <xs:element name="LatLng" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="Latitude" type="xs:float" minOccurs="1" maxOccurs="1" />
-            <xs:element name="Longitude" type="xs:float" minOccurs="1" maxOccurs="1" />
+            <xs:element name="Latitude" type="xs:double" minOccurs="1" maxOccurs="1" />
+            <xs:element name="Longitude" type="xs:double" minOccurs="1" maxOccurs="1" />
             <xs:element name="Source" type="xs:string" minOccurs="0" maxOccurs="1" />
           </xs:sequence>
           <xs:attribute name="label" type="xs:string" />


### PR DESCRIPTION
Lat/long coordinates frequently are given with greater precision than can
accurately be represented in a single-precision (32-bit) float. For example,
the lat/long pair "43.038217, -77.711050" when parsed as a pair of 32-bit
floats, produces a pair of numbers (to six significant figures) 43.038214,
-77.711053.

While the error introduced by round-tripping a lat-long pair in the US through
a float should usually amount to well under a meter of actual distance (in the
given example it's off by about 0.3m), the cost of using
double-precision (64-bit) floats, which can accurately represent a lat/long
pair in degrees to about a nanometer, is not meaningful, and the format change
is fully forwards-compatible (since the string representations of float and
double are identical).