### PR TITLE
Bug/source contact information incorrectly defined

### DIFF
--- a/docs/built_rst/csv/elements/source.rst
+++ b/docs/built_rst/csv/elements/source.rst
@@ -8,41 +8,41 @@ source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+=================+==============+==============+==========================================+==========================================+
-| name             | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                  |                 |              |              | that is providing the information.       | implementation is required to ignore the |
-|                  |                 |              |              |                                          | ``Source`` element containing it.        |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vip_id           | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                  |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                  |                 |              |              |                                          | ``Source`` element containing it.        |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_time        | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                  |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                  |                 |              |              | to be in the timezone local to the       |                                          |
-|                  |                 |              |              | organization.                            |                                          |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description      | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                  |                 |              |              | organization providing the data and what | present, then the implementation is      |
-|                  |                 |              |              | data is in the feed.                     | required to ignore it.                   |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| organization_uri | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                  |                 |              |              | organization publishing the data.        | then the implementation is required to   |
-|                  |                 |              |              |                                          | ignore it.                               |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| feed_contact_id  | ``xs:IDREF``    | Optional     | Single       | Reference to the :ref:`multi-csv-person` | If the field is invalid or not present,  |
-|                  |                 |              |              | who will respond to inquiries about the  | then the implementation is required to   |
-|                  |                 |              |              | information contained within the file.   | ignore it.                               |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| terms_of_use_uri | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                  |                 |              |              | Use for the information in this file can | then the implementation is required to   |
-|                  |                 |              |              | be found.                                | ignore it.                               |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| version          | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                  |                 |              |              |                                          | implementation is required to ignore it. |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                            | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+======================================+==============+==============+==========================================+==========================================+
+| name                     | ``xs:string``                        | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                          |                                      |              |              | that is providing the information.       | implementation is required to ignore the |
+|                          |                                      |              |              |                                          | ``Source`` element containing it.        |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vip_id                   | ``xs:string``                        | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                          |                                      |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                          |                                      |              |              |                                          | ``Source`` element containing it.        |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_time                | ``xs:dateTime``                      | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                          |                                      |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                          |                                      |              |              | to be in the timezone local to the       |                                          |
+|                          |                                      |              |              | organization.                            |                                          |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description              | ``xs:string``                        | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                          |                                      |              |              | organization providing the data and what | present, then the implementation is      |
+|                          |                                      |              |              | data is in the feed.                     | required to ignore it.                   |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| organization_uri         | ``xs:string``                        | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                          |                                      |              |              | organization publishing the data.        | then the implementation is required to   |
+|                          |                                      |              |              |                                          | ignore it.                               |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| feed_contact_information | :ref:`multi-csv-contact-information` | Optional     | Single       | Reference to the :ref:`multi-csv-person` | If the element is invalid or not         |
+|                          |                                      |              |              | who will respond to inquiries about the  | present, then the implementation is      |
+|                          |                                      |              |              | information contained within the file.   | required to ignore it.                   |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| terms_of_use_uri         | ``xs:anyURI``                        | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                          |                                      |              |              | Use for the information in this file can | then the implementation is required to   |
+|                          |                                      |              |              | be found.                                | ignore it.                               |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| version                  | ``xs:string``                        | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                          |                                      |              |              |                                          | implementation is required to ignore it. |
++--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:

--- a/docs/built_rst/csv/elements/source.rst
+++ b/docs/built_rst/csv/elements/source.rst
@@ -8,41 +8,41 @@ source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                            | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+======================================+==============+==============+==========================================+==========================================+
-| name                     | ``xs:string``                        | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                          |                                      |              |              | that is providing the information.       | implementation is required to ignore the |
-|                          |                                      |              |              |                                          | ``Source`` element containing it.        |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vip_id                   | ``xs:string``                        | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                          |                                      |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                          |                                      |              |              |                                          | ``Source`` element containing it.        |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_time                | ``xs:dateTime``                      | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                          |                                      |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                          |                                      |              |              | to be in the timezone local to the       |                                          |
-|                          |                                      |              |              | organization.                            |                                          |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description              | ``xs:string``                        | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                          |                                      |              |              | organization providing the data and what | present, then the implementation is      |
-|                          |                                      |              |              | data is in the feed.                     | required to ignore it.                   |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| organization_uri         | ``xs:string``                        | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                          |                                      |              |              | organization publishing the data.        | then the implementation is required to   |
-|                          |                                      |              |              |                                          | ignore it.                               |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| feed_contact_information | :ref:`multi-csv-contact-information` | Optional     | Single       | Reference to the :ref:`multi-csv-person` | If the element is invalid or not         |
-|                          |                                      |              |              | who will respond to inquiries about the  | present, then the implementation is      |
-|                          |                                      |              |              | information contained within the file.   | required to ignore it.                   |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| terms_of_use_uri         | ``xs:anyURI``                        | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                          |                                      |              |              | Use for the information in this file can | then the implementation is required to   |
-|                          |                                      |              |              | be found.                                | ignore it.                               |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| version                  | ``xs:string``                        | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                          |                                      |              |              |                                          | implementation is required to ignore it. |
-+--------------------------+--------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                         | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
++=============================+=================+==============+==============+==========================================+==========================================+
+| name                        | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                             |                 |              |              | that is providing the information.       | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vip_id                      | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                             |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | organization.                            |                                          |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                             |                 |              |              | organization providing the data and what | present, then the implementation is      |
+|                             |                 |              |              | data is in the feed.                     | required to ignore it.                   |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| organization_uri            | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                             |                 |              |              | organization publishing the data.        | then the implementation is required to   |
+|                             |                 |              |              |                                          | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| feed_contact_information_id | ``xs:IDREF``    | Optional     | Single       | Reference to the :ref:`multi-csv-person` | If the element is invalid or not         |
+|                             |                 |              |              | who will respond to inquiries about the  | present, then the implementation is      |
+|                             |                 |              |              | information contained within the file.   | required to ignore it.                   |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| terms_of_use_uri            | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                             |                 |              |              | Use for the information in this file can | then the implementation is required to   |
+|                             |                 |              |              | be found.                                | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                             |                 |              |              |                                          | implementation is required to ignore it. |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -345,42 +345,42 @@ source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+=======================================+==============+==============+==========================================+==========================================+
-| name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                          |                                       |              |              | that is providing the information.       | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Source`` element containing it.        |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vip_id                   | ``xs:string``                         | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                          |                                       |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Source`` element containing it.        |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_time                | ``xs:dateTime``                       | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                          |                                       |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                          |                                       |              |              | to be in the timezone local to the       |                                          |
-|                          |                                       |              |              | organization.                            |                                          |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description              | ``xs:string``                         | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                          |                                       |              |              | organization providing the data and what | present, then the implementation is      |
-|                          |                                       |              |              | data is in the feed.                     | required to ignore it.                   |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| organization_uri         | ``xs:string``                         | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                          |                                       |              |              | organization publishing the data.        | then the implementation is required to   |
-|                          |                                       |              |              |                                          | ignore it.                               |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| feed_contact_information | :ref:`single-csv-contact-information` | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
-|                          |                                       |              |              | :ref:`single-csv-person` who will        | present, then the implementation is      |
-|                          |                                       |              |              | respond to inquiries about the           | required to ignore it.                   |
-|                          |                                       |              |              | information contained within the file.   |                                          |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| terms_of_use_uri         | ``xs:anyURI``                         | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                          |                                       |              |              | Use for the information in this file can | then the implementation is required to   |
-|                          |                                       |              |              | be found.                                | ignore it.                               |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| version                  | ``xs:string``                         | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                          |                                       |              |              |                                          | implementation is required to ignore it. |
-+--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                         | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
++=============================+=================+==============+==============+==========================================+==========================================+
+| name                        | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                             |                 |              |              | that is providing the information.       | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vip_id                      | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                             |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | organization.                            |                                          |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                             |                 |              |              | organization providing the data and what | present, then the implementation is      |
+|                             |                 |              |              | data is in the feed.                     | required to ignore it.                   |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| organization_uri            | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                             |                 |              |              | organization publishing the data.        | then the implementation is required to   |
+|                             |                 |              |              |                                          | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| feed_contact_information_id | ``xs:IDREF``    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
+|                             |                 |              |              | :ref:`single-csv-person` who will        | present, then the implementation is      |
+|                             |                 |              |              | respond to inquiries about the           | required to ignore it.                   |
+|                             |                 |              |              | information contained within the file.   |                                          |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| terms_of_use_uri            | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                             |                 |              |              | Use for the information in this file can | then the implementation is required to   |
+|                             |                 |              |              | be found.                                | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                             |                 |              |              |                                          | implementation is required to ignore it. |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -345,42 +345,42 @@ source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+=================+==============+==============+==========================================+==========================================+
-| name             | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                  |                 |              |              | that is providing the information.       | implementation is required to ignore the |
-|                  |                 |              |              |                                          | ``Source`` element containing it.        |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vip_id           | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                  |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                  |                 |              |              |                                          | ``Source`` element containing it.        |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_time        | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                  |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                  |                 |              |              | to be in the timezone local to the       |                                          |
-|                  |                 |              |              | organization.                            |                                          |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description      | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                  |                 |              |              | organization providing the data and what | present, then the implementation is      |
-|                  |                 |              |              | data is in the feed.                     | required to ignore it.                   |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| organization_uri | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                  |                 |              |              | organization publishing the data.        | then the implementation is required to   |
-|                  |                 |              |              |                                          | ignore it.                               |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| feed_contact_id  | ``xs:IDREF``    | Optional     | Single       | Reference to the                         | If the field is invalid or not present,  |
-|                  |                 |              |              | :ref:`single-csv-person` who will        | then the implementation is required to   |
-|                  |                 |              |              | respond to inquiries about the           | ignore it.                               |
-|                  |                 |              |              | information contained within the file.   |                                          |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| terms_of_use_uri | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                  |                 |              |              | Use for the information in this file can | then the implementation is required to   |
-|                  |                 |              |              | be found.                                | ignore it.                               |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| version          | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                  |                 |              |              |                                          | implementation is required to ignore it. |
-+------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+=======================================+==============+==============+==========================================+==========================================+
+| name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                          |                                       |              |              | that is providing the information.       | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Source`` element containing it.        |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vip_id                   | ``xs:string``                         | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                          |                                       |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Source`` element containing it.        |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_time                | ``xs:dateTime``                       | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                          |                                       |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                          |                                       |              |              | to be in the timezone local to the       |                                          |
+|                          |                                       |              |              | organization.                            |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description              | ``xs:string``                         | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                          |                                       |              |              | organization providing the data and what | present, then the implementation is      |
+|                          |                                       |              |              | data is in the feed.                     | required to ignore it.                   |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| organization_uri         | ``xs:string``                         | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                          |                                       |              |              | organization publishing the data.        | then the implementation is required to   |
+|                          |                                       |              |              |                                          | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| feed_contact_information | :ref:`single-csv-contact-information` | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
+|                          |                                       |              |              | :ref:`single-csv-person` who will        | present, then the implementation is      |
+|                          |                                       |              |              | respond to inquiries about the           | required to ignore it.                   |
+|                          |                                       |              |              | information contained within the file.   |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| terms_of_use_uri         | ``xs:anyURI``                         | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                          |                                       |              |              | Use for the information in this file can | then the implementation is required to   |
+|                          |                                       |              |              | be found.                                | ignore it.                               |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| version                  | ``xs:string``                         | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                          |                                       |              |              |                                          | implementation is required to ignore it. |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:

--- a/docs/built_rst/tables/elements/source.rst
+++ b/docs/built_rst/tables/elements/source.rst
@@ -1,37 +1,37 @@
 .. This file is auto-generated.  Do not edit it by hand!
 
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+=========================================+==============+==============+==========================================+==========================================+
-| Name            | ``xs:string``                           | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                 |                                         |              |              | that is providing the information.       | implementation is required to ignore the |
-|                 |                                         |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VipId           | ``xs:string``                           | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                 |                                         |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                 |                                         |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| DateTime        | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                 |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                 |                                         |              |              | to be in the timezone local to the       |                                          |
-|                 |                                         |              |              | organization.                            |                                          |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description     | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                 |                                         |              |              | organization providing the data and what | present, then the implementation is      |
-|                 |                                         |              |              | data is in the feed.                     | required to ignore it.                   |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OrganizationUri | ``xs:string``                           | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                 |                                         |              |              | organization publishing the data.        | then the implementation is required to   |
-|                 |                                         |              |              |                                          | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FeedContactId   | ``xs:IDREF``                            | Optional     | Single       | Reference to the :ref:`multi-xml-person` | If the field is invalid or not present,  |
-|                 |                                         |              |              | who will respond to inquiries about the  | then the implementation is required to   |
-|                 |                                         |              |              | information contained within the file.   | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| TouUri          | ``xs:anyURI``                           | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                 |                                         |              |              | Use for the information in this file can | then the implementation is required to   |
-|                 |                                         |              |              | be found.                                | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Version         | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                 |                                         |              |              |                                          | implementation is required to ignore it. |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+=========================================+==============+==============+==========================================+==========================================+
+| Name                   | ``xs:string``                           | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                        |                                         |              |              | that is providing the information.       | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VipId                  | ``xs:string``                           | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                        |                                         |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | organization.                            |                                          |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                        |                                         |              |              | organization providing the data and what | present, then the implementation is      |
+|                        |                                         |              |              | data is in the feed.                     | required to ignore it.                   |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrganizationUri        | ``xs:string``                           | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                        |                                         |              |              | organization publishing the data.        | then the implementation is required to   |
+|                        |                                         |              |              |                                          | ignore it.                               |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FeedContactInformation | :ref:`multi-xml-contact-information`    | Optional     | Single       | Reference to the :ref:`multi-xml-person` | If the element is invalid or not         |
+|                        |                                         |              |              | who will respond to inquiries about the  | present, then the implementation is      |
+|                        |                                         |              |              | information contained within the file.   | required to ignore it.                   |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| TouUri                 | ``xs:anyURI``                           | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                        |                                         |              |              | Use for the information in this file can | then the implementation is required to   |
+|                        |                                         |              |              | be found.                                | ignore it.                               |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                        |                                         |              |              |                                          | implementation is required to ignore it. |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/source.rst
+++ b/docs/built_rst/xml/elements/source.rst
@@ -8,41 +8,41 @@ Source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+=========================================+==============+==============+==========================================+==========================================+
-| Name            | ``xs:string``                           | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                 |                                         |              |              | that is providing the information.       | implementation is required to ignore the |
-|                 |                                         |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VipId           | ``xs:string``                           | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                 |                                         |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                 |                                         |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| DateTime        | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                 |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                 |                                         |              |              | to be in the timezone local to the       |                                          |
-|                 |                                         |              |              | organization.                            |                                          |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description     | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                 |                                         |              |              | organization providing the data and what | present, then the implementation is      |
-|                 |                                         |              |              | data is in the feed.                     | required to ignore it.                   |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OrganizationUri | ``xs:string``                           | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                 |                                         |              |              | organization publishing the data.        | then the implementation is required to   |
-|                 |                                         |              |              |                                          | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FeedContactId   | ``xs:IDREF``                            | Optional     | Single       | Reference to the :ref:`multi-xml-person` | If the field is invalid or not present,  |
-|                 |                                         |              |              | who will respond to inquiries about the  | then the implementation is required to   |
-|                 |                                         |              |              | information contained within the file.   | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| TouUri          | ``xs:anyURI``                           | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                 |                                         |              |              | Use for the information in this file can | then the implementation is required to   |
-|                 |                                         |              |              | be found.                                | ignore it.                               |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Version         | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                 |                                         |              |              |                                          | implementation is required to ignore it. |
-+-----------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+=========================================+==============+==============+==========================================+==========================================+
+| Name                   | ``xs:string``                           | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                        |                                         |              |              | that is providing the information.       | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VipId                  | ``xs:string``                           | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                        |                                         |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | organization.                            |                                          |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                        |                                         |              |              | organization providing the data and what | present, then the implementation is      |
+|                        |                                         |              |              | data is in the feed.                     | required to ignore it.                   |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrganizationUri        | ``xs:string``                           | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                        |                                         |              |              | organization publishing the data.        | then the implementation is required to   |
+|                        |                                         |              |              |                                          | ignore it.                               |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FeedContactInformation | :ref:`multi-xml-contact-information`    | Optional     | Single       | Reference to the :ref:`multi-xml-person` | If the element is invalid or not         |
+|                        |                                         |              |              | who will respond to inquiries about the  | present, then the implementation is      |
+|                        |                                         |              |              | information contained within the file.   | required to ignore it.                   |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| TouUri                 | ``xs:anyURI``                           | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                        |                                         |              |              | Use for the information in this file can | then the implementation is required to   |
+|                        |                                         |              |              | be found.                                | ignore it.                               |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                        |                                         |              |              |                                          | implementation is required to ignore it. |
++------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
 

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -427,42 +427,42 @@ Source
 The Source object represents the organization that is publishing the information. This object is
 the only required object in the feed file, and only one source object is allowed to be present.
 
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+==========================================+==============+==============+==========================================+==========================================+
-| Name            | ``xs:string``                            | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                 |                                          |              |              | that is providing the information.       | implementation is required to ignore the |
-|                 |                                          |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VipId           | ``xs:string``                            | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                 |                                          |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                 |                                          |              |              |                                          | ``Source`` element containing it.        |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| DateTime        | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                 |                                          |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                 |                                          |              |              | to be in the timezone local to the       |                                          |
-|                 |                                          |              |              | organization.                            |                                          |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description     | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                 |                                          |              |              | organization providing the data and what | present, then the implementation is      |
-|                 |                                          |              |              | data is in the feed.                     | required to ignore it.                   |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OrganizationUri | ``xs:string``                            | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                 |                                          |              |              | organization publishing the data.        | then the implementation is required to   |
-|                 |                                          |              |              |                                          | ignore it.                               |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FeedContactId   | ``xs:IDREF``                             | Optional     | Single       | Reference to the                         | If the field is invalid or not present,  |
-|                 |                                          |              |              | :ref:`single-xml-person` who will        | then the implementation is required to   |
-|                 |                                          |              |              | respond to inquiries about the           | ignore it.                               |
-|                 |                                          |              |              | information contained within the file.   |                                          |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| TouUri          | ``xs:anyURI``                            | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                 |                                          |              |              | Use for the information in this file can | then the implementation is required to   |
-|                 |                                          |              |              | be found.                                | ignore it.                               |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Version         | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                 |                                          |              |              |                                          | implementation is required to ignore it. |
-+-----------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+==========================================+==============+==============+==========================================+==========================================+
+| Name                   | ``xs:string``                            | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                        |                                          |              |              | that is providing the information.       | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VipId                  | ``xs:string``                            | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                        |                                          |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateTime               | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore it. |
+|                        |                                          |              |              | to be in the timezone local to the       |                                          |
+|                        |                                          |              |              | organization.                            |                                          |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                        |                                          |              |              | organization providing the data and what | present, then the implementation is      |
+|                        |                                          |              |              | data is in the feed.                     | required to ignore it.                   |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrganizationUri        | ``xs:string``                            | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                        |                                          |              |              | organization publishing the data.        | then the implementation is required to   |
+|                        |                                          |              |              |                                          | ignore it.                               |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FeedContactInformation | :ref:`single-xml-contact-information`    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
+|                        |                                          |              |              | :ref:`single-xml-person` who will        | present, then the implementation is      |
+|                        |                                          |              |              | respond to inquiries about the           | required to ignore it.                   |
+|                        |                                          |              |              | information contained within the file.   |                                          |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| TouUri                 | ``xs:anyURI``                            | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                        |                                          |              |              | Use for the information in this file can | then the implementation is required to   |
+|                        |                                          |              |              | be found.                                | ignore it.                               |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Version                | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                        |                                          |              |              |                                          | implementation is required to ignore it. |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
 

--- a/docs/yaml/elements/source.yaml
+++ b/docs/yaml/elements/source.yaml
@@ -63,8 +63,8 @@ tags:
   error_then: =must-ignore
   type: xs:string
 - _name: FeedContactInformation
-  csv-header-name: feed_contact_information
-  csv-type: ContactInformation
+  csv-header-name: feed_contact_information_id
+  csv-type: xs:IDREF
   description: Reference to the :ref:`$$$-person` who will respond to inquiries about
     the information contained within the file.
   error_then: =must-ignore

--- a/docs/yaml/elements/source.yaml
+++ b/docs/yaml/elements/source.yaml
@@ -62,13 +62,13 @@ tags:
     data.
   error_then: =must-ignore
   type: xs:string
-- _name: FeedContactId
-  csv-header-name: feed_contact_id
-  csv-type: xs:IDREF
+- _name: FeedContactInformation
+  csv-header-name: feed_contact_information
+  csv-type: ContactInformation
   description: Reference to the :ref:`$$$-person` who will respond to inquiries about
     the information contained within the file.
   error_then: =must-ignore
-  type: xs:IDREF
+  type: ContactInformation
 - _name: TouUri
   csv-header-name: terms_of_use_uri
   csv-type: xs:anyURI


### PR DESCRIPTION
The documentation was incorrectly asserting there was a `Source.FeedContactId` attribute, and per the [XSD](https://github.com/votinginfoproject/vip-specification/blob/43488653f48b9362a7d7c04fc2326a352960f07f/vip_spec.xsd#L691) this should be `Source.FeedContactInformation` of type ContactInformation. 