### PR TITLE
Feature/issue 351 structured polling locations

### DIFF
--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -10,7 +10,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                  | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
 +======================================+==========================+==============+==============+==========================================+==========================================+
-| :ref:`multi-csv-simple-address-type` | ``hold``                 | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+| :ref:`multi-csv-simple-address-type` | ``simple-address-type``  | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
 |                                      |                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
 |                                      |                          |              |              |                                          | Location. If none is present, the        |
 |                                      |                          |              |              |                                          | implementation is required to ignore the |
@@ -68,10 +68,8 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 
 
     id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
-    poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
-    poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
-    poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
+    poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 
 
 .. _multi-csv-lat-lng:

--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -7,61 +7,68 @@ polling_location
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+==========================+==============+==============+==========================================+==========================================+
-| address_line    | ``xs:string``            | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
-|                 |                          |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
-|                 |                          |              |              |                                          | valid. If no valid ``AddressLine`` is    |
-|                 |                          |              |              |                                          | present, the implementation is required  |
-|                 |                          |              |              |                                          | to ignore the ``PollingLocation``        |
-|                 |                          |              |              |                                          | element containing it.                   |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions      | ``xs:string``            | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                 |                          |              |              | locating the polling location.           | present, then the implementation is      |
-|                 |                          |              |              |                                          | required to ignore it.                   |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours           | ``xs:string``            | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                 |                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                 |                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                 |                          |              |              | the more structured                      |                                          |
-|                 |                          |              |              | :ref:`multi-csv-hours-open` element. It  |                                          |
-|                 |                          |              |              | is strongly encouraged that data         |                                          |
-|                 |                          |              |              | providers move toward contributing hours |                                          |
-|                 |                          |              |              | in this format).                         |                                          |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id   | ``xs:IDREF``             | Optional     | Single       | Links to an :ref:`multi-csv-hours-open`  | If the field is invalid or not present,  |
-|                 |                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                 |                          |              |              | and hours during which the polling       | ignore it.                               |
-|                 |                          |              |              | location is available.                   |                                          |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_drop_box     | ``xs:boolean``           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                 |                          |              |              | drop box.                                | then the implementation is required to   |
-|                 |                          |              |              |                                          | ignore it.                               |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_early_voting | ``xs:boolean``           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                 |                          |              |              | early vote site.                         | then the implementation is required to   |
-|                 |                          |              |              |                                          | ignore it.                               |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_lng         | :ref:`multi-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                 |                          |              |              | this polling location.                   | present, then the implementation is      |
-|                 |                          |              |              |                                          | required to ignore it.                   |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name            | ``xs:string``            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                 |                          |              |              |                                          | then the implementation is required to   |
-|                 |                          |              |              |                                          | ignore it.                               |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| photo_uri       | ``xs:string``            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                 |                          |              |              | polling location.                        | then the implementation is required to   |
-|                 |                          |              |              |                                          | ignore it.                               |
-+-----------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                                  | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================================+==========================+==============+==============+==========================================+==========================================+
+| :ref:`multi-csv-simple-address-type` | ``hold``                 | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+|                                      |                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
+|                                      |                          |              |              |                                          | Location. If none is present, the        |
+|                                      |                          |              |              |                                          | implementation is required to ignore the |
+|                                      |                          |              |              |                                          | ``PollingLocation`` element containing   |
+|                                      |                          |              |              |                                          | it.                                      |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| address_line                         | ``xs:string``            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                                      |                          |              |              | address to a polling location.           | should be present for a given Polling    |
+|                                      |                          |              |              |                                          | Location. If none is present, the        |
+|                                      |                          |              |              |                                          | implementation is required to ignore the |
+|                                      |                          |              |              |                                          | ``PollingLocation`` element containing   |
+|                                      |                          |              |              |                                          | it.                                      |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions                           | ``xs:string``            | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                                      |                          |              |              | locating the polling location.           | present, then the implementation is      |
+|                                      |                          |              |              |                                          | required to ignore it.                   |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours                                | ``xs:string``            | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                                      |                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                                      |                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                                      |                          |              |              | the more structured                      |                                          |
+|                                      |                          |              |              | :ref:`multi-csv-hours-open` element. It  |                                          |
+|                                      |                          |              |              | is strongly encouraged that data         |                                          |
+|                                      |                          |              |              | providers move toward contributing hours |                                          |
+|                                      |                          |              |              | in this format).                         |                                          |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id                        | ``xs:IDREF``             | Optional     | Single       | Links to an :ref:`multi-csv-hours-open`  | If the field is invalid or not present,  |
+|                                      |                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                                      |                          |              |              | and hours during which the polling       | ignore it.                               |
+|                                      |                          |              |              | location is available.                   |                                          |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_drop_box                          | ``xs:boolean``           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                                      |                          |              |              | drop box.                                | then the implementation is required to   |
+|                                      |                          |              |              |                                          | ignore it.                               |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_early_voting                      | ``xs:boolean``           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                                      |                          |              |              | early vote site.                         | then the implementation is required to   |
+|                                      |                          |              |              |                                          | ignore it.                               |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_lng                              | :ref:`multi-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                                      |                          |              |              | this polling location.                   | present, then the implementation is      |
+|                                      |                          |              |              |                                          | required to ignore it.                   |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                                 | ``xs:string``            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                                      |                          |              |              |                                          | then the implementation is required to   |
+|                                      |                          |              |              |                                          | ignore it.                               |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| photo_uri                            | ``xs:string``            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                                      |                          |              |              | polling location.                        | then the implementation is required to   |
+|                                      |                          |              |              |                                          | ignore it.                               |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,name,address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
     poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
     poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
@@ -89,3 +96,44 @@ latitude and longitude values are measured in decimal degrees.
 |               |               |              |              | example, this could be the name of a     | ignore it.                               |
 |               |               |              |              | geocoding service.                       |                                          |
 +---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _multi-csv-simple-address-type:
+
+simple_address_type
+-------------------
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+===============+==============+==============+==========================================+==========================================+
+| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|                          |               |              |              | structured address.                      | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | suffix.                                  |                                          |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -111,6 +111,12 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                   |               |              |              | suffix.                                  |                                          |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -119,7 +125,7 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -24,11 +24,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                                      |                          |              |              |                                          | ``PollingLocation`` element containing   |
 |                                      |                          |              |              |                                          | it.                                      |
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| alias                                | ``xs:string``            | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
-|                                      |                          |              |              | particular voting location. Examples may | present, then the implementation is      |
-|                                      |                          |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
-|                                      |                          |              |              | "Vote Center" and others.                |                                          |
-+--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | directions                           | ``xs:string``            | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                                      |                          |              |              | locating the polling location.           | present, then the implementation is      |
 |                                      |                          |              |              |                                          | required to ignore it.                   |
@@ -72,8 +67,8 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    :linenos:
 
 
-    id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    id,name,address_line,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    poll001,ALBERMARLE HIGH SCHOOL,,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 
 
@@ -108,35 +103,23 @@ simple_address_type
 
 A ``SimpleAddressType`` represents a structured address.
 
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+===============+==============+==============+==========================================+==========================================+
-| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|                          |               |              |              | structured address.                      | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|                          |               |              |              | suffix.                                  |                                          |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|                   |               |              |              | suffix.                                  |                                          |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -24,6 +24,11 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                                      |                          |              |              |                                          | ``PollingLocation`` element containing   |
 |                                      |                          |              |              |                                          | it.                                      |
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| alias                                | ``xs:string``            | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
+|                                      |                          |              |              | particular voting location. Examples may | present, then the implementation is      |
+|                                      |                          |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
+|                                      |                          |              |              | "Vote Center" and others.                |                                          |
++--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | directions                           | ``xs:string``            | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                                      |                          |              |              | locating the polling location.           | present, then the implementation is      |
 |                                      |                          |              |              |                                          | required to ignore it.                   |
@@ -67,7 +72,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    :linenos:
 
 
-    id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
     poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 

--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -10,12 +10,12 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                  | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
 +======================================+==========================+==============+==============+==========================================+==========================================+
-| :ref:`multi-csv-simple-address-type` | ``simple-address-type``  | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
-|                                      |                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
-|                                      |                          |              |              |                                          | Location. If none is present, the        |
-|                                      |                          |              |              |                                          | implementation is required to ignore the |
-|                                      |                          |              |              |                                          | ``PollingLocation`` element containing   |
-|                                      |                          |              |              |                                          | it.                                      |
+| :ref:`multi-csv-simple-address-type` | ``simple-address-type``  | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                                      |                          |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                                      |                          |              |              |                                          | given Polling Location. If none is       |
+|                                      |                          |              |              |                                          | present, the implementation is required  |
+|                                      |                          |              |              |                                          | to ignore the ``PollingLocation``        |
+|                                      |                          |              |              |                                          | element containing it.                   |
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | address_line                         | ``xs:string``            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                                      |                          |              |              | address to a polling location.           | should be present for a given Polling    |
@@ -110,9 +110,9 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              | structured address.                      | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                          |               |              |              | suffix.                                  |                                          |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -123,15 +123,15 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              |                                          | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1196,7 +1196,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
 +=======================================+===========================+==============+==============+==========================================+==========================================+
-| :ref:`single-csv-simple-address-type` | ``hold``                  | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
 |                                       |                           |              |              | of an address to a polling location.     | should be present for a given Polling    |
 |                                       |                           |              |              |                                          | Location. If none is present, the        |
 |                                       |                           |              |              |                                          | implementation is required to ignore the |
@@ -1254,10 +1254,8 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 
 
     id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
-    poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
-    poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
-    poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
+    poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 
 
 .. _single-csv-lat-lng:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1210,11 +1210,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
 |                                       |                           |              |              |                                          | it.                                      |
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| alias                                 | ``xs:string``             | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
-|                                       |                           |              |              | particular voting location. Examples may | present, then the implementation is      |
-|                                       |                           |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
-|                                       |                           |              |              | "Vote Center" and others.                |                                          |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | directions                            | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                                       |                           |              |              | locating the polling location.           | present, then the implementation is      |
 |                                       |                           |              |              |                                          | required to ignore it.                   |
@@ -1258,8 +1253,8 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    :linenos:
 
 
-    id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    id,name,address_line,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    poll001,ALBERMARLE HIGH SCHOOL,,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 
 
@@ -1294,38 +1289,26 @@ simple_address_type
 
 A ``SimpleAddressType`` represents a structured address.
 
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+===============+==============+==============+==========================================+==========================================+
-| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|                          |               |              |              | structured address.                      | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|                          |               |              |              | suffix.                                  |                                          |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|                   |               |              |              | suffix.                                  |                                          |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-locality:
@@ -2772,38 +2755,26 @@ simple_address_type
 
 A ``SimpleAddressType`` represents a structured address.
 
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+===============+==============+==============+==========================================+==========================================+
-| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|                          |               |              |              | structured address.                      | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|                          |               |              |              | suffix.                                  |                                          |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|                          |               |              |              |                                          | then the implementation is required to   |
-|                          |               |              |              |                                          | ignore it.                               |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
-|                          |               |              |              |                                          | implementation should ignore the         |
-|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|                   |               |              |              | suffix.                                  |                                          |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-enumerations:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1193,61 +1193,68 @@ polling_location
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+===========================+==============+==============+==========================================+==========================================+
-| address_line    | ``xs:string``             | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
-|                 |                           |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
-|                 |                           |              |              |                                          | valid. If no valid ``AddressLine`` is    |
-|                 |                           |              |              |                                          | present, the implementation is required  |
-|                 |                           |              |              |                                          | to ignore the ``PollingLocation``        |
-|                 |                           |              |              |                                          | element containing it.                   |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions      | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                 |                           |              |              | locating the polling location.           | present, then the implementation is      |
-|                 |                           |              |              |                                          | required to ignore it.                   |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours           | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                 |                           |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                 |                           |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                 |                           |              |              | the more structured                      |                                          |
-|                 |                           |              |              | :ref:`single-csv-hours-open` element. It |                                          |
-|                 |                           |              |              | is strongly encouraged that data         |                                          |
-|                 |                           |              |              | providers move toward contributing hours |                                          |
-|                 |                           |              |              | in this format).                         |                                          |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id   | ``xs:IDREF``              | Optional     | Single       | Links to an :ref:`single-csv-hours-open` | If the field is invalid or not present,  |
-|                 |                           |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                 |                           |              |              | and hours during which the polling       | ignore it.                               |
-|                 |                           |              |              | location is available.                   |                                          |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_drop_box     | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                 |                           |              |              | drop box.                                | then the implementation is required to   |
-|                 |                           |              |              |                                          | ignore it.                               |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_early_voting | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                 |                           |              |              | early vote site.                         | then the implementation is required to   |
-|                 |                           |              |              |                                          | ignore it.                               |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_lng         | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                 |                           |              |              | this polling location.                   | present, then the implementation is      |
-|                 |                           |              |              |                                          | required to ignore it.                   |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name            | ``xs:string``             | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                 |                           |              |              |                                          | then the implementation is required to   |
-|                 |                           |              |              |                                          | ignore it.                               |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| photo_uri       | ``xs:string``             | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                 |                           |              |              | polling location.                        | then the implementation is required to   |
-|                 |                           |              |              |                                          | ignore it.                               |
-+-----------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
++=======================================+===========================+==============+==============+==========================================+==========================================+
+| :ref:`single-csv-simple-address-type` | ``hold``                  | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+|                                       |                           |              |              | of an address to a polling location.     | should be present for a given Polling    |
+|                                       |                           |              |              |                                          | Location. If none is present, the        |
+|                                       |                           |              |              |                                          | implementation is required to ignore the |
+|                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
+|                                       |                           |              |              |                                          | it.                                      |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| address_line                          | ``xs:string``             | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                                       |                           |              |              | address to a polling location.           | should be present for a given Polling    |
+|                                       |                           |              |              |                                          | Location. If none is present, the        |
+|                                       |                           |              |              |                                          | implementation is required to ignore the |
+|                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
+|                                       |                           |              |              |                                          | it.                                      |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions                            | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                                       |                           |              |              | locating the polling location.           | present, then the implementation is      |
+|                                       |                           |              |              |                                          | required to ignore it.                   |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours                                 | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                                       |                           |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                                       |                           |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                                       |                           |              |              | the more structured                      |                                          |
+|                                       |                           |              |              | :ref:`single-csv-hours-open` element. It |                                          |
+|                                       |                           |              |              | is strongly encouraged that data         |                                          |
+|                                       |                           |              |              | providers move toward contributing hours |                                          |
+|                                       |                           |              |              | in this format).                         |                                          |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id                         | ``xs:IDREF``              | Optional     | Single       | Links to an :ref:`single-csv-hours-open` | If the field is invalid or not present,  |
+|                                       |                           |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                                       |                           |              |              | and hours during which the polling       | ignore it.                               |
+|                                       |                           |              |              | location is available.                   |                                          |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_drop_box                           | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                                       |                           |              |              | drop box.                                | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_early_voting                       | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                                       |                           |              |              | early vote site.                         | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_lng                               | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                                       |                           |              |              | this polling location.                   | present, then the implementation is      |
+|                                       |                           |              |              |                                          | required to ignore it.                   |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                                  | ``xs:string``             | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                                       |                           |              |              |                                          | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| photo_uri                             | ``xs:string``             | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                                       |                           |              |              | polling location.                        | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,name,address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
     poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
     poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
@@ -1275,6 +1282,47 @@ latitude and longitude values are measured in decimal degrees.
 |               |               |              |              | example, this could be the name of a     | ignore it.                               |
 |               |               |              |              | geocoding service.                       |                                          |
 +---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-simple-address-type:
+
+simple_address_type
+^^^^^^^^^^^^^^^^^^^
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+===============+==============+==============+==========================================+==========================================+
+| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|                          |               |              |              | structured address.                      | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | suffix.                                  |                                          |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-locality:
@@ -2712,6 +2760,47 @@ A base model for all ballot selection types:
 |                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
 |                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
 +----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-simple-address-type:
+
+simple_address_type
+~~~~~~~~~~~~~~~~~~~
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+===============+==============+==============+==========================================+==========================================+
+| structured_location_name | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|                          |               |              |              | structured address.                      | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                          |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | suffix.                                  |                                          |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|                          |               |              |              |                                          | then the implementation is required to   |
+|                          |               |              |              |                                          | ignore it.                               |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|                          |               |              |              |                                          | implementation should ignore the         |
+|                          |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-enumerations:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1210,6 +1210,11 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
 |                                       |                           |              |              |                                          | it.                                      |
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| alias                                 | ``xs:string``             | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
+|                                       |                           |              |              | particular voting location. Examples may | present, then the implementation is      |
+|                                       |                           |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
+|                                       |                           |              |              | "Vote Center" and others.                |                                          |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | directions                            | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                                       |                           |              |              | locating the polling location.           | present, then the implementation is      |
 |                                       |                           |              |              |                                          | required to ignore it.                   |
@@ -1253,7 +1258,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    :linenos:
 
 
-    id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
     poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
     poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1196,12 +1196,12 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
 +=======================================+===========================+==============+==============+==========================================+==========================================+
-| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
-|                                       |                           |              |              | of an address to a polling location.     | should be present for a given Polling    |
-|                                       |                           |              |              |                                          | Location. If none is present, the        |
-|                                       |                           |              |              |                                          | implementation is required to ignore the |
-|                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
-|                                       |                           |              |              |                                          | it.                                      |
+| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                                       |                           |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                                       |                           |              |              |                                          | given Polling Location. If none is       |
+|                                       |                           |              |              |                                          | present, the implementation is required  |
+|                                       |                           |              |              |                                          | to ignore the ``PollingLocation``        |
+|                                       |                           |              |              |                                          | element containing it.                   |
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | address_line                          | ``xs:string``             | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                                       |                           |              |              | address to a polling location.           | should be present for a given Polling    |
@@ -1296,9 +1296,9 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              | structured address.                      | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                          |               |              |              | suffix.                                  |                                          |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -1309,15 +1309,15 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              |                                          | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -2774,9 +2774,9 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              | structured address.                      | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| structured_line_1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |                          |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                          |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|                          |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                          |               |              |              | suffix.                                  |                                          |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_line_2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -2787,15 +2787,15 @@ A ``SimpleAddressType`` represents a structured address.
 |                          |               |              |              |                                          | then the implementation is required to   |
 |                          |               |              |              |                                          | ignore it.                               |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| structured_city          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| structured_state         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip           | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| structured_zip           | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |                          |               |              |              |                                          | implementation should ignore the         |
 |                          |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1297,6 +1297,12 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                   |               |              |              | suffix.                                  |                                          |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -1305,7 +1311,7 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -2763,6 +2769,12 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |                   |               |              |              | suffix.                                  |                                          |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -2771,7 +2783,7 @@ A ``SimpleAddressType`` represents a structured address.
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip    | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |                   |               |              |              |                                          | implementation should ignore the         |
 |                   |               |              |              |                                          | ``SimpleAddressType``.                   |
 +-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/polling_location.rst
+++ b/docs/built_rst/tables/elements/polling_location.rst
@@ -17,11 +17,6 @@
 |                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                         |              |              |                                          | it.                                      |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Alias             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
-|                   |                                         |              |              | particular voting location. Examples may | present, then the implementation is      |
-|                   |                                         |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
-|                   |                                         |              |              | "Vote Center" and others.                |                                          |
-+-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                         |              |              |                                          | required to ignore it.                   |

--- a/docs/built_rst/tables/elements/polling_location.rst
+++ b/docs/built_rst/tables/elements/polling_location.rst
@@ -17,6 +17,11 @@
 |                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                         |              |              |                                          | it.                                      |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Alias             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
+|                   |                                         |              |              | particular voting location. Examples may | present, then the implementation is      |
+|                   |                                         |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
+|                   |                                         |              |              | "Vote Center" and others.                |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                         |              |              |                                          | required to ignore it.                   |

--- a/docs/built_rst/tables/elements/polling_location.rst
+++ b/docs/built_rst/tables/elements/polling_location.rst
@@ -3,7 +3,7 @@
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+=========================================+==============+==============+==========================================+==========================================+
-| StructuredAddress | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
 |                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
 |                   |                                         |              |              |                                          | Location. If none is present, the        |
 |                   |                                         |              |              |                                          | implementation is required to ignore the |

--- a/docs/built_rst/tables/elements/polling_location.rst
+++ b/docs/built_rst/tables/elements/polling_location.rst
@@ -3,12 +3,12 @@
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+=========================================+==============+==============+==========================================+==========================================+
-| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
-|                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
-|                   |                                         |              |              |                                          | Location. If none is present, the        |
-|                   |                                         |              |              |                                          | implementation is required to ignore the |
-|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
-|                   |                                         |              |              |                                          | it.                                      |
+| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                   |                                         |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                   |                                         |              |              |                                          | given Polling Location. If none is       |
+|                   |                                         |              |              |                                          | present, the implementation is required  |
+|                   |                                         |              |              |                                          | to ignore the ``PollingLocation``        |
+|                   |                                         |              |              |                                          | element containing it.                   |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | AddressLine       | ``xs:string``                           | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                   |                                         |              |              | address to a polling location.           | should be present for a given Polling    |

--- a/docs/built_rst/tables/elements/polling_location.rst
+++ b/docs/built_rst/tables/elements/polling_location.rst
@@ -1,50 +1,57 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+=========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                           | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
-|                  |                                         |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
-|                  |                                         |              |              |                                          | valid. If no valid ``AddressLine`` is    |
-|                  |                                         |              |              |                                          | present, the implementation is required  |
-|                  |                                         |              |              |                                          | to ignore the ``PollingLocation``        |
-|                  |                                         |              |              |                                          | element containing it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                         |              |              | locating the polling location.           | present, then the implementation is      |
-|                  |                                         |              |              |                                          | required to ignore it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                         |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                  |                                         |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                  |                                         |              |              | the more structured                      |                                          |
-|                  |                                         |              |              | :ref:`multi-xml-hours-open` element. It  |                                          |
-|                  |                                         |              |              | is strongly encouraged that data         |                                          |
-|                  |                                         |              |              | providers move toward contributing hours |                                          |
-|                  |                                         |              |              | in this format).                         |                                          |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                            | Optional     | Single       | Links to an :ref:`multi-xml-hours-open`  | If the field is invalid or not present,  |
-|                  |                                         |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                  |                                         |              |              | and hours during which the polling       | ignore it.                               |
-|                  |                                         |              |              | location is available.                   |                                          |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsDropBox        | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                  |                                         |              |              | drop box.                                | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsEarlyVoting    | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                  |                                         |              |              | early vote site.                         | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`multi-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                         |              |              | this polling location.                   | present, then the implementation is      |
-|                  |                                         |              |              |                                          | required to ignore it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                           | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                  |                                         |              |              |                                          | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PhotoUri         | ``xs:anyURI``                           | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                  |                                         |              |              | polling location.                        | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+=========================================+==============+==============+==========================================+==========================================+
+| StructuredAddress | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+|                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
+|                   |                                         |              |              |                                          | Location. If none is present, the        |
+|                   |                                         |              |              |                                          | implementation is required to ignore the |
+|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                         |              |              |                                          | it.                                      |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AddressLine       | ``xs:string``                           | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                   |                                         |              |              | address to a polling location.           | should be present for a given Polling    |
+|                   |                                         |              |              |                                          | Location. If none is present, the        |
+|                   |                                         |              |              |                                          | implementation is required to ignore the |
+|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                         |              |              |                                          | it.                                      |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
+|                   |                                         |              |              |                                          | required to ignore it.                   |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**  |                                         |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                   |                                         |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                   |                                         |              |              | the more structured                      |                                          |
+|                   |                                         |              |              | :ref:`multi-xml-hours-open` element. It  |                                          |
+|                   |                                         |              |              | is strongly encouraged that data         |                                          |
+|                   |                                         |              |              | providers move toward contributing hours |                                          |
+|                   |                                         |              |              | in this format).                         |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId       | ``xs:IDREF``                            | Optional     | Single       | Links to an :ref:`multi-xml-hours-open`  | If the field is invalid or not present,  |
+|                   |                                         |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                   |                                         |              |              | and hours during which the polling       | ignore it.                               |
+|                   |                                         |              |              | location is available.                   |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsDropBox         | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                   |                                         |              |              | drop box.                                | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsEarlyVoting     | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                   |                                         |              |              | early vote site.                         | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng            | :ref:`multi-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                   |                                         |              |              | this polling location.                   | present, then the implementation is      |
+|                   |                                         |              |              |                                          | required to ignore it.                   |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name              | ``xs:string``                           | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                   |                                         |              |              |                                          | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PhotoUri          | ``xs:anyURI``                           | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                   |                                         |              |              | polling location.                        | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/simple_address_type.rst
+++ b/docs/built_rst/tables/elements/simple_address_type.rst
@@ -7,9 +7,9 @@
 |              |               |              |              | structured address.                      | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -20,15 +20,15 @@
 |              |               |              |              |                                          | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/simple_address_type.rst
+++ b/docs/built_rst/tables/elements/simple_address_type.rst
@@ -8,6 +8,12 @@
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -16,7 +22,7 @@
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/simple_address_type.rst
+++ b/docs/built_rst/tables/elements/simple_address_type.rst
@@ -1,0 +1,34 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|              |               |              |              | structured address.                      | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/simple_address_type.rst
+++ b/docs/built_rst/tables/elements/simple_address_type.rst
@@ -3,32 +3,20 @@
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
 +==============+===============+==============+==============+==========================================+==========================================+
-| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|              |               |              |              | structured address.                      | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -24,6 +24,11 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                         |              |              |                                          | it.                                      |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Alias             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
+|                   |                                         |              |              | particular voting location. Examples may | present, then the implementation is      |
+|                   |                                         |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
+|                   |                                         |              |              | "Vote Center" and others.                |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                         |              |              |                                          | required to ignore it.                   |
@@ -79,6 +84,9 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
+      <Alias>
+        <Text language="en">Vote Center</Text>
+      </Alias>
       <AddressStructured>
          <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -10,12 +10,12 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+=========================================+==============+==============+==========================================+==========================================+
-| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
-|                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
-|                   |                                         |              |              |                                          | Location. If none is present, the        |
-|                   |                                         |              |              |                                          | implementation is required to ignore the |
-|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
-|                   |                                         |              |              |                                          | it.                                      |
+| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                   |                                         |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                   |                                         |              |              |                                          | given Polling Location. If none is       |
+|                   |                                         |              |              |                                          | present, the implementation is required  |
+|                   |                                         |              |              |                                          | to ignore the ``PollingLocation``        |
+|                   |                                         |              |              |                                          | element containing it.                   |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | AddressLine       | ``xs:string``                           | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                   |                                         |              |              | address to a polling location.           | should be present for a given Polling    |
@@ -134,9 +134,9 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | structured address.                      | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -147,15 +147,15 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -7,54 +7,93 @@ PollingLocation
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+=========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                           | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
-|                  |                                         |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
-|                  |                                         |              |              |                                          | valid. If no valid ``AddressLine`` is    |
-|                  |                                         |              |              |                                          | present, the implementation is required  |
-|                  |                                         |              |              |                                          | to ignore the ``PollingLocation``        |
-|                  |                                         |              |              |                                          | element containing it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                         |              |              | locating the polling location.           | present, then the implementation is      |
-|                  |                                         |              |              |                                          | required to ignore it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                         |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                  |                                         |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                  |                                         |              |              | the more structured                      |                                          |
-|                  |                                         |              |              | :ref:`multi-xml-hours-open` element. It  |                                          |
-|                  |                                         |              |              | is strongly encouraged that data         |                                          |
-|                  |                                         |              |              | providers move toward contributing hours |                                          |
-|                  |                                         |              |              | in this format).                         |                                          |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                            | Optional     | Single       | Links to an :ref:`multi-xml-hours-open`  | If the field is invalid or not present,  |
-|                  |                                         |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                  |                                         |              |              | and hours during which the polling       | ignore it.                               |
-|                  |                                         |              |              | location is available.                   |                                          |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsDropBox        | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                  |                                         |              |              | drop box.                                | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsEarlyVoting    | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                  |                                         |              |              | early vote site.                         | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`multi-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                         |              |              | this polling location.                   | present, then the implementation is      |
-|                  |                                         |              |              |                                          | required to ignore it.                   |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                           | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                  |                                         |              |              |                                          | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PhotoUri         | ``xs:anyURI``                           | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                  |                                         |              |              | polling location.                        | then the implementation is required to   |
-|                  |                                         |              |              |                                          | ignore it.                               |
-+------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+=========================================+==============+==============+==========================================+==========================================+
+| StructuredAddress | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+|                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
+|                   |                                         |              |              |                                          | Location. If none is present, the        |
+|                   |                                         |              |              |                                          | implementation is required to ignore the |
+|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                         |              |              |                                          | it.                                      |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AddressLine       | ``xs:string``                           | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                   |                                         |              |              | address to a polling location.           | should be present for a given Polling    |
+|                   |                                         |              |              |                                          | Location. If none is present, the        |
+|                   |                                         |              |              |                                          | implementation is required to ignore the |
+|                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                         |              |              |                                          | it.                                      |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
+|                   |                                         |              |              |                                          | required to ignore it.                   |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**  |                                         |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                   |                                         |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                   |                                         |              |              | the more structured                      |                                          |
+|                   |                                         |              |              | :ref:`multi-xml-hours-open` element. It  |                                          |
+|                   |                                         |              |              | is strongly encouraged that data         |                                          |
+|                   |                                         |              |              | providers move toward contributing hours |                                          |
+|                   |                                         |              |              | in this format).                         |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId       | ``xs:IDREF``                            | Optional     | Single       | Links to an :ref:`multi-xml-hours-open`  | If the field is invalid or not present,  |
+|                   |                                         |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                   |                                         |              |              | and hours during which the polling       | ignore it.                               |
+|                   |                                         |              |              | location is available.                   |                                          |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsDropBox         | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                   |                                         |              |              | drop box.                                | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsEarlyVoting     | ``xs:boolean``                          | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                   |                                         |              |              | early vote site.                         | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng            | :ref:`multi-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                   |                                         |              |              | this polling location.                   | present, then the implementation is      |
+|                   |                                         |              |              |                                          | required to ignore it.                   |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name              | ``xs:string``                           | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                   |                                         |              |              |                                          | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PhotoUri          | ``xs:anyURI``                           | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                   |                                         |              |              | polling location.                        | then the implementation is required to   |
+|                   |                                         |              |              |                                          | ignore it.                               |
++-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <PollingLocation id="pl00000">
+      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
+   </PollingLocation>
+   <!-- Or: -->
+   <PollingLocation id="pl00000">
+      <StructuredAddress>
+         <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
+         <Line1>2775 Hydraulic Rd</Line1>
+         <City>CHARLOTTESVILLE</City>
+         <State>VA</State>
+         <Zip>22901</Zip>
+      </StructuredAddress>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+   </PollingLocation>
 
 
 .. _multi-xml-lat-lng:
@@ -80,19 +119,43 @@ latitude and longitude values are measured in decimal degrees.
 |              |               |              |              | geocoding service.                       |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
-.. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
 
-.. code-block:: xml
-   :linenos:
+.. _multi-xml-simple-address-type:
 
-   <PollingLocation id="pl81274">
-      <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
-      <AddressLine>2775 Hydraulic Rd</AddressLine>
-      <AddressLine>Charlottesville, VA 229018917</AddressLine>
-      <HoursOpenId>hours0001</HoursOpenId>
-      <LatLng>
-        <Latitude>38.0754627</Latitude>
-        <Longitude>-78.5014875</Longitude>
-        <Source>Google Maps</Source>
-      </LatLng>
-   </PollingLocation>
+SimpleAddressType
+-----------------
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|              |               |              |              | structured address.                      | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -135,6 +135,12 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -143,7 +149,7 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -24,11 +24,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                   |                                         |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                         |              |              |                                          | it.                                      |
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Alias             | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
-|                   |                                         |              |              | particular voting location. Examples may | present, then the implementation is      |
-|                   |                                         |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
-|                   |                                         |              |              | "Vote Center" and others.                |                                          |
-+-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                         |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                         |              |              |                                          | required to ignore it.                   |
@@ -84,11 +79,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
-      <Alias>
-        <Text language="en">Vote Center</Text>
-      </Alias>
       <AddressStructured>
-         <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>
          <City>CHARLOTTESVILLE</City>
          <State>VA</State>
@@ -101,6 +92,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
          <Latitude>38.009939</Latitude>
          <Longitude>-78.506204</Longitude>
       </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
    </PollingLocation>
 
 
@@ -138,32 +130,20 @@ A ``SimpleAddressType`` represents a structured address.
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
 +==============+===============+==============+==============+==========================================+==========================================+
-| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|              |               |              |              | structured address.                      | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/polling_location.rst
+++ b/docs/built_rst/xml/elements/polling_location.rst
@@ -10,7 +10,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +-------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+=========================================+==============+==============+==========================================+==========================================+
-| StructuredAddress | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+| AddressStructured | :ref:`multi-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
 |                   |                                         |              |              | of an address to a polling location.     | should be present for a given Polling    |
 |                   |                                         |              |              |                                          | Location. If none is present, the        |
 |                   |                                         |              |              |                                          | implementation is required to ignore the |
@@ -79,13 +79,13 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
-      <StructuredAddress>
+      <AddressStructured>
          <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>
          <City>CHARLOTTESVILLE</City>
          <State>VA</State>
          <Zip>22901</Zip>
-      </StructuredAddress>
+      </AddressStructured>
       <HoursOpenId>hours0002</HoursOpenId>
       <IsDropBox>true</IsDropBox>
       <IsEarlyVoting>true</IsEarlyVoting>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1342,23 +1342,6 @@ latitude and longitude values are measured in decimal degrees.
 |              |               |              |              | geocoding service.                       |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
-.. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
-
-.. code-block:: xml
-   :linenos:
-
-   <PollingLocation id="pl81274">
-      <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
-      <AddressLine>2775 Hydraulic Rd</AddressLine>
-      <AddressLine>Charlottesville, VA 229018917</AddressLine>
-      <HoursOpenId>hours0001</HoursOpenId>
-      <LatLng>
-        <Latitude>38.0754627</Latitude>
-        <Longitude>-78.5014875</Longitude>
-        <Source>Google Maps</Source>
-      </LatLng>
-   </PollingLocation>
-
 
 .. _single-xml-candidate:
 
@@ -1438,54 +1421,93 @@ PollingLocation
 
 The PollingLocation object represents a site where voters cast or drop off ballots.
 
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+==========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                            | **Required** | Repeats      | Represents the various parts of an       | At least one valid ``AddressLine`` must  |
-|                  |                                          |              |              | address to a polling location.           | be present for ``PollingLocation`` to be |
-|                  |                                          |              |              |                                          | valid. If no valid ``AddressLine`` is    |
-|                  |                                          |              |              |                                          | present, the implementation is required  |
-|                  |                                          |              |              |                                          | to ignore the ``PollingLocation``        |
-|                  |                                          |              |              |                                          | element containing it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                          |              |              | locating the polling location.           | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                  |                                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                  |                                          |              |              | the more structured                      |                                          |
-|                  |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
-|                  |                                          |              |              | is strongly encouraged that data         |                                          |
-|                  |                                          |              |              | providers move toward contributing hours |                                          |
-|                  |                                          |              |              | in this format).                         |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | Links to an :ref:`single-xml-hours-open` | If the field is invalid or not present,  |
-|                  |                                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                  |                                          |              |              | and hours during which the polling       | ignore it.                               |
-|                  |                                          |              |              | location is available.                   |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsDropBox        | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                  |                                          |              |              | drop box.                                | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsEarlyVoting    | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                  |                                          |              |              | early vote site.                         | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                          |              |              | this polling location.                   | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PhotoUri         | ``xs:anyURI``                            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                  |                                          |              |              | polling location.                        | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+==========================================+==============+==============+==========================================+==========================================+
+| StructuredAddress | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+|                   |                                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
+|                   |                                          |              |              |                                          | Location. If none is present, the        |
+|                   |                                          |              |              |                                          | implementation is required to ignore the |
+|                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                          |              |              |                                          | it.                                      |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AddressLine       | ``xs:string``                            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                   |                                          |              |              | address to a polling location.           | should be present for a given Polling    |
+|                   |                                          |              |              |                                          | Location. If none is present, the        |
+|                   |                                          |              |              |                                          | implementation is required to ignore the |
+|                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                          |              |              |                                          | it.                                      |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions        | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                   |                                          |              |              | locating the polling location.           | present, then the implementation is      |
+|                   |                                          |              |              |                                          | required to ignore it.                   |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**  |                                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                   |                                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                   |                                          |              |              | the more structured                      |                                          |
+|                   |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
+|                   |                                          |              |              | is strongly encouraged that data         |                                          |
+|                   |                                          |              |              | providers move toward contributing hours |                                          |
+|                   |                                          |              |              | in this format).                         |                                          |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId       | ``xs:IDREF``                             | Optional     | Single       | Links to an :ref:`single-xml-hours-open` | If the field is invalid or not present,  |
+|                   |                                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                   |                                          |              |              | and hours during which the polling       | ignore it.                               |
+|                   |                                          |              |              | location is available.                   |                                          |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsDropBox         | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                   |                                          |              |              | drop box.                                | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsEarlyVoting     | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                   |                                          |              |              | early vote site.                         | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng            | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                   |                                          |              |              | this polling location.                   | present, then the implementation is      |
+|                   |                                          |              |              |                                          | required to ignore it.                   |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name              | ``xs:string``                            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                   |                                          |              |              |                                          | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PhotoUri          | ``xs:anyURI``                            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                   |                                          |              |              | polling location.                        | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <PollingLocation id="pl00000">
+      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
+   </PollingLocation>
+   <!-- Or: -->
+   <PollingLocation id="pl00000">
+      <StructuredAddress>
+         <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
+         <Line1>2775 Hydraulic Rd</Line1>
+         <City>CHARLOTTESVILLE</City>
+         <State>VA</State>
+         <Zip>22901</Zip>
+      </StructuredAddress>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+   </PollingLocation>
 
 
 .. _single-xml-lat-lng:
@@ -1511,22 +1533,46 @@ latitude and longitude values are measured in decimal degrees.
 |              |               |              |              | geocoding service.                       |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
-.. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
 
-.. code-block:: xml
-   :linenos:
+.. _single-xml-simple-address-type:
 
-   <PollingLocation id="pl81274">
-      <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
-      <AddressLine>2775 Hydraulic Rd</AddressLine>
-      <AddressLine>Charlottesville, VA 229018917</AddressLine>
-      <HoursOpenId>hours0001</HoursOpenId>
-      <LatLng>
-        <Latitude>38.0754627</Latitude>
-        <Longitude>-78.5014875</Longitude>
-        <Source>Google Maps</Source>
-      </LatLng>
-   </PollingLocation>
+SimpleAddressType
+^^^^^^^^^^^^^^^^^
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|              |               |              |              | structured address.                      | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-xml-locality:
@@ -3119,6 +3165,47 @@ A base model for all ballot selection types:
 |               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
 |               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
 +---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-simple-address-type:
+
+SimpleAddressType
+~~~~~~~~~~~~~~~~~
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
+|              |               |              |              | structured address.                      | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
+|              |               |              |              |                                          | then the implementation is required to   |
+|              |               |              |              |                                          | ignore it.                               |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-xml-enumerations:

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1424,7 +1424,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+==========================================+==============+==============+==========================================+==========================================+
-| StructuredAddress | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
+| AddressStructured | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
 |                   |                                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
 |                   |                                          |              |              |                                          | Location. If none is present, the        |
 |                   |                                          |              |              |                                          | implementation is required to ignore the |
@@ -1493,13 +1493,13 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
-      <StructuredAddress>
+      <AddressStructured>
          <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>
          <City>CHARLOTTESVILLE</City>
          <State>VA</State>
          <Zip>22901</Zip>
-      </StructuredAddress>
+      </AddressStructured>
       <HoursOpenId>hours0002</HoursOpenId>
       <IsDropBox>true</IsDropBox>
       <IsEarlyVoting>true</IsEarlyVoting>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1424,12 +1424,12 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag               | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
 +===================+==========================================+==============+==============+==========================================+==========================================+
-| AddressStructured | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of AddressStructured and AddressLine |
-|                   |                                          |              |              | of an address to a polling location.     | should be present for a given Polling    |
-|                   |                                          |              |              |                                          | Location. If none is present, the        |
-|                   |                                          |              |              |                                          | implementation is required to ignore the |
-|                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
-|                   |                                          |              |              |                                          | it.                                      |
+| AddressStructured | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                   |                                          |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                   |                                          |              |              |                                          | given Polling Location. If none is       |
+|                   |                                          |              |              |                                          | present, the implementation is required  |
+|                   |                                          |              |              |                                          | to ignore the ``PollingLocation``        |
+|                   |                                          |              |              |                                          | element containing it.                   |
 +-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | AddressLine       | ``xs:string``                            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                   |                                          |              |              | address to a polling location.           | should be present for a given Polling    |
@@ -1548,9 +1548,9 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | structured address.                      | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -1561,15 +1561,15 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -3181,9 +3181,9 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | structured address.                      | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line1        | ``xs:string`` | Optional     | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, stree name, and any prefix and   | ``SimpleAddressType``.                   |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
@@ -3194,15 +3194,15 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | then the implementation is required to   |
 |              |               |              |              |                                          | ignore it.                               |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``City`` is not provided, the      |
+| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``State`` is not provided, the     |
+| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | TBD                                      | If no ``Zip`` is not provided, the       |
+| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1438,6 +1438,11 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                          |              |              |                                          | it.                                      |
 +-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Alias             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
+|                   |                                          |              |              | particular voting location. Examples may | present, then the implementation is      |
+|                   |                                          |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
+|                   |                                          |              |              | "Vote Center" and others.                |                                          |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                          |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                          |              |              |                                          | required to ignore it.                   |
@@ -1493,6 +1498,9 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
+      <Alias>
+        <Text language="en">Vote Center</Text>
+      </Alias>
       <AddressStructured>
          <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1438,11 +1438,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 |                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
 |                   |                                          |              |              |                                          | it.                                      |
 +-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Alias             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the term used to describe the  | If the element is invalid or not         |
-|                   |                                          |              |              | particular voting location. Examples may | present, then the implementation is      |
-|                   |                                          |              |              | include "VSPC", "Mail in absentee",      | required to ignore it.                   |
-|                   |                                          |              |              | "Vote Center" and others.                |                                          |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Directions        | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
 |                   |                                          |              |              | locating the polling location.           | present, then the implementation is      |
 |                   |                                          |              |              |                                          | required to ignore it.                   |
@@ -1498,11 +1493,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
    </PollingLocation>
    <!-- Or: -->
    <PollingLocation id="pl00000">
-      <Alias>
-        <Text language="en">Vote Center</Text>
-      </Alias>
       <AddressStructured>
-         <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
          <Line1>2775 Hydraulic Rd</Line1>
          <City>CHARLOTTESVILLE</City>
          <State>VA</State>
@@ -1515,6 +1506,7 @@ The PollingLocation object represents a site where voters cast or drop off ballo
          <Latitude>38.009939</Latitude>
          <Longitude>-78.506204</Longitude>
       </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
    </PollingLocation>
 
 
@@ -1552,32 +1544,20 @@ A ``SimpleAddressType`` represents a structured address.
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
 +==============+===============+==============+==============+==========================================+==========================================+
-| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|              |               |              |              | structured address.                      | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -3185,32 +3165,20 @@ A ``SimpleAddressType`` represents a structured address.
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
 +==============+===============+==============+==============+==========================================+==========================================+
-| LocationName | ``xs:string`` | Optional     | Single       | The name of the building a part of the   | If the field is invalid or not present,  |
-|              |               |              |              | structured address.                      | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
 |              |               |              |              | address. Should include the street       | implementation should ignore the         |
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | TBD                                      | If the field is invalid or not present,  |
-|              |               |              |              |                                          | then the implementation is required to   |
-|              |               |              |              |                                          | ignore it.                               |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | TBD                                      | If ``City`` is not provided, the         |
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | TBD                                      | If ``State`` is not provided, the        |
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | TBD                                      | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1549,6 +1549,12 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -1557,7 +1563,7 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -3170,6 +3176,12 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
 |              |               |              |              | suffix.                                  |                                          |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
@@ -3178,7 +3190,7 @@ A ``SimpleAddressType`` represents a structured address.
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | **Required** | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
 |              |               |              |              |                                          | implementation should ignore the         |
 |              |               |              |              |                                          | ``SimpleAddressType``.                   |
 +--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/yaml/elements/lat_lng.yaml
+++ b/docs/yaml/elements/lat_lng.yaml
@@ -3,23 +3,6 @@ csv-header-name: lat_long
 description: |-
   The latitude and longitude of a polling location in `WGS 84`_ format. Both
   latitude and longitude values are measured in decimal degrees.
-post: |-
-  .. _`WGS 84`: http://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84
-
-  .. code-block:: xml
-     :linenos:
-
-     <PollingLocation id="pl81274">
-        <AddressLine>ALBEMARLE HIGH SCHOOL</AddressLine>
-        <AddressLine>2775 Hydraulic Rd</AddressLine>
-        <AddressLine>Charlottesville, VA 229018917</AddressLine>
-        <HoursOpenId>hours0001</HoursOpenId>
-        <LatLng>
-          <Latitude>38.0754627</Latitude>
-          <Longitude>-78.5014875</Longitude>
-          <Source>Google Maps</Source>
-        </LatLng>
-     </PollingLocation>
 tags:
 - _name: Latitude
   csv-header-name: latitude

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -6,10 +6,8 @@ csv-post: |-
 
 
       id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-      poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
-      poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
-      poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
-      poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
+      poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+      poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 description: The PollingLocation object represents a site where voters cast or drop
   off ballots.
 extends:
@@ -50,7 +48,7 @@ post: |-
 tags:
 - _name: AddressStructured
   csv-header-name: :ref:`$$$-simple-address-type`
-  csv-type: hold
+  csv-type: simple-address-type
   description: Represents the various structured parts of an address to a polling
     location.
   error: One of AddressStructured and AddressLine should be present for a given Polling

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -51,9 +51,9 @@ tags:
   csv-type: simple-address-type
   description: Represents the various structured parts of an address to a polling
     location.
-  error: One of AddressStructured and AddressLine should be present for a given Polling
-    Location. If none is present, the implementation is required to ignore the ``PollingLocation``
-    element containing it.
+  error: One of **AddressStructured** and **AddressLine** should be present for a
+    given Polling Location. If none is present, the implementation is required to
+    ignore the ``PollingLocation`` element containing it.
   repeating: false
   required: false
   type: SimpleAddressType

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -19,35 +19,34 @@ post: |-
   .. code-block:: xml
      :linenos:
 
-
      <PollingLocation id="pl00000">
-      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
-      <HoursOpenId>hours0002</HoursOpenId>
-      <IsDropBox>true</IsDropBox>
-      <IsEarlyVoting>true</IsEarlyVoting>
-      <LatLng>
-        <Latitude>38.009939</Latitude>
-        <Longitude>-78.506204</Longitude>
-      </LatLng>
-      <Name>ALBERMARLE HIGH SCHOOL</Name>
-    </PollingLocation>
-    <!-- Or: -->
-    <PollingLocation id="pl00000">
-      <StructuredAddress>
-        <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
-        <Line1>2775 Hydraulic Rd</Line1>
-        <City>CHARLOTTESVILLE</City>
-        <State>VA</State>
-        <Zip>22901</Zip>
-      </StructuredAddress>
-      <HoursOpenId>hours0002</HoursOpenId>
-      <IsDropBox>true</IsDropBox>
-      <IsEarlyVoting>true</IsEarlyVoting>
+        <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
+        <HoursOpenId>hours0002</HoursOpenId>
+        <IsDropBox>true</IsDropBox>
+        <IsEarlyVoting>true</IsEarlyVoting>
         <LatLng>
-          <Latitude>38.009939</Latitude>
-          <Longitude>-78.506204</Longitude>
-      </LatLng>
-    </PollingLocation>
+           <Latitude>38.009939</Latitude>
+           <Longitude>-78.506204</Longitude>
+        </LatLng>
+        <Name>ALBERMARLE HIGH SCHOOL</Name>
+     </PollingLocation>
+     <!-- Or: -->
+     <PollingLocation id="pl00000">
+        <StructuredAddress>
+           <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
+           <Line1>2775 Hydraulic Rd</Line1>
+           <City>CHARLOTTESVILLE</City>
+           <State>VA</State>
+           <Zip>22901</Zip>
+        </StructuredAddress>
+        <HoursOpenId>hours0002</HoursOpenId>
+        <IsDropBox>true</IsDropBox>
+        <IsEarlyVoting>true</IsEarlyVoting>
+        <LatLng>
+           <Latitude>38.009939</Latitude>
+           <Longitude>-78.506204</Longitude>
+        </LatLng>
+     </PollingLocation>
 tags:
 - _name: StructuredAddress
   csv-header-name: :ref:`$$$-simple-address-type`

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -5,7 +5,7 @@ csv-post: |-
      :linenos:
 
 
-      id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+      id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
       poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
       poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 description: The PollingLocation object represents a site where voters cast or drop
@@ -30,6 +30,9 @@ post: |-
      </PollingLocation>
      <!-- Or: -->
      <PollingLocation id="pl00000">
+        <Alias>
+          <Text language="en">Vote Center</Text>
+        </Alias>
         <AddressStructured>
            <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
            <Line1>2775 Hydraulic Rd</Line1>
@@ -67,6 +70,13 @@ tags:
   repeating: true
   required: false
   type: xs:string
+- _name: Alias
+  csv-header-name: alias
+  csv-type: xs:string
+  description: Specifies the term used to describe the particular voting location.
+    Examples may include "VSPC", "Mail in absentee", "Vote Center" and others.
+  error_then: =must-ignore
+  type: InternationalizedText
 - _name: Directions
   csv-header-name: directions
   csv-type: xs:string

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -32,13 +32,13 @@ post: |-
      </PollingLocation>
      <!-- Or: -->
      <PollingLocation id="pl00000">
-        <StructuredAddress>
+        <AddressStructured>
            <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
            <Line1>2775 Hydraulic Rd</Line1>
            <City>CHARLOTTESVILLE</City>
            <State>VA</State>
            <Zip>22901</Zip>
-        </StructuredAddress>
+        </AddressStructured>
         <HoursOpenId>hours0002</HoursOpenId>
         <IsDropBox>true</IsDropBox>
         <IsEarlyVoting>true</IsEarlyVoting>
@@ -48,7 +48,7 @@ post: |-
         </LatLng>
      </PollingLocation>
 tags:
-- _name: StructuredAddress
+- _name: AddressStructured
   csv-header-name: :ref:`$$$-simple-address-type`
   csv-type: hold
   description: Represents the various structured parts of an address to a polling

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -14,16 +14,28 @@ description: The PollingLocation object represents a site where voters cast or d
   off ballots.
 extends:
 - LatLng
+- SimpleAddressType
 tags:
+- _name: StructuredAddress
+  csv-header-name: :ref:`$$$-simple-address-type`
+  csv-type: hold
+  description: Represents the various structured parts of an address to a polling
+    location.
+  error: One of AddressStructured and AddressLine should be present for a given Polling
+    Location. If none is present, the implementation is required to ignore the ``PollingLocation``
+    element containing it.
+  repeating: false
+  required: false
+  type: SimpleAddressType
 - _name: AddressLine
   csv-header-name: address_line
   csv-type: xs:string
   description: Represents the various parts of an address to a polling location.
-  error: At least one valid ``AddressLine`` must be present for ``PollingLocation``
-    to be valid. If no valid ``AddressLine`` is present, the implementation is required
-    to ignore the ``PollingLocation`` element containing it.
+  error: One of AddressStructured and AddressLine should be present for a given Polling
+    Location. If none is present, the implementation is required to ignore the ``PollingLocation``
+    element containing it.
   repeating: true
-  required: true
+  required: false
   type: xs:string
 - _name: Directions
   csv-header-name: directions

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -5,8 +5,8 @@ csv-post: |-
      :linenos:
 
 
-      id,name,alias,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-      poll001,,,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+      id,name,address_line,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+      poll001,ALBERMARLE HIGH SCHOOL,,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
       poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
 description: The PollingLocation object represents a site where voters cast or drop
   off ballots.
@@ -30,11 +30,7 @@ post: |-
      </PollingLocation>
      <!-- Or: -->
      <PollingLocation id="pl00000">
-        <Alias>
-          <Text language="en">Vote Center</Text>
-        </Alias>
         <AddressStructured>
-           <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
            <Line1>2775 Hydraulic Rd</Line1>
            <City>CHARLOTTESVILLE</City>
            <State>VA</State>
@@ -47,6 +43,7 @@ post: |-
            <Latitude>38.009939</Latitude>
            <Longitude>-78.506204</Longitude>
         </LatLng>
+        <Name>ALBERMARLE HIGH SCHOOL</Name>
      </PollingLocation>
 tags:
 - _name: AddressStructured
@@ -70,13 +67,6 @@ tags:
   repeating: true
   required: false
   type: xs:string
-- _name: Alias
-  csv-header-name: alias
-  csv-type: xs:string
-  description: Specifies the term used to describe the particular voting location.
-    Examples may include "VSPC", "Mail in absentee", "Vote Center" and others.
-  error_then: =must-ignore
-  type: InternationalizedText
 - _name: Directions
   csv-header-name: directions
   csv-type: xs:string

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -5,8 +5,8 @@ csv-post: |-
      :linenos:
 
 
-      id,name,address_line,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-      poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+      id,name,address_line,structured_location_name,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+      poll001,ALBERMARLE HIGH SCHOOL","2775 Hydraulic Rd Charlottesville, VA 22901,ALBERMARLE HIGH SCHOOL,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
       poll002,Public Library, Main St Denver,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
       poll003,Historic Society,,wheelchair entrance,7am-8pm,www.picture.com,,false,true,,,
       poll004,Community Center,,behind the big oak tree,7am-8pm,www.picture.com,,false,true,,,
@@ -15,6 +15,39 @@ description: The PollingLocation object represents a site where voters cast or d
 extends:
 - LatLng
 - SimpleAddressType
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+
+     <PollingLocation id="pl00000">
+      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+        <Latitude>38.009939</Latitude>
+        <Longitude>-78.506204</Longitude>
+      </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
+    </PollingLocation>
+    <!-- Or: -->
+    <PollingLocation id="pl00000">
+      <StructuredAddress>
+        <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
+        <Line1>2775 Hydraulic Rd</Line1>
+        <City>CHARLOTTESVILLE</City>
+        <State>VA</State>
+        <Zip>22901</Zip>
+      </StructuredAddress>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+        <LatLng>
+          <Latitude>38.009939</Latitude>
+          <Longitude>-78.506204</Longitude>
+      </LatLng>
+    </PollingLocation>
 tags:
 - _name: StructuredAddress
   csv-header-name: :ref:`$$$-simple-address-type`

--- a/docs/yaml/elements/simple_address_type.yaml
+++ b/docs/yaml/elements/simple_address_type.yaml
@@ -11,6 +11,20 @@ tags:
   repreating: false
   required: true
   type: xs:string
+- _name: Line2
+  csv-header-name: structured_line_2
+  csv-type: xs:string
+  description: Additional field for an address
+  error: If no ``Line2`` is provided, the implementation should ignore it.
+  repreating: false
+  type: xs:string
+- _name: Line3
+  csv-header-name: structured_line_3
+  csv-type: xs:string
+  description: Additional field for an address
+  error: If no ``Line3`` is provided, the implementation should ignore it.
+  repreating: false
+  type: xs:string
 - _name: City
   csv-header-name: structured_city
   csv-type: xs:string
@@ -30,5 +44,4 @@ tags:
   csv-type: xs:string
   description: The ZIP code of a structured address.
   error: If ``Zip`` is not provided, the implementation should ignore the ``SimpleAddressType``.
-  required: true
   type: xs:string

--- a/docs/yaml/elements/simple_address_type.yaml
+++ b/docs/yaml/elements/simple_address_type.yaml
@@ -14,9 +14,10 @@ tags:
   csv-header-name: structured_line_1
   csv-type: xs:string
   description: The address line for a structured address. Should include the street
-    number, stree name, and any prefix and suffix.
+    number, street name, and any prefix and suffix.
   error: If no ``Line1`` is provided, the implementation should ignore the ``SimpleAddressType``.
   repreating: false
+  required: true
   type: xs:string
 - _name: Line2
   csv-header-name: structured_line_2
@@ -38,17 +39,20 @@ tags:
   csv-header-name: structured_city
   csv-type: xs:string
   description: TBD
-  error: If no ``City`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  error: If ``City`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  required: true
   type: xs:string
 - _name: State
   csv-header-name: structured_state
   csv-type: xs:string
   description: TBD
-  error: If no ``State`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  error: If ``State`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  required: true
   type: xs:string
 - _name: Zip
   csv-header-name: structured_zip
   csv-type: xs:string
   description: TBD
-  error: If no ``Zip`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  error: If ``Zip`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  required: true
   type: xs:string

--- a/docs/yaml/elements/simple_address_type.yaml
+++ b/docs/yaml/elements/simple_address_type.yaml
@@ -2,14 +2,6 @@ _name: SimpleAddressType
 csv-header-name: simple_address_type
 description: A ``SimpleAddressType`` represents a structured address.
 tags:
-- _name: LocationName
-  csv-header-name: structured_location_name
-  csv-type: xs:string
-  description: The name of the building a part of the structured address.
-  error_then: =must-ignore
-  repeating: false
-  required: false
-  type: xs:string
 - _name: Line1
   csv-header-name: structured_line_1
   csv-type: xs:string
@@ -19,40 +11,24 @@ tags:
   repreating: false
   required: true
   type: xs:string
-- _name: Line2
-  csv-header-name: structured_line_2
-  csv-type: xs:string
-  description: TBD
-  error_then: =must-ignore
-  repeating: false
-  required: false
-  type: xs:string
-- _name: Line3
-  csv-header-name: structured_line_3
-  csv-type: xs:string
-  description: TBD
-  error_then: =must-ignore
-  repeating: false
-  required: false
-  type: xs:string
 - _name: City
   csv-header-name: structured_city
   csv-type: xs:string
-  description: TBD
+  description: The City value of a structured address.
   error: If ``City`` is not provided, the implementation should ignore the ``SimpleAddressType``.
   required: true
   type: xs:string
 - _name: State
   csv-header-name: structured_state
   csv-type: xs:string
-  description: TBD
+  description: The State value of a structured address.
   error: If ``State`` is not provided, the implementation should ignore the ``SimpleAddressType``.
   required: true
   type: xs:string
 - _name: Zip
   csv-header-name: structured_zip
   csv-type: xs:string
-  description: TBD
+  description: The ZIP code of a structured address.
   error: If ``Zip`` is not provided, the implementation should ignore the ``SimpleAddressType``.
   required: true
   type: xs:string

--- a/docs/yaml/elements/simple_address_type.yaml
+++ b/docs/yaml/elements/simple_address_type.yaml
@@ -1,0 +1,54 @@
+_name: SimpleAddressType
+csv-header-name: simple_address_type
+description: A ``SimpleAddressType`` represents a structured address.
+tags:
+- _name: LocationName
+  csv-header-name: structured_location_name
+  csv-type: xs:string
+  description: The name of the building a part of the structured address.
+  error_then: =must-ignore
+  repeating: false
+  required: false
+  type: xs:string
+- _name: Line1
+  csv-header-name: structured_line_1
+  csv-type: xs:string
+  description: The address line for a structured address. Should include the street
+    number, stree name, and any prefix and suffix.
+  error: If no ``Line1`` is provided, the implementation should ignore the ``SimpleAddressType``.
+  repreating: false
+  type: xs:string
+- _name: Line2
+  csv-header-name: structured_line_2
+  csv-type: xs:string
+  description: TBD
+  error_then: =must-ignore
+  repeating: false
+  required: false
+  type: xs:string
+- _name: Line3
+  csv-header-name: structured_line_3
+  csv-type: xs:string
+  description: TBD
+  error_then: =must-ignore
+  repeating: false
+  required: false
+  type: xs:string
+- _name: City
+  csv-header-name: structured_city
+  csv-type: xs:string
+  description: TBD
+  error: If no ``City`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  type: xs:string
+- _name: State
+  csv-header-name: structured_state
+  csv-type: xs:string
+  description: TBD
+  error: If no ``State`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  type: xs:string
+- _name: Zip
+  csv-header-name: structured_zip
+  csv-type: xs:string
+  description: TBD
+  error: If no ``Zip`` is not provided, the implementation should ignore the ``SimpleAddressType``.
+  type: xs:string

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -1484,7 +1484,6 @@
   <!-- The polling locations in this jurisdiction. -->
   <PollingLocation id="pl00000">
     <AddressStructured>
-       <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
        <Line1>2775 Hydraulic Rd</Line1>
       <City>CHARLOTTESVILLE</City>
       <State>VA</State>

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -1483,8 +1483,13 @@
 
   <!-- The polling locations in this jurisdiction. -->
   <PollingLocation id="pl00000">
-    <AddressLine>1600 5TH STREET</AddressLine>
-    <AddressLine>CHARLOTTESVILLE, VA 22902</AddressLine>
+    <AddressStructured>
+       <LocationName>ALBERMARLE HIGH SCHOOL</LocationName>
+       <Line1>2775 Hydraulic Rd</Line1>
+      <City>CHARLOTTESVILLE</City>
+      <State>VA</State>
+     <Zip>22901</Zip>
+    </AddressStructured>
     <HoursOpenId>hours0002</HoursOpenId>
     <IsDropBox>true</IsDropBox>
     <IsEarlyVoting>true</IsEarlyVoting>
@@ -1492,7 +1497,6 @@
       <Latitude>38.009939</Latitude>
       <Longitude>-78.506204</Longitude>
     </LatLng>
-    <Name>DEPARTMENT OF VOTER REGISTRATION AND ELECTIONS</Name>
   </PollingLocation>
   <PollingLocation id="pl81273">
     <AddressLine>2775 Hydraulic Rd</AddressLine>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -531,8 +531,10 @@
   <xs:complexType name="PollingLocation">
     <xs:sequence>
       <!-- It is intentional that an address is required. -->
-      <xs:element name="StructuredAddress" type="SimpleAddressType" minOccurs="0" />
-      <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
+      <xs:choice>
+        <xs:element name="AddressStructured" type="SimpleAddressType"/>
+        <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
+      </xs:choice>
       <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
       <!--
            Note: The "Hours" element is being deprecated and will be removed

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -535,6 +535,7 @@
         <xs:element name="AddressStructured" type="SimpleAddressType"/>
         <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
       </xs:choice>
+      <xs:element name="Alias" type="InternationalizedText" minOccurs="0" maxOccurs="1"/>
       <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
       <!--
            Note: The "Hours" element is being deprecated and will be removed

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -581,9 +581,11 @@
   <xs:complexType name="SimpleAddressType">
     <xs:sequence>
       <xs:element name="Line1" type="xs:string"/>
+      <xs:element name="Line2" type="xs:string" minOccurs="0" />
+      <xs:element name="Line3" type="xs:string" minOccurs="0" />
       <xs:element name="City" type="xs:string"/>
       <xs:element name="State" type="xs:string"/>
-      <xs:element name="Zip" type="xs:string"/>
+      <xs:element name="Zip" type="xs:string" minOccurs="0" />
     </xs:sequence>
   </xs:complexType>
 

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -531,6 +531,7 @@
   <xs:complexType name="PollingLocation">
     <xs:sequence>
       <!-- It is intentional that an address is required. -->
+      <xs:element name="StructuredAddress" type="SimpleAddressType" minOccurs="0" />
       <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
       <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
       <!--
@@ -573,6 +574,18 @@
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SimpleAddressType">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="LocationName" type="xs:string"/>
+      <xs:element name="Line1" type="xs:string"/>
+      <xs:element minOccurs="0" name="Line2" type="xs:string"/>
+      <xs:element minOccurs="0" name="Line3" type="xs:string"/>
+      <xs:element name="City" type="xs:string"/>
+      <xs:element name="State" type="xs:string"/>
+      <xs:element name="Zip" type="xs:string"/>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="State">

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -535,7 +535,6 @@
         <xs:element name="AddressStructured" type="SimpleAddressType"/>
         <xs:element name="AddressLine" type="xs:string" maxOccurs="unbounded" />
       </xs:choice>
-      <xs:element name="Alias" type="InternationalizedText" minOccurs="0" maxOccurs="1"/>
       <xs:element name="Directions" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
       <!--
            Note: The "Hours" element is being deprecated and will be removed
@@ -581,10 +580,7 @@
 
   <xs:complexType name="SimpleAddressType">
     <xs:sequence>
-      <xs:element minOccurs="0" name="LocationName" type="xs:string"/>
       <xs:element name="Line1" type="xs:string"/>
-      <xs:element minOccurs="0" name="Line2" type="xs:string"/>
-      <xs:element minOccurs="0" name="Line3" type="xs:string"/>
       <xs:element name="City" type="xs:string"/>
       <xs:element name="State" type="xs:string"/>
       <xs:element name="Zip" type="xs:string"/>


### PR DESCRIPTION
This includes updates the YAML, RST and XSD files to support structured addresses for PollingLocation objects. The 5.2 revision will give the option to provide structured or unstructured addresses for polling locations via `choice` in the XSD file. Further discussion around this revision update is found here: https://github.com/votinginfoproject/vip-specification/issues/351

This PR also relocates the PollingLocation XML example from `lat_lng.yaml` to `polling_location.yaml`. 