### PR TITLE
Feature/issue 367 add ballot tracking uris

### DIFF
--- a/docs/built_rst/csv/elements/election_administration.rst
+++ b/docs/built_rst/csv/elements/election_administration.rst
@@ -8,52 +8,61 @@ election_administration
 The Election Administration represents an institution for serving a locality's (or state's) election
 functions.
 
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+=============================+==============+==============+==========================================+==========================================+
-| absentee_uri         | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                      |                             |              |              | information on absentee voting.          | then the implementation is required to   |
-|                      |                             |              |              |                                          | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| am_i_registered_uri  | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                      |                             |              |              | information on whether an individual is  | then the implementation is required to   |
-|                      |                             |              |              | registered.                              | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| department           | :ref:`multi-csv-department` | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
-|                      |                             |              |              | particular voter service.                | `Department` in each                     |
-|                      |                             |              |              |                                          | `ElectionAdministration` element. If no  |
-|                      |                             |              |              |                                          | valid `Department` objects are present,  |
-|                      |                             |              |              |                                          | the implementation is required to ignore |
-|                      |                             |              |              |                                          | the `ElectionAdministration` object that |
-|                      |                             |              |              |                                          | contains it/them.                        |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| elections_uri        | ``xs:anyURI``               | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
-|                      |                             |              |              | administration's website.                | then the implementation is required to   |
-|                      |                             |              |              |                                          | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_uri     | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                      |                             |              |              | registering to vote.                     | then the implementation is required to   |
-|                      |                             |              |              |                                          | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| rules_uri            | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
-|                      |                             |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
-|                      |                             |              |              | of the administration.                   | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| what_is_on_my_ballot | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                      |                             |              |              | what is on an individual's ballot.       | then the implementation is required to   |
-|                      |                             |              |              |                                          | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| where_do_i_vote_uri  | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
-|                      |                             |              |              | information on where an individual votes | then the implementation is required to   |
-|                      |                             |              |              | based on their address.                  | ignore it.                               |
-+----------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Tag                             | Data Type                   | Required?    | Repeats?     | Description                                                 | Error Handling                           |
++=================================+=============================+==============+==============+=============================================================+==========================================+
+| absentee_uri                    | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on absentee       | If the field is invalid or not present,  |
+|                                 |                             |              |              | voting.                                                     | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| am_i_registered_uri             | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on whether an     | If the field is invalid or not present,  |
+|                                 |                             |              |              | individual is registered.                                   | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ballot_tracking_uri             | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                                 |                             |              |              | ballot cast by mail                                         | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ballot_tracking_provisional_uri | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                                 |                             |              |              | provisional ballot. To support EAC guidelines for           | then the implementation is required to   |
+|                                 |                             |              |              | "Processing Provisional Ballots"                            | ignore it.                               |
+|                                 |                             |              |              | (https://www.eac.gov/research-and-data/provisional-voting/) |                                          |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| department                      | :ref:`multi-csv-department` | **Required** | Repeats      | Describes the administrative body for a particular voter    | There must be at least one valid         |
+|                                 |                             |              |              | service.                                                    | `Department` in each                     |
+|                                 |                             |              |              |                                                             | `ElectionAdministration` element. If no  |
+|                                 |                             |              |              |                                                             | valid `Department` objects are present,  |
+|                                 |                             |              |              |                                                             | the implementation is required to ignore |
+|                                 |                             |              |              |                                                             | the `ElectionAdministration` object that |
+|                                 |                             |              |              |                                                             | contains it/them.                        |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| elections_uri                   | ``xs:anyURI``               | Optional     | Single       | Specifies web address the administration's website.         | If the field is invalid or not present,  |
+|                                 |                             |              |              |                                                             | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| registration_uri                | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on registering to     | If the field is invalid or not present,  |
+|                                 |                             |              |              | vote.                                                       | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| rules_uri                       | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules and laws (if any)    | If the field is invalid or not present,  |
+|                                 |                             |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| what_is_on_my_ballot            | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+|                                 |                             |              |              | individual's ballot.                                        | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| where_do_i_vote_uri             | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for information on where an       | If the field is invalid or not present,  |
+|                                 |                             |              |              | individual votes based on their address.                    | then the implementation is required to   |
+|                                 |                             |              |              |                                                             | ignore it.                               |
++---------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,absentee_uri,am_i_registered_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
-    ea123,https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
+    id,absentee_uri,am_i_registered_uri,ballot_tracking_uri,ballot_tracking_provisional_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
+    ea123,https://example.com/absentee,https://example.com/am-i-registered,https://www.vote.virginia.gov/,https://www.vote.virginia.gov/,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
     ea345,https://example.com/absentee2,https://example.com/am-i-registered2,https://example.com/elections2,https://example.com/registration2,https://example.com/rules2,https://example.com/what-is-on-my-ballot2,https://example.com/where-do-i-vote2
     ea625,https://example.com/absentee3,https://example.com/am-i-registered3,https://example.com/elections3,https://example.com/registration3,https://example.com/rules3,https://example.com/what-is-on-my-ballot3,https://example.com/where-do-i-vote3
 

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1805,52 +1805,61 @@ election_administration
 The Election Administration represents an institution for serving a locality's (or state's) election
 functions.
 
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                    | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+==============================+==============+==============+==========================================+==========================================+
-| absentee_uri         | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                      |                              |              |              | information on absentee voting.          | then the implementation is required to   |
-|                      |                              |              |              |                                          | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| am_i_registered_uri  | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                      |                              |              |              | information on whether an individual is  | then the implementation is required to   |
-|                      |                              |              |              | registered.                              | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| department           | :ref:`single-csv-department` | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
-|                      |                              |              |              | particular voter service.                | `Department` in each                     |
-|                      |                              |              |              |                                          | `ElectionAdministration` element. If no  |
-|                      |                              |              |              |                                          | valid `Department` objects are present,  |
-|                      |                              |              |              |                                          | the implementation is required to ignore |
-|                      |                              |              |              |                                          | the `ElectionAdministration` object that |
-|                      |                              |              |              |                                          | contains it/them.                        |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| elections_uri        | ``xs:anyURI``                | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
-|                      |                              |              |              | administration's website.                | then the implementation is required to   |
-|                      |                              |              |              |                                          | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_uri     | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                      |                              |              |              | registering to vote.                     | then the implementation is required to   |
-|                      |                              |              |              |                                          | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| rules_uri            | ``xs:anyURI``                | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
-|                      |                              |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
-|                      |                              |              |              | of the administration.                   | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| what_is_on_my_ballot | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                      |                              |              |              | what is on an individual's ballot.       | then the implementation is required to   |
-|                      |                              |              |              |                                          | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| where_do_i_vote_uri  | ``xs:anyURI``                | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
-|                      |                              |              |              | information on where an individual votes | then the implementation is required to   |
-|                      |                              |              |              | based on their address.                  | ignore it.                               |
-+----------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Tag                             | Data Type                    | Required?    | Repeats?     | Description                                                 | Error Handling                           |
++=================================+==============================+==============+==============+=============================================================+==========================================+
+| absentee_uri                    | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for information on absentee       | If the field is invalid or not present,  |
+|                                 |                              |              |              | voting.                                                     | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| am_i_registered_uri             | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for information on whether an     | If the field is invalid or not present,  |
+|                                 |                              |              |              | individual is registered.                                   | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ballot_tracking_uri             | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                                 |                              |              |              | ballot cast by mail                                         | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ballot_tracking_provisional_uri | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                                 |                              |              |              | provisional ballot. To support EAC guidelines for           | then the implementation is required to   |
+|                                 |                              |              |              | "Processing Provisional Ballots"                            | ignore it.                               |
+|                                 |                              |              |              | (https://www.eac.gov/research-and-data/provisional-voting/) |                                          |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| department                      | :ref:`single-csv-department` | **Required** | Repeats      | Describes the administrative body for a particular voter    | There must be at least one valid         |
+|                                 |                              |              |              | service.                                                    | `Department` in each                     |
+|                                 |                              |              |              |                                                             | `ElectionAdministration` element. If no  |
+|                                 |                              |              |              |                                                             | valid `Department` objects are present,  |
+|                                 |                              |              |              |                                                             | the implementation is required to ignore |
+|                                 |                              |              |              |                                                             | the `ElectionAdministration` object that |
+|                                 |                              |              |              |                                                             | contains it/them.                        |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| elections_uri                   | ``xs:anyURI``                | Optional     | Single       | Specifies web address the administration's website.         | If the field is invalid or not present,  |
+|                                 |                              |              |              |                                                             | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| registration_uri                | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on registering to     | If the field is invalid or not present,  |
+|                                 |                              |              |              | vote.                                                       | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| rules_uri                       | ``xs:anyURI``                | Optional     | Single       | Specifies a URI for the election rules and laws (if any)    | If the field is invalid or not present,  |
+|                                 |                              |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| what_is_on_my_ballot            | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+|                                 |                              |              |              | individual's ballot.                                        | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| where_do_i_vote_uri             | ``xs:anyURI``                | Optional     | Single       | The Specifies web address for information on where an       | If the field is invalid or not present,  |
+|                                 |                              |              |              | individual votes based on their address.                    | then the implementation is required to   |
+|                                 |                              |              |              |                                                             | ignore it.                               |
++---------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,absentee_uri,am_i_registered_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
-    ea123,https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
+    id,absentee_uri,am_i_registered_uri,ballot_tracking_uri,ballot_tracking_provisional_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
+    ea123,https://example.com/absentee,https://example.com/am-i-registered,https://www.vote.virginia.gov/,https://www.vote.virginia.gov/,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
     ea345,https://example.com/absentee2,https://example.com/am-i-registered2,https://example.com/elections2,https://example.com/registration2,https://example.com/rules2,https://example.com/what-is-on-my-ballot2,https://example.com/where-do-i-vote2
     ea625,https://example.com/absentee3,https://example.com/am-i-registered3,https://example.com/elections3,https://example.com/registration3,https://example.com/rules3,https://example.com/what-is-on-my-ballot3,https://example.com/where-do-i-vote3
 

--- a/docs/built_rst/tables/elements/election_administration.rst
+++ b/docs/built_rst/tables/elements/election_administration.rst
@@ -1,41 +1,50 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=============================+==============+==============+==========================================+==========================================+
-| AbsenteeUri         | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on absentee voting.          | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AmIRegisteredUri    | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on whether an individual is  | then the implementation is required to   |
-|                     |                             |              |              | registered.                              | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Department          | :ref:`multi-xml-department` | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
-|                     |                             |              |              | particular voter service.                | `Department` in each                     |
-|                     |                             |              |              |                                          | `ElectionAdministration` element. If no  |
-|                     |                             |              |              |                                          | valid `Department` objects are present,  |
-|                     |                             |              |              |                                          | the implementation is required to ignore |
-|                     |                             |              |              |                                          | the `ElectionAdministration` object that |
-|                     |                             |              |              |                                          | contains it/them.                        |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectionsUri        | ``xs:anyURI``               | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
-|                     |                             |              |              | administration's website.                | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RegistrationUri     | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                             |              |              | registering to vote.                     | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RulesUri            | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
-|                     |                             |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
-|                     |                             |              |              | of the administration.                   | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhatIsOnMyBallotUri | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                             |              |              | what is on an individual's ballot.       | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhereDoIVoteUri     | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on where an individual votes | then the implementation is required to   |
-|                     |                             |              |              | based on their address.                  | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Tag                          | Data Type                   | Required?    | Repeats?     | Description                                                 | Error Handling                           |
++==============================+=============================+==============+==============+=============================================================+==========================================+
+| AbsenteeUri                  | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on absentee       | If the field is invalid or not present,  |
+|                              |                             |              |              | voting.                                                     | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| AmIRegisteredUri             | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on whether an     | If the field is invalid or not present,  |
+|                              |                             |              |              | individual is registered.                                   | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotTrackingUri            | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                             |              |              | ballot cast by mail                                         | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotProvisionalTrackingUri | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                             |              |              | provisional ballot. To support EAC guidelines for           | then the implementation is required to   |
+|                              |                             |              |              | "Processing Provisional Ballots"                            | ignore it.                               |
+|                              |                             |              |              | (https://www.eac.gov/research-and-data/provisional-voting/) |                                          |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Department                   | :ref:`multi-xml-department` | **Required** | Repeats      | Describes the administrative body for a particular voter    | There must be at least one valid         |
+|                              |                             |              |              | service.                                                    | `Department` in each                     |
+|                              |                             |              |              |                                                             | `ElectionAdministration` element. If no  |
+|                              |                             |              |              |                                                             | valid `Department` objects are present,  |
+|                              |                             |              |              |                                                             | the implementation is required to ignore |
+|                              |                             |              |              |                                                             | the `ElectionAdministration` object that |
+|                              |                             |              |              |                                                             | contains it/them.                        |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ElectionsUri                 | ``xs:anyURI``               | Optional     | Single       | Specifies web address the administration's website.         | If the field is invalid or not present,  |
+|                              |                             |              |              |                                                             | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RegistrationUri              | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on registering to     | If the field is invalid or not present,  |
+|                              |                             |              |              | vote.                                                       | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RulesUri                     | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules and laws (if any)    | If the field is invalid or not present,  |
+|                              |                             |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhatIsOnMyBallotUri          | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+|                              |                             |              |              | individual's ballot.                                        | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhereDoIVoteUri              | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for information on where an       | If the field is invalid or not present,  |
+|                              |                             |              |              | individual votes based on their address.                    | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/election_administration.rst
+++ b/docs/built_rst/xml/elements/election_administration.rst
@@ -8,45 +8,77 @@ ElectionAdministration
 The Election Administration represents an institution for serving a locality's (or state's) election
 functions.
 
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                   | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=============================+==============+==============+==========================================+==========================================+
-| AbsenteeUri         | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on absentee voting.          | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AmIRegisteredUri    | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on whether an individual is  | then the implementation is required to   |
-|                     |                             |              |              | registered.                              | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Department          | :ref:`multi-xml-department` | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
-|                     |                             |              |              | particular voter service.                | `Department` in each                     |
-|                     |                             |              |              |                                          | `ElectionAdministration` element. If no  |
-|                     |                             |              |              |                                          | valid `Department` objects are present,  |
-|                     |                             |              |              |                                          | the implementation is required to ignore |
-|                     |                             |              |              |                                          | the `ElectionAdministration` object that |
-|                     |                             |              |              |                                          | contains it/them.                        |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectionsUri        | ``xs:anyURI``               | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
-|                     |                             |              |              | administration's website.                | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RegistrationUri     | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                             |              |              | registering to vote.                     | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RulesUri            | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
-|                     |                             |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
-|                     |                             |              |              | of the administration.                   | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhatIsOnMyBallotUri | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                             |              |              | what is on an individual's ballot.       | then the implementation is required to   |
-|                     |                             |              |              |                                          | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhereDoIVoteUri     | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
-|                     |                             |              |              | information on where an individual votes | then the implementation is required to   |
-|                     |                             |              |              | based on their address.                  | ignore it.                               |
-+---------------------+-----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Tag                          | Data Type                   | Required?    | Repeats?     | Description                                                 | Error Handling                           |
++==============================+=============================+==============+==============+=============================================================+==========================================+
+| AbsenteeUri                  | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on absentee       | If the field is invalid or not present,  |
+|                              |                             |              |              | voting.                                                     | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| AmIRegisteredUri             | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for information on whether an     | If the field is invalid or not present,  |
+|                              |                             |              |              | individual is registered.                                   | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotTrackingUri            | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                             |              |              | ballot cast by mail                                         | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotProvisionalTrackingUri | ``xs:anyURI``               | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                             |              |              | provisional ballot. To support EAC guidelines for           | then the implementation is required to   |
+|                              |                             |              |              | "Processing Provisional Ballots"                            | ignore it.                               |
+|                              |                             |              |              | (https://www.eac.gov/research-and-data/provisional-voting/) |                                          |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Department                   | :ref:`multi-xml-department` | **Required** | Repeats      | Describes the administrative body for a particular voter    | There must be at least one valid         |
+|                              |                             |              |              | service.                                                    | `Department` in each                     |
+|                              |                             |              |              |                                                             | `ElectionAdministration` element. If no  |
+|                              |                             |              |              |                                                             | valid `Department` objects are present,  |
+|                              |                             |              |              |                                                             | the implementation is required to ignore |
+|                              |                             |              |              |                                                             | the `ElectionAdministration` object that |
+|                              |                             |              |              |                                                             | contains it/them.                        |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ElectionsUri                 | ``xs:anyURI``               | Optional     | Single       | Specifies web address the administration's website.         | If the field is invalid or not present,  |
+|                              |                             |              |              |                                                             | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RegistrationUri              | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on registering to     | If the field is invalid or not present,  |
+|                              |                             |              |              | vote.                                                       | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RulesUri                     | ``xs:anyURI``               | Optional     | Single       | Specifies a URI for the election rules and laws (if any)    | If the field is invalid or not present,  |
+|                              |                             |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhatIsOnMyBallotUri          | ``xs:anyURI``               | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+|                              |                             |              |              | individual's ballot.                                        | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhereDoIVoteUri              | ``xs:anyURI``               | Optional     | Single       | The Specifies web address for information on where an       | If the field is invalid or not present,  |
+|                              |                             |              |              | individual votes based on their address.                    | then the implementation is required to   |
+|                              |                             |              |              |                                                             | ignore it.                               |
++------------------------------+-----------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <ElectionAdministration id="ea40133">
+      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
+      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
+      <BallotTrackingUri>https://www.vote.virginia.gov/</BallotTrackingUri>
+      <BallotProvisionalTrackingUri>https://www.vote.virginia.gov/</BallotProvisionalTrackingUri>
+      <Department>
+        <ContactInformation label="ci60000">
+          <AddressLine>Washington Building First Floor</AddressLine>
+          <AddressLine>1100 Bank Street</AddressLine>
+          <AddressLine>Richmond, VA 23219</AddressLine>
+          <Name>State Board of Elections</Name>
+        </ContactInformation>
+      </Department>
+      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
+      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
+      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
+      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
+      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
+   </ElectionAdministration>
 
 
 .. _multi-xml-department:
@@ -102,27 +134,6 @@ VoterService
 |                          |                                         |              |              | cataloging another type of voter         | then the implementation is required to   |
 |                          |                                         |              |              | service.                                 | ignore it.                               |
 +--------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>
 
 
 .. _multi-xml-contact-information:
@@ -261,24 +272,3 @@ VoterService
 |                          |                                         |              |              | cataloging another type of voter         | then the implementation is required to   |
 |                          |                                         |              |              | service.                                 | ignore it.                               |
 +--------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1129,27 +1129,6 @@ VoterService
 |                          |                                          |              |              | service.                                 | ignore it.                               |
 +--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>
-
 
 .. _single-xml-contact-information:
 
@@ -1646,27 +1625,6 @@ VoterService
 |                          |                                          |              |              | service.                                 | ignore it.                               |
 +--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>
-
 
 .. _single-xml-contact-information:
 
@@ -2131,45 +2089,77 @@ ElectionAdministration
 The Election Administration represents an institution for serving a locality's (or state's) election
 functions.
 
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                    | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+==============================+==============+==============+==========================================+==========================================+
-| AbsenteeUri         | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                              |              |              | information on absentee voting.          | then the implementation is required to   |
-|                     |                              |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AmIRegisteredUri    | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for            | If the field is invalid or not present,  |
-|                     |                              |              |              | information on whether an individual is  | then the implementation is required to   |
-|                     |                              |              |              | registered.                              | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Department          | :ref:`single-xml-department` | **Required** | Repeats      | Describes the administrative body for a  | There must be at least one valid         |
-|                     |                              |              |              | particular voter service.                | `Department` in each                     |
-|                     |                              |              |              |                                          | `ElectionAdministration` element. If no  |
-|                     |                              |              |              |                                          | valid `Department` objects are present,  |
-|                     |                              |              |              |                                          | the implementation is required to ignore |
-|                     |                              |              |              |                                          | the `ElectionAdministration` object that |
-|                     |                              |              |              |                                          | contains it/them.                        |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectionsUri        | ``xs:anyURI``                | Optional     | Single       | Specifies web address the                | If the field is invalid or not present,  |
-|                     |                              |              |              | administration's website.                | then the implementation is required to   |
-|                     |                              |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RegistrationUri     | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                              |              |              | registering to vote.                     | then the implementation is required to   |
-|                     |                              |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RulesUri            | ``xs:anyURI``                | Optional     | Single       | Specifies a URI for the election rules   | If the field is invalid or not present,  |
-|                     |                              |              |              | and laws (if any) for the jurisdiction   | then the implementation is required to   |
-|                     |                              |              |              | of the administration.                   | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhatIsOnMyBallotUri | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on | If the field is invalid or not present,  |
-|                     |                              |              |              | what is on an individual's ballot.       | then the implementation is required to   |
-|                     |                              |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| WhereDoIVoteUri     | ``xs:anyURI``                | Optional     | Single       | The Specifies web address for            | If the field is invalid or not present,  |
-|                     |                              |              |              | information on where an individual votes | then the implementation is required to   |
-|                     |                              |              |              | based on their address.                  | ignore it.                               |
-+---------------------+------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Tag                          | Data Type                    | Required?    | Repeats?     | Description                                                 | Error Handling                           |
++==============================+==============================+==============+==============+=============================================================+==========================================+
+| AbsenteeUri                  | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for information on absentee       | If the field is invalid or not present,  |
+|                              |                              |              |              | voting.                                                     | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| AmIRegisteredUri             | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for information on whether an     | If the field is invalid or not present,  |
+|                              |                              |              |              | individual is registered.                                   | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotTrackingUri            | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                              |              |              | ballot cast by mail                                         | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| BallotProvisionalTrackingUri | ``xs:anyURI``                | Optional     | Single       | Specifies the web address for tracking information for a    | If the field is invalid or not present,  |
+|                              |                              |              |              | provisional ballot. To support EAC guidelines for           | then the implementation is required to   |
+|                              |                              |              |              | "Processing Provisional Ballots"                            | ignore it.                               |
+|                              |                              |              |              | (https://www.eac.gov/research-and-data/provisional-voting/) |                                          |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| Department                   | :ref:`single-xml-department` | **Required** | Repeats      | Describes the administrative body for a particular voter    | There must be at least one valid         |
+|                              |                              |              |              | service.                                                    | `Department` in each                     |
+|                              |                              |              |              |                                                             | `ElectionAdministration` element. If no  |
+|                              |                              |              |              |                                                             | valid `Department` objects are present,  |
+|                              |                              |              |              |                                                             | the implementation is required to ignore |
+|                              |                              |              |              |                                                             | the `ElectionAdministration` object that |
+|                              |                              |              |              |                                                             | contains it/them.                        |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| ElectionsUri                 | ``xs:anyURI``                | Optional     | Single       | Specifies web address the administration's website.         | If the field is invalid or not present,  |
+|                              |                              |              |              |                                                             | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RegistrationUri              | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on registering to     | If the field is invalid or not present,  |
+|                              |                              |              |              | vote.                                                       | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| RulesUri                     | ``xs:anyURI``                | Optional     | Single       | Specifies a URI for the election rules and laws (if any)    | If the field is invalid or not present,  |
+|                              |                              |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhatIsOnMyBallotUri          | ``xs:anyURI``                | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+|                              |                              |              |              | individual's ballot.                                        | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+| WhereDoIVoteUri              | ``xs:anyURI``                | Optional     | Single       | The Specifies web address for information on where an       | If the field is invalid or not present,  |
+|                              |                              |              |              | individual votes based on their address.                    | then the implementation is required to   |
+|                              |                              |              |              |                                                             | ignore it.                               |
++------------------------------+------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <ElectionAdministration id="ea40133">
+      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
+      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
+      <BallotTrackingUri>https://www.vote.virginia.gov/</BallotTrackingUri>
+      <BallotProvisionalTrackingUri>https://www.vote.virginia.gov/</BallotProvisionalTrackingUri>
+      <Department>
+        <ContactInformation label="ci60000">
+          <AddressLine>Washington Building First Floor</AddressLine>
+          <AddressLine>1100 Bank Street</AddressLine>
+          <AddressLine>Richmond, VA 23219</AddressLine>
+          <Name>State Board of Elections</Name>
+        </ContactInformation>
+      </Department>
+      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
+      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
+      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
+      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
+      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
+   </ElectionAdministration>
 
 
 .. _single-xml-department:
@@ -2225,27 +2215,6 @@ VoterService
 |                          |                                          |              |              | cataloging another type of voter         | then the implementation is required to   |
 |                          |                                          |              |              | service.                                 | ignore it.                               |
 +--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>
 
 
 .. _single-xml-contact-information:
@@ -2384,27 +2353,6 @@ VoterService
 |                          |                                          |              |              | cataloging another type of voter         | then the implementation is required to   |
 |                          |                                          |              |              | service.                                 | ignore it.                               |
 +--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <ElectionAdministration id="ea40133">
-      <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-      <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-      <Department>
-        <ContactInformation label="ci60000">
-          <AddressLine>Washington Building First Floor</AddressLine>
-          <AddressLine>1100 Bank Street</AddressLine>
-          <AddressLine>Richmond, VA 23219</AddressLine>
-          <Name>State Board of Elections</Name>
-        </ContactInformation>
-      </Department>
-      <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-      <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-      <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-      <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-      <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-   </ElectionAdministration>
 
 
 .. _single-xml-hours:

--- a/docs/yaml/elements/election_administration.yaml
+++ b/docs/yaml/elements/election_administration.yaml
@@ -8,13 +8,36 @@ csv-post: |-
      :linenos:
 
 
-      id,absentee_uri,am_i_registered_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
-      ea123,https://example.com/absentee,https://example.com/am-i-registered,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
+      id,absentee_uri,am_i_registered_uri,ballot_tracking_uri,ballot_tracking_provisional_uri,elections_uri,registration_uri,rules_uri,what_is_on_my_ballot_uri,where_do_i_vote_uri
+      ea123,https://example.com/absentee,https://example.com/am-i-registered,https://www.vote.virginia.gov/,https://www.vote.virginia.gov/,https://example.com/elections,https://example.com/registration,https://example.com/rules,https://example.com/what-is-on-my-ballot,https://example.com/where-do-i-vote
       ea345,https://example.com/absentee2,https://example.com/am-i-registered2,https://example.com/elections2,https://example.com/registration2,https://example.com/rules2,https://example.com/what-is-on-my-ballot2,https://example.com/where-do-i-vote2
       ea625,https://example.com/absentee3,https://example.com/am-i-registered3,https://example.com/elections3,https://example.com/registration3,https://example.com/rules3,https://example.com/what-is-on-my-ballot3,https://example.com/where-do-i-vote3
 description: |-
   The Election Administration represents an institution for serving a locality's (or state's) election
   functions.
+post: |-
+  .. code-block:: xml
+     :linenos:
+
+     <ElectionAdministration id="ea40133">
+        <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
+        <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
+        <BallotTrackingUri>https://www.vote.virginia.gov/</BallotTrackingUri>
+        <BallotProvisionalTrackingUri>https://www.vote.virginia.gov/</BallotProvisionalTrackingUri>
+        <Department>
+          <ContactInformation label="ci60000">
+            <AddressLine>Washington Building First Floor</AddressLine>
+            <AddressLine>1100 Bank Street</AddressLine>
+            <AddressLine>Richmond, VA 23219</AddressLine>
+            <Name>State Board of Elections</Name>
+          </ContactInformation>
+        </Department>
+        <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
+        <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
+        <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
+        <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
+        <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
+     </ElectionAdministration>
 tags:
 - _name: AbsenteeUri
   csv-header-name: absentee_uri
@@ -27,6 +50,20 @@ tags:
   csv-type: xs:anyURI
   description: Specifies the web address for information on whether an individual
     is registered.
+  error_then: =must-ignore
+  type: xs:anyURI
+- _name: BallotTrackingUri
+  csv-header-name: ballot_tracking_uri
+  csv-type: xs:anyURI
+  description: Specifies the web address for tracking information for a ballot cast
+    by mail
+  error_then: =must-ignore
+  type: xs:anyURI
+- _name: BallotProvisionalTrackingUri
+  csv-header-name: ballot_tracking_provisional_uri
+  csv-type: xs:anyURI
+  description: Specifies the web address for tracking information for a provisional
+    ballot. To support EAC guidelines for "Processing Provisional Ballots" (https://www.eac.gov/research-and-data/provisional-voting/)
   error_then: =must-ignore
   type: xs:anyURI
 - _name: Department

--- a/docs/yaml/elements/voter_service.yaml
+++ b/docs/yaml/elements/voter_service.yaml
@@ -11,27 +11,6 @@ csv-post: |-
       vs02,Pencil sharpening,per50002,other,office-help,dep03
       vs03,Guided hike to polling place,per50002,other,polling-places,dep03
       vs04,Bike messenger ballot delivery,per50002,other,absentee-ballots,dep03
-post: |-
-  .. code-block:: xml
-     :linenos:
-
-     <ElectionAdministration id="ea40133">
-        <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>
-        <AmIRegisteredUri>https://www.vote.virginia.gov/</AmIRegisteredUri>
-        <Department>
-          <ContactInformation label="ci60000">
-            <AddressLine>Washington Building First Floor</AddressLine>
-            <AddressLine>1100 Bank Street</AddressLine>
-            <AddressLine>Richmond, VA 23219</AddressLine>
-            <Name>State Board of Elections</Name>
-          </ContactInformation>
-        </Department>
-        <ElectionsUri>http://www.sbe.virginia.gov/</ElectionsUri>
-        <RegistrationUri>https://www.vote.virginia.gov/</RegistrationUri>
-        <RulesUri>http://www.sbe.virginia.gov/</RulesUri>
-        <WhatIsOnMyBallotUri>https://www.vote.virginia.gov/</WhatIsOnMyBallotUri>
-        <WhereDoIVoteUri>https://www.vote.virginia.gov/</WhereDoIVoteUri>
-     </ElectionAdministration>
 tags:
 - _name: ContactInformation
   csv-header-name: contact_information

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -288,6 +288,8 @@
     <xs:sequence>
       <xs:element name="AbsenteeUri" type="xs:anyURI" minOccurs="0" />
       <xs:element name="AmIRegisteredUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="BallotTrackingUri" type="xs:anyURI" minOccurs="0" />
+      <xs:element name="BallotProvisionalTrackingUri" type="xs:anyURI" minOccurs="0" />
       <!-- A locality may have more than one department with each handling different services. -->
       <xs:element name="Department" maxOccurs="unbounded">
         <xs:complexType>


### PR DESCRIPTION
This will allow VIP participating States and Counties to list web urls in the `ElectionAdministration` object to point users to where they may find information about the tracking of mail-in ballots and provisional ballots with the latter being a suggestion from the EAC. 

Discussion thread here: https://github.com/votinginfoproject/vip-specification/issues/367