### PR TITLE
Feature/issue 400 add locality ismailonly

### DIFF
--- a/docs/built_rst/csv/elements/locality.rst
+++ b/docs/built_rst/csv/elements/locality.rst
@@ -18,9 +18,25 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                            |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                            |                                       |              |              |                                          | implementation is required to ignore the |
 |                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| is_mail_only               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                            |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                            |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                            |                                       |              |              | locality will also run mail-only         |                                          |
+|                            |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                            |                                       |              |              | addition to this flag using a            |                                          |
+|                            |                                       |              |              | :ref:`polling location                   |                                          |
+|                            |                                       |              |              | <multi-csv-polling-location>` record     |                                          |
+|                            |                                       |              |              | configured as a Drop Box.                |                                          |
++----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                            |                                       |              |              |                                          | the implementation is required to ignore |
+|                            |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                            |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |
@@ -48,6 +64,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
    :linenos:
 
 
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-    loc002,ea345,,,,Locality #2,,st51,other,unique type
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+    loc002,ea345,,,,,Locality #2,,st51,other,unique type

--- a/docs/built_rst/csv/elements/locality.rst
+++ b/docs/built_rst/csv/elements/locality.rst
@@ -18,11 +18,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                            |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                            |                                       |              |              |                                          | implementation is required to ignore the |
-|                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | is_mail_only               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                            |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                            |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -33,10 +28,9 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | <multi-csv-polling-location>` record     |                                          |
 |                            |                                       |              |              | configured as a Drop Box.                |                                          |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                            |                                       |              |              |                                          | the implementation is required to ignore |
-|                            |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                            |                                       |              |              |                                          | implementation is required to ignore the |
+|                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                            |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/csv/elements/source.rst
+++ b/docs/built_rst/csv/elements/source.rst
@@ -20,8 +20,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                             |                 |              |              | organization.                            |                                          |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -41,7 +41,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              | be found.                                | ignore it.                               |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                             |                 |              |              |                                          | implementation is required to ignore it. |
+|                             |                 |              |              |                                          | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1335,9 +1335,24 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                            |                                        |              |              |                                           | required to ignore it.                   |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
 |                            |                                        |              |              |                                           | implementation is required to ignore the |
 |                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
+=======
+| is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                            |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                            |                                        |              |              | may be used in addition to this flag      |                                          |
+|                            |                                        |              |              | using a :ref:`polling location            |                                          |
+|                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
+|                            |                                        |              |              | configured as a Drop Box.                 |                                          |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
+|                            |                                        |              |              |                                           | the implementation is required to ignore |
+|                            |                                        |              |              |                                           | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -1365,9 +1380,9 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
    :linenos:
 
 
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-    loc002,ea345,,,,Locality #2,,st51,other,unique type
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+    loc002,ea345,,,,,Locality #2,,st51,other,unique type
 
 
 .. _single-csv-department:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -358,8 +358,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                             |                 |              |              | organization.                            |                                          |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -380,7 +380,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              | be found.                                | ignore it.                               |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                             |                 |              |              |                                          | implementation is required to ignore it. |
+|                             |                 |              |              |                                          | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
@@ -1335,11 +1336,6 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                            |                                        |              |              |                                           | required to ignore it.                   |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                            |                                        |              |              |                                           | implementation is required to ignore the |
-|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
-=======
 | is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
 |                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
 |                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
@@ -1349,10 +1345,9 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
 |                            |                                        |              |              | configured as a Drop Box.                 |                                          |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
-|                            |                                        |              |              |                                           | the implementation is required to ignore |
-|                            |                                        |              |              |                                           | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                            |                                        |              |              |                                           | implementation is required to ignore the |
+|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |

--- a/docs/built_rst/tables/elements/locality.rst
+++ b/docs/built_rst/tables/elements/locality.rst
@@ -11,11 +11,6 @@
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                          |                                       |              |              |                                          | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -26,10 +21,9 @@
 |                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
 |                          |                                       |              |              | configured as a Drop Box.                |                                          |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                          |                                       |              |              |                                          | the implementation is required to ignore |
-|                          |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                          |                                       |              |              |                                          | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/tables/elements/locality.rst
+++ b/docs/built_rst/tables/elements/locality.rst
@@ -11,9 +11,25 @@
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                          |                                       |              |              |                                          | implementation is required to ignore the |
 |                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                          |                                       |              |              | locality will also run mail-only         |                                          |
+|                          |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                          |                                       |              |              | addition to this flag using a            |                                          |
+|                          |                                       |              |              | :ref:`polling location                   |                                          |
+|                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
+|                          |                                       |              |              | configured as a Drop Box.                |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/tables/elements/source.rst
+++ b/docs/built_rst/tables/elements/source.rst
@@ -12,8 +12,8 @@
 |                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                         |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                         |              |              | organization.                            |                                          |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -33,5 +33,6 @@
 |                        |                                         |              |              | be found.                                | ignore it.                               |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                         |              |              |                                          | implementation is required to ignore it. |
+|                        |                                         |              |              |                                          | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/locality.rst
+++ b/docs/built_rst/xml/elements/locality.rst
@@ -18,11 +18,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                          |                                       |              |              |                                          | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -33,10 +28,9 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
 |                          |                                       |              |              | configured as a Drop Box.                |                                          |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                          |                                       |              |              |                                          | the implementation is required to ignore |
-|                          |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                          |                                       |              |              |                                          | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/xml/elements/locality.rst
+++ b/docs/built_rst/xml/elements/locality.rst
@@ -18,9 +18,25 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                          |                                       |              |              |                                          | implementation is required to ignore the |
 |                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                          |                                       |              |              | locality will also run mail-only         |                                          |
+|                          |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                          |                                       |              |              | addition to this flag using a            |                                          |
+|                          |                                       |              |              | :ref:`polling location                   |                                          |
+|                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
+|                          |                                       |              |              | configured as a Drop Box.                |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |
@@ -57,6 +73,7 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
          <Value>ocd-division/country:us/state:va/county:albemarle</Value>
        </ExternalIdentifier>
      </ExternalIdentifiers>
+     <IsMailOnly>true</IsMailOnly>
      <Name>ALBEMARLE COUNTY</Name>
      <StateId>st51</StateId>
      <Type>county</Type>

--- a/docs/built_rst/xml/elements/source.rst
+++ b/docs/built_rst/xml/elements/source.rst
@@ -20,8 +20,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                         |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                         |              |              | organization.                            |                                          |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -41,7 +41,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                         |              |              | be found.                                | ignore it.                               |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                         |              |              |                                          | implementation is required to ignore it. |
+|                        |                                         |              |              |                                          | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -440,8 +440,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                          |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                          |              |              | to be in the timezone local to the       |                                          |
+|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                          |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                          |              |              | organization.                            |                                          |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -462,7 +462,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                          |              |              | be found.                                | ignore it.                               |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                          |              |              |                                          | implementation is required to ignore it. |
+|                        |                                          |              |              |                                          | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
@@ -1566,11 +1567,6 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                          |                                        |              |              |                                           | required to ignore it.                   |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                          |                                        |              |              |                                           | implementation is required to ignore the |
-|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
 |                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
 |                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
@@ -1580,10 +1576,9 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
 |                          |                                        |              |              | configured as a Drop Box.                 |                                          |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
-|                          |                                        |              |              |                                           | the implementation is required to ignore |
-|                          |                                        |              |              |                                           | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                          |                                        |              |              |                                           | implementation is required to ignore the |
+|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1566,9 +1566,24 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                          |                                        |              |              |                                           | required to ignore it.                   |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
 |                          |                                        |              |              |                                           | implementation is required to ignore the |
 |                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                          |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                          |                                        |              |              | may be used in addition to this flag      |                                          |
+|                          |                                        |              |              | using a :ref:`polling location            |                                          |
+|                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
+|                          |                                        |              |              | configured as a Drop Box.                 |                                          |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
+|                          |                                        |              |              |                                           | the implementation is required to ignore |
+|                          |                                        |              |              |                                           | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -1605,6 +1620,7 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
          <Value>ocd-division/country:us/state:va/county:albemarle</Value>
        </ExternalIdentifier>
      </ExternalIdentifiers>
+     <IsMailOnly>true</IsMailOnly>
      <Name>ALBEMARLE COUNTY</Name>
      <StateId>st51</StateId>
      <Type>county</Type>

--- a/docs/yaml/elements/locality.yaml
+++ b/docs/yaml/elements/locality.yaml
@@ -5,9 +5,9 @@ csv-post: |-
      :linenos:
 
 
-      id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-      loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-      loc002,ea345,,,,Locality #2,,st51,other,unique type
+      id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+      loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+      loc002,ea345,,,,,Locality #2,,st51,other,unique type
 description: The Locality object represents the jurisdiction below the :ref:`$$$-state`
   (e.g. county).
 post: |-
@@ -24,6 +24,7 @@ post: |-
            <Value>ocd-division/country:us/state:va/county:albemarle</Value>
          </ExternalIdentifier>
        </ExternalIdentifiers>
+       <IsMailOnly>true</IsMailOnly>
        <Name>ALBEMARLE COUNTY</Name>
        <StateId>st51</StateId>
        <Type>county</Type>
@@ -42,6 +43,16 @@ tags:
     `OCD-ID`_)
   error_then: =must-ignore
   type: ExternalIdentifiers
+- _name: IsMailOnly
+  csv-header-name: is_mail_only
+  csv-type: xs:boolean
+  description: Determines if the locality runs mail-only elections. If this is true,
+    then all precincts a part of the locality will also run mail-only elections. Drop
+    boxes may be used in addition to this flag using a :ref:`polling location <$$$-polling-location>`
+    record configured as a Drop Box.
+  error: If the field is missing or invalid, the implementation is required to assume
+    `IsMailOnly` is false.
+  type: xs:boolean
 - _name: Name
   csv-header-name: name
   csv-type: xs:string

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -72,6 +72,20 @@
     <Type>county</Type>
   </Locality>
 
+  <Locality id="loc70002">
+    <ElectionAdministrationId>ea40001</ElectionAdministrationId>
+    <ExternalIdentifiers>
+      <ExternalIdentifier>
+        <Type>ocd-id</Type>
+        <Value>ocd-division/country:us/state:va/county:fairfax</Value>
+      </ExternalIdentifier>
+    </ExternalIdentifiers>
+    <IsMailOnly>true</IsMailOnly>
+    <Name>Fairfax COUNTY</Name>
+    <StateId>st51</StateId>
+    <Type>county</Type>
+  </Locality>
+
   <!-- Information about the election administration organizations for various jurisdictions. -->
   <ElectionAdministration id="ea40133">
     <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -441,7 +441,7 @@
     <xs:sequence>
       <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
       <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
-      <xs:element name="Name" type="xs:string" />
+      <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
       <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
       <xs:element name="StateId" type="xs:IDREF" />
       <xs:element name="Type" type="DistrictType" minOccurs="0" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -442,6 +442,7 @@
       <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
       <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
       <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Name" type="xs:string" />
       <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
       <xs:element name="StateId" type="xs:IDREF" />
       <xs:element name="Type" type="DistrictType" minOccurs="0" />


### PR DESCRIPTION
We're adding an `IsMailOnly` flag to the Locality element to efficiently flag that a Locality maintains vote by mail for each of it's precincts. 