### PR TITLE
Feature/issue 162 restore address pre suf fix

### DIFF
--- a/docs/built_rst/csv/elements/street_segment.rst
+++ b/docs/built_rst/csv/elements/street_segment.rst
@@ -67,17 +67,17 @@ are equal.
 |                        |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                        |                           |              |              | value is ignored.                        |                                          |
 +------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| house_number_prefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                        |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
-|                        |                           |              |              | Main St'). If this value is present then | it.                                      |
+| house_number_prefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                        |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | then the implementation is required to   |
+|                        |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                        |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                        |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                        |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
 |                        |                           |              |              | **IncludesAllStreets** are true.         |                                          |
 +------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| house_number_suffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                        |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
-|                        |                           |              |              | Main St'). If this value is present then | it.                                      |
+| house_number_suffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                        |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | then the implementation is required to   |
+|                        |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                        |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                        |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                        |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
@@ -125,5 +125,6 @@ are equal.
 
 
     id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
-    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
-    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002
+    ss000001,N,Washington,false,false,odd,pre90113,101,199,,,DC,NW,Delaware,St,,20001
+    ss000002,S,Washington,true,false,both,pre90112,,,,,DC,SE,Wisconsin,Ave,,20002
+    ss000003,N,Washington,false,false,even,pre90113,100,100,A,1/2,DC,NW,Delaware,St,,20001

--- a/docs/built_rst/csv/elements/street_segment.rst
+++ b/docs/built_rst/csv/elements/street_segment.rst
@@ -67,6 +67,22 @@ are equal.
 |                        |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                        |                           |              |              | value is ignored.                        |                                          |
 +------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| house_number_prefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                        |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
+|                        |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                        |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                        |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                        |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                        |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| house_number_suffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                        |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
+|                        |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                        |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                        |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                        |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                        |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | state                  | ``xs:string``             | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
 |                        |                           |              |              | abbreviation of the address.             | implementation is required to ignore it. |
 +------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -108,6 +124,6 @@ are equal.
    :linenos:
 
 
-    id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,state,street_direction,street_name,street_suffix,unit_number,zip
-    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,Delaware,St,,20001
-    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,Wisconsin,Ave,,20002
+    id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
+    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
+    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -2181,17 +2181,17 @@ are equal.
 |                        |                            |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                        |                            |              |              | value is ignored.                        |                                          |
 +------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| house_number_prefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                        |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
-|                        |                            |              |              | Main St'). If this value is present then | it.                                      |
+| house_number_prefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                        |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | then the implementation is required to   |
+|                        |                            |              |              | Main St'). If this value is present then | ignore it.                               |
 |                        |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                        |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                        |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
 |                        |                            |              |              | **IncludesAllStreets** are true.         |                                          |
 +------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| house_number_suffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                        |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
-|                        |                            |              |              | Main St'). If this value is present then | it.                                      |
+| house_number_suffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                        |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | then the implementation is required to   |
+|                        |                            |              |              | Main St'). If this value is present then | ignore it.                               |
 |                        |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                        |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                        |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
@@ -2239,8 +2239,9 @@ are equal.
 
 
     id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
-    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
-    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002
+    ss000001,N,Washington,false,false,odd,pre90113,101,199,,,DC,NW,Delaware,St,,20001
+    ss000002,S,Washington,true,false,both,pre90112,,,,,DC,SE,Wisconsin,Ave,,20002
+    ss000003,N,Washington,false,false,even,pre90113,100,100,A,1/2,DC,NW,Delaware,St,,20001
 
 
 .. _single-csv-candidate-contest:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -2181,6 +2181,22 @@ are equal.
 |                        |                            |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                        |                            |              |              | value is ignored.                        |                                          |
 +------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| house_number_prefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                        |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
+|                        |                            |              |              | Main St'). If this value is present then | it.                                      |
+|                        |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                        |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                        |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                        |                            |              |              | **IncludesAllStreets** are true.         |                                          |
++------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| house_number_suffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                        |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
+|                        |                            |              |              | Main St'). If this value is present then | it.                                      |
+|                        |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                        |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                        |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                        |                            |              |              | **IncludesAllStreets** are true.         |                                          |
++------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | state                  | ``xs:string``              | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
 |                        |                            |              |              | abbreviation of the address.             | implementation is required to ignore it. |
 +------------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -2222,9 +2238,9 @@ are equal.
    :linenos:
 
 
-    id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,state,street_direction,street_name,street_suffix,unit_number,zip
-    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,Delaware,St,,20001
-    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,Wisconsin,Ave,,20002
+    id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
+    ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
+    ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002
 
 
 .. _single-csv-candidate-contest:

--- a/docs/built_rst/tables/elements/street_segment.rst
+++ b/docs/built_rst/tables/elements/street_segment.rst
@@ -57,17 +57,17 @@
 |                      |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                           |              |              | value is ignored.                        |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
-|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | then the implementation is required to   |
+|                      |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
 |                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
-|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | then the implementation is required to   |
+|                      |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |

--- a/docs/built_rst/tables/elements/street_segment.rst
+++ b/docs/built_rst/tables/elements/street_segment.rst
@@ -57,6 +57,22 @@
 |                      |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                           |              |              | value is ignored.                        |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
+|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
+|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | State                | ``xs:string``             | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
 |                      |                           |              |              | abbreviation of the address.             | implementation is required to ignore it. |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/street_segment.rst
+++ b/docs/built_rst/xml/elements/street_segment.rst
@@ -67,6 +67,22 @@ are equal.
 |                      |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                           |              |              | value is ignored.                        |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
+|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
+|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | State                | ``xs:string``             | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
 |                      |                           |              |              | abbreviation of the address.             | implementation is required to ignore it. |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -123,6 +139,19 @@ are equal.
       <PrecinctId>pre92145</PrecinctId>
       <StartHouseNumber>1</StartHouseNumber>
       <EndHouseNumber>201</EndHouseNumber>
+      <State>VA</State>
+      <StreetName>MISTY MOUNTAIN</StreetName>
+      <StreetSuffix>RD</StreetSuffix>
+      <Zip>22943</Zip>
+   </StreetSegment>
+   <StreetSegment id = "ss1"
+      <City>GREENWOOD</City>
+      <OddEvenBoth>both</OddEvenBoth>
+      <PrecinctId>pre92145</PrecinctId>
+      <StartHouseNumber>1</StartHouseNumber>
+      <EndHouseNumber>1</EndHouseNumber>
+      <HouseNumberPrefix>B</HouseNumberPrefix>
+      <HouseNumberSuffix>1/2</HouseNumberSuffix>
       <State>VA</State>
       <StreetName>MISTY MOUNTAIN</StreetName>
       <StreetSuffix>RD</StreetSuffix>

--- a/docs/built_rst/xml/elements/street_segment.rst
+++ b/docs/built_rst/xml/elements/street_segment.rst
@@ -67,17 +67,17 @@ are equal.
 |                      |                           |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                           |              |              | value is ignored.                        |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
-|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberPrefix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                           |              |              | letters or slashes (e.g., 'B' in 'B22    | then the implementation is required to   |
+|                      |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |
 |                      |                           |              |              | **IncludesAllStreets** are true.         |                                          |
 +----------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
-|                      |                           |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberSuffix    | ``xs:string``             | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                           |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | then the implementation is required to   |
+|                      |                           |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                           |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                           |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                           |              |              | used if **IncludesAllAddresses** or      |                                          |

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -2561,17 +2561,17 @@ are equal.
 |                      |                            |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                            |              |              | value is ignored.                        |                                          |
 +----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberPrefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
-|                      |                            |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberPrefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | then the implementation is required to   |
+|                      |                            |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
 |                      |                            |              |              | **IncludesAllStreets** are true.         |                                          |
 +----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HouseNumberSuffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
-|                      |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
-|                      |                            |              |              | Main St'). If this value is present then | it.                                      |
+| HouseNumberSuffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is invalid or not present,  |
+|                      |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | then the implementation is required to   |
+|                      |                            |              |              | Main St'). If this value is present then | ignore it.                               |
 |                      |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
 |                      |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
 |                      |                            |              |              | used if **IncludesAllAddresses** or      |                                          |

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -2561,6 +2561,22 @@ are equal.
 |                      |                            |              |              | **IncludesAllStreets** are true, this    |                                          |
 |                      |                            |              |              | value is ignored.                        |                                          |
 +----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberPrefix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                            |              |              | letters or slashes (e.g., 'B' in 'B22    | the implementation is required to ignore |
+|                      |                            |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                            |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HouseNumberSuffix    | ``xs:string``              | Optional     | Single       | Part of a street address. It may contain | If the field is not present of invalid,  |
+|                      |                            |              |              | letters or slashes (e.g., 1/2 in '22 1/2 | the implementation is required to ignore |
+|                      |                            |              |              | Main St'). If this value is present then | it.                                      |
+|                      |                            |              |              | **StartHouseNumber** must be equal to    |                                          |
+|                      |                            |              |              | **EndHouseNumber**. This field cannot be |                                          |
+|                      |                            |              |              | used if **IncludesAllAddresses** or      |                                          |
+|                      |                            |              |              | **IncludesAllStreets** are true.         |                                          |
++----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | State                | ``xs:string``              | **Required** | Single       | Specifies the two-letter state           | If the field is invalid, then the        |
 |                      |                            |              |              | abbreviation of the address.             | implementation is required to ignore it. |
 +----------------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
@@ -2617,6 +2633,19 @@ are equal.
       <PrecinctId>pre92145</PrecinctId>
       <StartHouseNumber>1</StartHouseNumber>
       <EndHouseNumber>201</EndHouseNumber>
+      <State>VA</State>
+      <StreetName>MISTY MOUNTAIN</StreetName>
+      <StreetSuffix>RD</StreetSuffix>
+      <Zip>22943</Zip>
+   </StreetSegment>
+   <StreetSegment id = "ss1"
+      <City>GREENWOOD</City>
+      <OddEvenBoth>both</OddEvenBoth>
+      <PrecinctId>pre92145</PrecinctId>
+      <StartHouseNumber>1</StartHouseNumber>
+      <EndHouseNumber>1</EndHouseNumber>
+      <HouseNumberPrefix>B</HouseNumberPrefix>
+      <HouseNumberSuffix>1/2</HouseNumberSuffix>
       <State>VA</State>
       <StreetName>MISTY MOUNTAIN</StreetName>
       <StreetSuffix>RD</StreetSuffix>

--- a/docs/yaml/elements/street_segment.yaml
+++ b/docs/yaml/elements/street_segment.yaml
@@ -5,9 +5,9 @@ csv-post: |-
      :linenos:
 
 
-      id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,state,street_direction,street_name,street_suffix,unit_number,zip
-      ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,Delaware,St,,20001
-      ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,Wisconsin,Ave,,20002
+      id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
+      ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
+      ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002
 description: |-
   A Street Segment objection represents a portion of a street and the links to the precinct that this
   geography (i.e., segment) is contained within. The start address house number must be less than the
@@ -33,6 +33,19 @@ post: |-
         <PrecinctId>pre92145</PrecinctId>
         <StartHouseNumber>1</StartHouseNumber>
         <EndHouseNumber>201</EndHouseNumber>
+        <State>VA</State>
+        <StreetName>MISTY MOUNTAIN</StreetName>
+        <StreetSuffix>RD</StreetSuffix>
+        <Zip>22943</Zip>
+     </StreetSegment>
+     <StreetSegment id = "ss1"
+        <City>GREENWOOD</City>
+        <OddEvenBoth>both</OddEvenBoth>
+        <PrecinctId>pre92145</PrecinctId>
+        <StartHouseNumber>1</StartHouseNumber>
+        <EndHouseNumber>1</EndHouseNumber>
+        <HouseNumberPrefix>B</HouseNumberPrefix>
+        <HouseNumberSuffix>1/2</HouseNumberSuffix>
         <State>VA</State>
         <StreetName>MISTY MOUNTAIN</StreetName>
         <StreetSuffix>RD</StreetSuffix>
@@ -116,7 +129,9 @@ tags:
   csv-header-name: house_number_prefix
   csv-type: xs:string
   description: Part of a street address. It may contain letters or slashes (e.g.,
-    'B' in 'B22 Main St')
+    'B' in 'B22 Main St'). If this value is present then **StartHouseNumber** must
+    be equal to **EndHouseNumber**. This field cannot be used if **IncludesAllAddresses**
+    or **IncludesAllStreets** are true.
   error: If the field is not present of invalid, the implementation is required to
     ignore it.
   type: xs:string
@@ -124,7 +139,9 @@ tags:
   csv-header-name: house_number_suffix
   csv-type: xs:string
   description: Part of a street address. It may contain letters or slashes (e.g.,
-    1/2 in '22 1/2 Main St')
+    1/2 in '22 1/2 Main St'). If this value is present then **StartHouseNumber** must
+    be equal to **EndHouseNumber**. This field cannot be used if **IncludesAllAddresses**
+    or **IncludesAllStreets** are true.
   error: If the field is not present of invalid, the implementation is required to
     ignore it.
   type: xs:string

--- a/docs/yaml/elements/street_segment.yaml
+++ b/docs/yaml/elements/street_segment.yaml
@@ -112,6 +112,22 @@ tags:
     **StartHouseNumber**, the implementation should ignore the element containing
     it.
   type: xs:integer
+- _name: HouseNumberPrefix
+  csv-header-name: house_number_prefix
+  csv-type: xs:string
+  description: Part of a street address. It may contain letters or slashes (e.g.,
+    'B' in 'B22 Main St')
+  error: If the field is not present of invalid, the implementation is required to
+    ignore it.
+  type: xs:string
+- _name: HouseNumberSuffix
+  csv-header-name: house_number_suffix
+  csv-type: xs:string
+  description: Part of a street address. It may contain letters or slashes (e.g.,
+    1/2 in '22 1/2 Main St')
+  error: If the field is not present of invalid, the implementation is required to
+    ignore it.
+  type: xs:string
 - _name: State
   csv-header-name: state
   csv-type: xs:string

--- a/docs/yaml/elements/street_segment.yaml
+++ b/docs/yaml/elements/street_segment.yaml
@@ -6,8 +6,9 @@ csv-post: |-
 
 
       id,address_direction,city,includes_all_addresses,includes_all_streets,odd_even_both,precinct_id,start_house_number,end_house_number,house_number_prefix,house_number_suffix,state,street_direction,street_name,street_suffix,unit_number,zip
-      ss000001,N,Washington,false,false,odd,pre90113,101,199,DC,NW,,,Delaware,St,,20001
-      ss000002,S,Washington,true,false,both,pre90112,,,DC,SE,,,Wisconsin,Ave,,20002
+      ss000001,N,Washington,false,false,odd,pre90113,101,199,,,DC,NW,Delaware,St,,20001
+      ss000002,S,Washington,true,false,both,pre90112,,,,,DC,SE,Wisconsin,Ave,,20002
+      ss000003,N,Washington,false,false,even,pre90113,100,100,A,1/2,DC,NW,Delaware,St,,20001
 description: |-
   A Street Segment objection represents a portion of a street and the links to the precinct that this
   geography (i.e., segment) is contained within. The start address house number must be less than the
@@ -132,8 +133,7 @@ tags:
     'B' in 'B22 Main St'). If this value is present then **StartHouseNumber** must
     be equal to **EndHouseNumber**. This field cannot be used if **IncludesAllAddresses**
     or **IncludesAllStreets** are true.
-  error: If the field is not present of invalid, the implementation is required to
-    ignore it.
+  error_then: =must-ignore
   type: xs:string
 - _name: HouseNumberSuffix
   csv-header-name: house_number_suffix
@@ -142,8 +142,7 @@ tags:
     1/2 in '22 1/2 Main St'). If this value is present then **StartHouseNumber** must
     be equal to **EndHouseNumber**. This field cannot be used if **IncludesAllAddresses**
     or **IncludesAllStreets** are true.
-  error: If the field is not present of invalid, the implementation is required to
-    ignore it.
+  error_then: =must-ignore
   type: xs:string
 - _name: State
   csv-header-name: state

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -2026,6 +2026,19 @@
   </Precinct>
 
   <!-- Street segments -->
+   <StreetSegment id = "ss1">
+      <City>GREENWOOD</City>
+      <OddEvenBoth>both</OddEvenBoth>
+      <PrecinctId>pre92145</PrecinctId>
+      <StartHouseNumber>1</StartHouseNumber>
+      <EndHouseNumber>1</EndHouseNumber>
+      <HouseNumberPrefix>B</HouseNumberPrefix>
+      <HouseNumberSuffix>1/2</HouseNumberSuffix>
+      <State>VA</State>
+      <StreetName>MISTY MOUNTAIN</StreetName>
+      <StreetSuffix>RD</StreetSuffix>
+      <Zip>22943</Zip>
+   </StreetSegment>
   <StreetSegment id="ss000000">
     <City>Charlottesville</City>
     <IncludesAllStreets>true</IncludesAllStreets>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -595,6 +595,8 @@
       <xs:element name="PrecinctId" type="xs:IDREF" />
       <xs:element name="StartHouseNumber" type="xs:integer" minOccurs="0" />
       <xs:element name="EndHouseNumber" type="xs:integer" minOccurs="0" />
+      <xs:element name="HouseNumberPrefix" type="xs:string" minOccurs="0" />
+      <xs:element name="HouseNumberSuffix" type="xs:string" minOccurs="0" />
       <xs:element name="State" type="xs:string" />
       <xs:element name="StreetDirection" type="xs:string" minOccurs="0" />
       <xs:element name="StreetName" type="xs:string" minOccurs="0"/>


### PR DESCRIPTION
We are restoring `StreetSegment.HouseNumberPrefix` and `StreetSegment.HouseNumberSuffix` to the specification to support States who make use of these fields in the 3.0 specification. It has been discussed that the removal of these fields has prevented upgrading to 5.1, and so we'll restore them to facilitate higher adoption of version 5.  

Issue discussion can be found here: https://github.com/votinginfoproject/vip-specification/issues/162