### PR TITLE
Feature/issue 401 add election notice

### DIFF
--- a/docs/built_rst/csv/elements/election.rst
+++ b/docs/built_rst/csv/elements/election.rst
@@ -12,77 +12,103 @@ the Election specified by this object. It is permissible, and recommended, to co
 contests (e.g., a special election and a general election) that occur on the same day into one feed
 with one Election object.
 
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============================+================+==============+==============+==========================================+==========================================+
-| date                          | ``xs:date``    | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
-|                               |                |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
-|                               |                |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
-|                               |                |              |              | the election.                            |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| election_type                 | ``xs:string``  | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
-|                               |                |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
-|                               |                |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| state_id                      | ``xs:IDREF``   | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
-|                               |                |              |              | where the election is being held.        | implementation is required to ignore the |
-|                               |                |              |              |                                          | ``Election`` element containing it.      |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_statewide                  | ``xs:boolean`` | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
-|                               |                |              |              | statewide.                               | the implementation is required to        |
-|                               |                |              |              |                                          | default to "yes".                        |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                          | ``xs:string``  | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
-|                               |                |              |              | optional, this element is highly         | present, then the implementation is      |
-|                               |                |              |              | recommended).                            | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_info             | ``xs:string``  | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
-|                               |                |              |              | for this election either as text or a    | present, then the implementation is      |
-|                               |                |              |              | URI.                                     | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_ballot_info          | ``xs:string``  | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
-|                               |                |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
-|                               |                |              |              |                                          | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| results_uri                   | ``xs:anyURI``  | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
-|                               |                |              |              | election may be found                    | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| polling_hours                 | ``xs:string``  | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                               |                |              |              | Election Day polling locations are open. | present, then the implementation is      |
-|                               |                |              |              | If polling hours differ in specific      | required to ignore it.                   |
-|                               |                |              |              | polling locations, alternative hours may |                                          |
-|                               |                |              |              | be specified in the                      |                                          |
-|                               |                |              |              | :ref:`multi-csv-polling-location` object |                                          |
-|                               |                |              |              | *(NB: this element is deprecated in      |                                          |
-|                               |                |              |              | favor of the more structured             |                                          |
-|                               |                |              |              | :ref:`multi-csv-hours-open` element. It  |                                          |
-|                               |                |              |              | is strongly encouraged that data         |                                          |
-|                               |                |              |              | providers move toward contributing hours |                                          |
-|                               |                |              |              | in this format)*.                        |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_ids                | ``xs:IDREF``   | Optional     | Single       | References the                           | If the field is invalid or not present,  |
-|                               |                |              |              | :ref:`multi-csv-hours-open` element,     | then the implementation is required to   |
-|                               |                |              |              | which lists the hours of operation for   | ignore it.                               |
-|                               |                |              |              | polling locations.                       |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| has_election_day_registration | ``xs:boolean`` | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
-|                               |                |              |              | same day of the election (i.e., the last | then the implementation is required to   |
-|                               |                |              |              | day of the election). Valid items are    | ignore it.                               |
-|                               |                |              |              | "yes" and "no".                          |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_deadline         | ``xs:date``    | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
-|                               |                |              |              | the election with the possible exception | then the implementation is required to   |
-|                               |                |              |              | of Election Day registration.            | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_request_deadline     | ``xs:date``    | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
-|                               |                |              |              | absentee ballot.                         | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                           | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============================+==================================+==============+==============+==========================================+==========================================+
+| date                          | ``xs:date``                      | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
+|                               |                                  |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
+|                               |                                  |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
+|                               |                                  |              |              | the election.                            |                                          |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice               | :ref:`multi-csv-election-notice` | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
+|                               |                                  |              |              | information related to election notices, | present, then the implementation is      |
+|                               |                                  |              |              | including those attributed to natural    | required to ignore it.                   |
+|                               |                                  |              |              | disasters and other unforseen events.    |                                          |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_type                 | ``xs:string``                    | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
+|                               |                                  |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
+|                               |                                  |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| state_id                      | ``xs:IDREF``                     | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
+|                               |                                  |              |              | where the election is being held.        | implementation is required to ignore the |
+|                               |                                  |              |              |                                          | ``Election`` element containing it.      |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_statewide                  | ``xs:boolean``                   | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
+|                               |                                  |              |              | statewide.                               | the implementation is required to        |
+|                               |                                  |              |              |                                          | default to "yes".                        |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                          | ``xs:string``                    | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
+|                               |                                  |              |              | optional, this element is highly         | present, then the implementation is      |
+|                               |                                  |              |              | recommended).                            | required to ignore it.                   |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_info             | ``xs:string``                    | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
+|                               |                                  |              |              | for this election either as text or a    | present, then the implementation is      |
+|                               |                                  |              |              | URI.                                     | required to ignore it.                   |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_ballot_info          | ``xs:string``                    | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
+|                               |                                  |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
+|                               |                                  |              |              |                                          | required to ignore it.                   |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| results_uri                   | ``xs:anyURI``                    | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
+|                               |                                  |              |              | election may be found                    | then the implementation is required to   |
+|                               |                                  |              |              |                                          | ignore it.                               |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| polling_hours                 | ``xs:string``                    | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                               |                                  |              |              | Election Day polling locations are open. | present, then the implementation is      |
+|                               |                                  |              |              | If polling hours differ in specific      | required to ignore it.                   |
+|                               |                                  |              |              | polling locations, alternative hours may |                                          |
+|                               |                                  |              |              | be specified in the                      |                                          |
+|                               |                                  |              |              | :ref:`multi-csv-polling-location` object |                                          |
+|                               |                                  |              |              | *(NB: this element is deprecated in      |                                          |
+|                               |                                  |              |              | favor of the more structured             |                                          |
+|                               |                                  |              |              | :ref:`multi-csv-hours-open` element. It  |                                          |
+|                               |                                  |              |              | is strongly encouraged that data         |                                          |
+|                               |                                  |              |              | providers move toward contributing hours |                                          |
+|                               |                                  |              |              | in this format)*.                        |                                          |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_ids                | ``xs:IDREF``                     | Optional     | Single       | References the                           | If the field is invalid or not present,  |
+|                               |                                  |              |              | :ref:`multi-csv-hours-open` element,     | then the implementation is required to   |
+|                               |                                  |              |              | which lists the hours of operation for   | ignore it.                               |
+|                               |                                  |              |              | polling locations.                       |                                          |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| has_election_day_registration | ``xs:boolean``                   | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
+|                               |                                  |              |              | same day of the election (i.e., the last | then the implementation is required to   |
+|                               |                                  |              |              | day of the election). Valid items are    | ignore it.                               |
+|                               |                                  |              |              | "yes" and "no".                          |                                          |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_deadline         | ``xs:date``                      | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
+|                               |                                  |              |              | the election with the possible exception | then the implementation is required to   |
+|                               |                                  |              |              | of Election Day registration.            | ignore it.                               |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_request_deadline     | ``xs:date``                      | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
+|                               |                                  |              |              | absentee ballot.                         | then the implementation is required to   |
+|                               |                                  |              |              |                                          | ignore it.                               |
++-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,date,name,election_type,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
-    e001,10-08-2016,Best Hot Dog,State,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
+    id,date,name,election_type,election_notice_text,election_notice_uri,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
+    e001,10-08-2016,Best Hot Dog,State,There are some last minute changes for this election. For additional information see the accompanying URL,https://someelectionnotice.gov,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
+
+
+.. _multi-csv-election-notice:
+
+election_notice
+---------------
+
+The ElectionNotice description. 
+
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+===============+==============+==============+==========================================+==========================================+
+| election_notice_text | ``xs:string`` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|                      |               |              |              |                                          | implementation is required to ignore the |
+|                      |               |              |              |                                          | ``ElectionNotice`` element containing    |
+|                      |               |              |              |                                          | it.                                      |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice_uri  | ``xs:string`` | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|                      |               |              |              | related to the Election Notice.          | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/elements/election.rst
+++ b/docs/built_rst/csv/elements/election.rst
@@ -23,7 +23,7 @@ with one Election object.
 | election_notice               | :ref:`multi-csv-election-notice` | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
 |                               |                                  |              |              | information related to election notices, | present, then the implementation is      |
 |                               |                                  |              |              | including those attributed to natural    | required to ignore it.                   |
-|                               |                                  |              |              | disasters and other unforseen events.    |                                          |
+|                               |                                  |              |              | disasters and other unforeseen events.   |                                          |
 +-------------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | election_type                 | ``xs:string``                    | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                               |                                  |              |              | authority for election (e.g., federal,   | present, then the implementation is      |

--- a/docs/built_rst/csv/elements/locality.rst
+++ b/docs/built_rst/csv/elements/locality.rst
@@ -18,9 +18,25 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                            |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                            |                                       |              |              |                                          | implementation is required to ignore the |
 |                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| is_mail_only               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                            |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                            |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                            |                                       |              |              | locality will also run mail-only         |                                          |
+|                            |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                            |                                       |              |              | addition to this flag using a            |                                          |
+|                            |                                       |              |              | :ref:`polling location                   |                                          |
+|                            |                                       |              |              | <multi-csv-polling-location>` record     |                                          |
+|                            |                                       |              |              | configured as a Drop Box.                |                                          |
++----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                            |                                       |              |              |                                          | the implementation is required to ignore |
+|                            |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                            |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |
@@ -48,6 +64,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
    :linenos:
 
 
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-    loc002,ea345,,,,Locality #2,,st51,other,unique type
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+    loc002,ea345,,,,,Locality #2,,st51,other,unique type

--- a/docs/built_rst/csv/elements/locality.rst
+++ b/docs/built_rst/csv/elements/locality.rst
@@ -18,11 +18,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                            |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                            |                                       |              |              |                                          | implementation is required to ignore the |
-|                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | is_mail_only               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                            |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                            |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -33,10 +28,9 @@ The Locality object represents the jurisdiction below the :ref:`multi-csv-state`
 |                            |                                       |              |              | <multi-csv-polling-location>` record     |                                          |
 |                            |                                       |              |              | configured as a Drop Box.                |                                          |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                            |                                       |              |              |                                          | the implementation is required to ignore |
-|                            |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| name                       | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                            |                                       |              |              |                                          | implementation is required to ignore the |
+|                            |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                            |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/csv/elements/source.rst
+++ b/docs/built_rst/csv/elements/source.rst
@@ -20,8 +20,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                             |                 |              |              | organization.                            |                                          |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -41,7 +41,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              | be found.                                | ignore it.                               |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                             |                 |              |              |                                          | implementation is required to ignore it. |
+|                             |                 |              |              |                                          | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -253,7 +253,7 @@ with one Election object.
 | election_notice               | :ref:`single-csv-election-notice` | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
 |                               |                                   |              |              | information related to election notices, | present, then the implementation is      |
 |                               |                                   |              |              | including those attributed to natural    | required to ignore it.                   |
-|                               |                                   |              |              | disasters and other unforseen events.    |                                          |
+|                               |                                   |              |              | disasters and other unforeseen events.   |                                          |
 +-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | election_type                 | ``xs:string``                     | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                               |                                   |              |              | authority for election (e.g., federal,   | present, then the implementation is      |

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1335,9 +1335,24 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                            |                                        |              |              |                                           | required to ignore it.                   |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
 |                            |                                        |              |              |                                           | implementation is required to ignore the |
 |                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
+=======
+| is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                            |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                            |                                        |              |              | may be used in addition to this flag      |                                          |
+|                            |                                        |              |              | using a :ref:`polling location            |                                          |
+|                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
+|                            |                                        |              |              | configured as a Drop Box.                 |                                          |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
+|                            |                                        |              |              |                                           | the implementation is required to ignore |
+|                            |                                        |              |              |                                           | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -1365,9 +1380,9 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
    :linenos:
 
 
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-    loc002,ea345,,,,Locality #2,,st51,other,unique type
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+    loc002,ea345,,,,,Locality #2,,st51,other,unique type
 
 
 .. _single-csv-department:

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -242,80 +242,106 @@ the Election specified by this object. It is permissible, and recommended, to co
 contests (e.g., a special election and a general election) that occur on the same day into one feed
 with one Election object.
 
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============================+================+==============+==============+==========================================+==========================================+
-| date                          | ``xs:date``    | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
-|                               |                |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
-|                               |                |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
-|                               |                |              |              | the election.                            |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| election_type                 | ``xs:string``  | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
-|                               |                |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
-|                               |                |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| state_id                      | ``xs:IDREF``   | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
-|                               |                |              |              | where the election is being held.        | implementation is required to ignore the |
-|                               |                |              |              |                                          | ``Election`` element containing it.      |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_statewide                  | ``xs:boolean`` | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
-|                               |                |              |              | statewide.                               | the implementation is required to        |
-|                               |                |              |              |                                          | default to "yes".                        |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                          | ``xs:string``  | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
-|                               |                |              |              | optional, this element is highly         | present, then the implementation is      |
-|                               |                |              |              | recommended).                            | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_info             | ``xs:string``  | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
-|                               |                |              |              | for this election either as text or a    | present, then the implementation is      |
-|                               |                |              |              | URI.                                     | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_ballot_info          | ``xs:string``  | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
-|                               |                |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
-|                               |                |              |              |                                          | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| results_uri                   | ``xs:anyURI``  | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
-|                               |                |              |              | election may be found                    | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| polling_hours                 | ``xs:string``  | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                               |                |              |              | Election Day polling locations are open. | present, then the implementation is      |
-|                               |                |              |              | If polling hours differ in specific      | required to ignore it.                   |
-|                               |                |              |              | polling locations, alternative hours may |                                          |
-|                               |                |              |              | be specified in the                      |                                          |
-|                               |                |              |              | :ref:`single-csv-polling-location`       |                                          |
-|                               |                |              |              | object *(NB: this element is deprecated  |                                          |
-|                               |                |              |              | in favor of the more structured          |                                          |
-|                               |                |              |              | :ref:`single-csv-hours-open` element. It |                                          |
-|                               |                |              |              | is strongly encouraged that data         |                                          |
-|                               |                |              |              | providers move toward contributing hours |                                          |
-|                               |                |              |              | in this format)*.                        |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_ids                | ``xs:IDREF``   | Optional     | Single       | References the                           | If the field is invalid or not present,  |
-|                               |                |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
-|                               |                |              |              | which lists the hours of operation for   | ignore it.                               |
-|                               |                |              |              | polling locations.                       |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| has_election_day_registration | ``xs:boolean`` | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
-|                               |                |              |              | same day of the election (i.e., the last | then the implementation is required to   |
-|                               |                |              |              | day of the election). Valid items are    | ignore it.                               |
-|                               |                |              |              | "yes" and "no".                          |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_deadline         | ``xs:date``    | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
-|                               |                |              |              | the election with the possible exception | then the implementation is required to   |
-|                               |                |              |              | of Election Day registration.            | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_request_deadline     | ``xs:date``    | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
-|                               |                |              |              | absentee ballot.                         | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                           | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============================+===================================+==============+==============+==========================================+==========================================+
+| date                          | ``xs:date``                       | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
+|                               |                                   |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
+|                               |                                   |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
+|                               |                                   |              |              | the election.                            |                                          |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice               | :ref:`single-csv-election-notice` | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
+|                               |                                   |              |              | information related to election notices, | present, then the implementation is      |
+|                               |                                   |              |              | including those attributed to natural    | required to ignore it.                   |
+|                               |                                   |              |              | disasters and other unforseen events.    |                                          |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_type                 | ``xs:string``                     | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
+|                               |                                   |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
+|                               |                                   |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| state_id                      | ``xs:IDREF``                      | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
+|                               |                                   |              |              | where the election is being held.        | implementation is required to ignore the |
+|                               |                                   |              |              |                                          | ``Election`` element containing it.      |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_statewide                  | ``xs:boolean``                    | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
+|                               |                                   |              |              | statewide.                               | the implementation is required to        |
+|                               |                                   |              |              |                                          | default to "yes".                        |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                          | ``xs:string``                     | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
+|                               |                                   |              |              | optional, this element is highly         | present, then the implementation is      |
+|                               |                                   |              |              | recommended).                            | required to ignore it.                   |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_info             | ``xs:string``                     | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
+|                               |                                   |              |              | for this election either as text or a    | present, then the implementation is      |
+|                               |                                   |              |              | URI.                                     | required to ignore it.                   |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_ballot_info          | ``xs:string``                     | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
+|                               |                                   |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
+|                               |                                   |              |              |                                          | required to ignore it.                   |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| results_uri                   | ``xs:anyURI``                     | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
+|                               |                                   |              |              | election may be found                    | then the implementation is required to   |
+|                               |                                   |              |              |                                          | ignore it.                               |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| polling_hours                 | ``xs:string``                     | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                               |                                   |              |              | Election Day polling locations are open. | present, then the implementation is      |
+|                               |                                   |              |              | If polling hours differ in specific      | required to ignore it.                   |
+|                               |                                   |              |              | polling locations, alternative hours may |                                          |
+|                               |                                   |              |              | be specified in the                      |                                          |
+|                               |                                   |              |              | :ref:`single-csv-polling-location`       |                                          |
+|                               |                                   |              |              | object *(NB: this element is deprecated  |                                          |
+|                               |                                   |              |              | in favor of the more structured          |                                          |
+|                               |                                   |              |              | :ref:`single-csv-hours-open` element. It |                                          |
+|                               |                                   |              |              | is strongly encouraged that data         |                                          |
+|                               |                                   |              |              | providers move toward contributing hours |                                          |
+|                               |                                   |              |              | in this format)*.                        |                                          |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_ids                | ``xs:IDREF``                      | Optional     | Single       | References the                           | If the field is invalid or not present,  |
+|                               |                                   |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
+|                               |                                   |              |              | which lists the hours of operation for   | ignore it.                               |
+|                               |                                   |              |              | polling locations.                       |                                          |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| has_election_day_registration | ``xs:boolean``                    | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
+|                               |                                   |              |              | same day of the election (i.e., the last | then the implementation is required to   |
+|                               |                                   |              |              | day of the election). Valid items are    | ignore it.                               |
+|                               |                                   |              |              | "yes" and "no".                          |                                          |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_deadline         | ``xs:date``                       | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
+|                               |                                   |              |              | the election with the possible exception | then the implementation is required to   |
+|                               |                                   |              |              | of Election Day registration.            | ignore it.                               |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_request_deadline     | ``xs:date``                       | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
+|                               |                                   |              |              | absentee ballot.                         | then the implementation is required to   |
+|                               |                                   |              |              |                                          | ignore it.                               |
++-------------------------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,date,name,election_type,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
-    e001,10-08-2016,Best Hot Dog,State,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
+    id,date,name,election_type,election_notice_text,election_notice_uri,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
+    e001,10-08-2016,Best Hot Dog,State,There are some last minute changes for this election. For additional information see the accompanying URL,https://someelectionnotice.gov,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
+
+
+.. _single-csv-election-notice:
+
+election_notice
+^^^^^^^^^^^^^^^
+
+The ElectionNotice description. 
+
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+===============+==============+==============+==========================================+==========================================+
+| election_notice_text | ``xs:string`` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|                      |               |              |              |                                          | implementation is required to ignore the |
+|                      |               |              |              |                                          | ``ElectionNotice`` element containing    |
+|                      |               |              |              |                                          | it.                                      |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice_uri  | ``xs:string`` | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|                      |               |              |              | related to the Election Notice.          | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-ballot-selection-base:
@@ -358,8 +384,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                             |                 |              |              | to be in the timezone local to the       |                                          |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                             |                 |              |              | organization.                            |                                          |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -380,7 +406,8 @@ the only required object in the feed file, and only one source object is allowed
 |                             |                 |              |              | be found.                                | ignore it.                               |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                             |                 |              |              |                                          | implementation is required to ignore it. |
+|                             |                 |              |              |                                          | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
 +-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
@@ -1335,11 +1362,6 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                            |                                        |              |              |                                           | required to ignore it.                   |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                            |                                        |              |              |                                           | implementation is required to ignore the |
-|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
-=======
 | is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
 |                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
 |                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
@@ -1349,10 +1371,9 @@ The Locality object represents the jurisdiction below the :ref:`single-csv-state
 |                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
 |                            |                                        |              |              | configured as a Drop Box.                 |                                          |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
-|                            |                                        |              |              |                                           | the implementation is required to ignore |
-|                            |                                        |              |              |                                           | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                            |                                        |              |              |                                           | implementation is required to ignore the |
+|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
 +----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -2154,6 +2175,27 @@ UTC. The pattern is
        <EndDate>2013-11-05</EndDate>
      </Schedule>
    </HoursOpen>
+
+
+.. _single-csv-election-notice:
+
+election_notice
+~~~~~~~~~~~~~~~
+
+The ElectionNotice description. 
+
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+===============+==============+==============+==========================================+==========================================+
+| election_notice_text | ``xs:string`` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|                      |               |              |              |                                          | implementation is required to ignore the |
+|                      |               |              |              |                                          | ``ElectionNotice`` element containing    |
+|                      |               |              |              |                                          | it.                                      |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice_uri  | ``xs:string`` | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|                      |               |              |              | related to the Election Notice.          | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-retention-contest:

--- a/docs/built_rst/tables/elements/election.rst
+++ b/docs/built_rst/tables/elements/election.rst
@@ -8,6 +8,11 @@
 |                            |                                         |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
 |                            |                                         |              |              | the election.                            |                                          |
 +----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionNotice             | :ref:`multi-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
+|                            |                                         |              |              | information related to election notices, | present, then the implementation is      |
+|                            |                                         |              |              | including those attributed to natural    | required to ignore it.                   |
+|                            |                                         |              |              | disasters and other unforseen events.    |                                          |
++----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                         |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
 |                            |                                         |              |              | state, county, city, town, etc.)         | required to ignore it.                   |

--- a/docs/built_rst/tables/elements/election.rst
+++ b/docs/built_rst/tables/elements/election.rst
@@ -11,7 +11,7 @@
 | ElectionNotice             | :ref:`multi-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
 |                            |                                         |              |              | information related to election notices, | present, then the implementation is      |
 |                            |                                         |              |              | including those attributed to natural    | required to ignore it.                   |
-|                            |                                         |              |              | disasters and other unforseen events.    |                                          |
+|                            |                                         |              |              | disasters and other unforeseen events.   |                                          |
 +----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                         |              |              | authority for election (e.g., federal,   | present, then the implementation is      |

--- a/docs/built_rst/tables/elements/election_notice.rst
+++ b/docs/built_rst/tables/elements/election_notice.rst
@@ -1,0 +1,14 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`multi-xml-internationalized-text` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|              |                                         |              |              |                                          | implementation is required to ignore the |
+|              |                                         |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                         |              |              |                                          | it.                                      |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                           | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|              |                                         |              |              | related to the Election Notice.          | then the implementation is required to   |
+|              |                                         |              |              |                                          | ignore it.                               |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/tables/elements/locality.rst
+++ b/docs/built_rst/tables/elements/locality.rst
@@ -11,11 +11,6 @@
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                          |                                       |              |              |                                          | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -26,10 +21,9 @@
 |                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
 |                          |                                       |              |              | configured as a Drop Box.                |                                          |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                          |                                       |              |              |                                          | the implementation is required to ignore |
-|                          |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                          |                                       |              |              |                                          | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/tables/elements/locality.rst
+++ b/docs/built_rst/tables/elements/locality.rst
@@ -11,9 +11,25 @@
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                          |                                       |              |              |                                          | implementation is required to ignore the |
 |                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                          |                                       |              |              | locality will also run mail-only         |                                          |
+|                          |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                          |                                       |              |              | addition to this flag using a            |                                          |
+|                          |                                       |              |              | :ref:`polling location                   |                                          |
+|                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
+|                          |                                       |              |              | configured as a Drop Box.                |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/tables/elements/source.rst
+++ b/docs/built_rst/tables/elements/source.rst
@@ -12,8 +12,8 @@
 |                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                         |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                         |              |              | organization.                            |                                          |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -33,5 +33,6 @@
 |                        |                                         |              |              | be found.                                | ignore it.                               |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                         |              |              |                                          | implementation is required to ignore it. |
+|                        |                                         |              |              |                                          | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/election.rst
+++ b/docs/built_rst/xml/elements/election.rst
@@ -20,6 +20,11 @@ with one Election object.
 |                            |                                         |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
 |                            |                                         |              |              | the election.                            |                                          |
 +----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionNotice             | :ref:`multi-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
+|                            |                                         |              |              | information related to election notices, | present, then the implementation is      |
+|                            |                                         |              |              | including those attributed to natural    | required to ignore it.                   |
+|                            |                                         |              |              | disasters and other unforseen events.    |                                          |
++----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                         |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
 |                            |                                         |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
@@ -86,6 +91,12 @@ with one Election object.
    <Election id="ele30000">
      <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
      <Date>2013-11-05</Date>
+     <ElectionNotice>
+       <NoticeText>
+          <Text language="en">There are some last minute changes for this election. For additional information see the accompanying URL</Text>
+       </NoticeText>
+       <NoticeUri>https://someelectionnotice.gov</NoticeUri>
+     </ElectionNotice>
      <ElectionType>
        <Text language="en">General</Text>
        <Text language="es">Generales</Text>
@@ -100,3 +111,24 @@ with one Election object.
      <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
      <StateId>st51</StateId>
    </Election>
+
+
+.. _multi-xml-election-notice:
+
+ElectionNotice
+--------------
+
+The ElectionNotice description. 
+
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`multi-xml-internationalized-text` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|              |                                         |              |              |                                          | implementation is required to ignore the |
+|              |                                         |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                         |              |              |                                          | it.                                      |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                           | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|              |                                         |              |              | related to the Election Notice.          | then the implementation is required to   |
+|              |                                         |              |              |                                          | ignore it.                               |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/election.rst
+++ b/docs/built_rst/xml/elements/election.rst
@@ -23,7 +23,7 @@ with one Election object.
 | ElectionNotice             | :ref:`multi-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
 |                            |                                         |              |              | information related to election notices, | present, then the implementation is      |
 |                            |                                         |              |              | including those attributed to natural    | required to ignore it.                   |
-|                            |                                         |              |              | disasters and other unforseen events.    |                                          |
+|                            |                                         |              |              | disasters and other unforeseen events.   |                                          |
 +----------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                         |              |              | authority for election (e.g., federal,   | present, then the implementation is      |

--- a/docs/built_rst/xml/elements/election_notice.rst
+++ b/docs/built_rst/xml/elements/election_notice.rst
@@ -1,0 +1,21 @@
+.. This file is auto-generated.  Do not edit it by hand!
+
+.. _multi-xml-election-notice:
+
+ElectionNotice
+==============
+
+The ElectionNotice description. 
+
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                               | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`multi-xml-internationalized-text` | **Required** | Single       | NoticeText description                   | If the element is invalid, then the      |
+|              |                                         |              |              |                                          | implementation is required to ignore the |
+|              |                                         |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                         |              |              |                                          | it.                                      |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                           | Optional     | Single       | NoticeUri description                    | If the field is invalid or not present,  |
+|              |                                         |              |              |                                          | then the implementation is required to   |
+|              |                                         |              |              |                                          | ignore it.                               |
++--------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+

--- a/docs/built_rst/xml/elements/locality.rst
+++ b/docs/built_rst/xml/elements/locality.rst
@@ -18,11 +18,6 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
-|                          |                                       |              |              |                                          | implementation is required to ignore the |
-|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
 |                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
 |                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
@@ -33,10 +28,9 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
 |                          |                                       |              |              | configured as a Drop Box.                |                                          |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
-|                          |                                       |              |              |                                          | the implementation is required to ignore |
-|                          |                                       |              |              |                                          | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
+|                          |                                       |              |              |                                          | implementation is required to ignore the |
+|                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |

--- a/docs/built_rst/xml/elements/locality.rst
+++ b/docs/built_rst/xml/elements/locality.rst
@@ -18,9 +18,25 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
 |                          |                                       |              |              | links to another dataset (e.g.           | present, then the implementation is      |
 |                          |                                       |              |              | `OCD-ID`_)                               | required to ignore it.                   |
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is invalid, then the        |
 |                          |                                       |              |              |                                          | implementation is required to ignore the |
 |                          |                                       |              |              |                                          | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                        | Optional     | Single       | Determines if the locality runs          | If the field is missing or invalid, the  |
+|                          |                                       |              |              | mail-only elections. If this is true,    | implementation is required to assume     |
+|                          |                                       |              |              | then all precincts a part of the         | `IsMailOnly` is false.                   |
+|                          |                                       |              |              | locality will also run mail-only         |                                          |
+|                          |                                       |              |              | elections. Drop boxes may be used in     |                                          |
+|                          |                                       |              |              | addition to this flag using a            |                                          |
+|                          |                                       |              |              | :ref:`polling location                   |                                          |
+|                          |                                       |              |              | <multi-xml-polling-location>` record     |                                          |
+|                          |                                       |              |              | configured as a Drop Box.                |                                          |
++--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                         | **Required** | Single       | Specifies the name of a locality.        | If the field is not present or invalid,  |
+|                          |                                       |              |              |                                          | the implementation is required to ignore |
+|                          |                                       |              |              |                                          | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                         | Optional     | Single       | Specifies a link to a set of the         | If the field is invalid or not present,  |
 |                          |                                       |              |              | locality's :ref:`polling locations       | the implementation is required to ignore |
@@ -57,6 +73,7 @@ The Locality object represents the jurisdiction below the :ref:`multi-xml-state`
          <Value>ocd-division/country:us/state:va/county:albemarle</Value>
        </ExternalIdentifier>
      </ExternalIdentifiers>
+     <IsMailOnly>true</IsMailOnly>
      <Name>ALBEMARLE COUNTY</Name>
      <StateId>st51</StateId>
      <Type>county</Type>

--- a/docs/built_rst/xml/elements/source.rst
+++ b/docs/built_rst/xml/elements/source.rst
@@ -20,8 +20,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                         | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                         |              |              | to be in the timezone local to the       |                                          |
+|                        |                                         |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                         |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                         |              |              | organization.                            |                                          |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`multi-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -41,7 +41,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                         |              |              | be found.                                | ignore it.                               |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                           | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                         |              |              |                                          | implementation is required to ignore it. |
+|                        |                                         |              |              |                                          | implementation is required to ignore the |
+|                        |                                         |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+-----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -318,6 +318,11 @@ with one Election object.
 |                            |                                          |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
 |                            |                                          |              |              | the election.                            |                                          |
 +----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionNotice             | :ref:`single-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
+|                            |                                          |              |              | information related to election notices, | present, then the implementation is      |
+|                            |                                          |              |              | including those attributed to natural    | required to ignore it.                   |
+|                            |                                          |              |              | disasters and other unforseen events.    |                                          |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                          |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
 |                            |                                          |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
@@ -384,6 +389,12 @@ with one Election object.
    <Election id="ele30000">
      <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
      <Date>2013-11-05</Date>
+     <ElectionNotice>
+       <NoticeText>
+          <Text language="en">There are some last minute changes for this election. For additional information see the accompanying URL</Text>
+       </NoticeText>
+       <NoticeUri>https://someelectionnotice.gov</NoticeUri>
+     </ElectionNotice>
      <ElectionType>
        <Text language="en">General</Text>
        <Text language="es">Generales</Text>
@@ -398,6 +409,27 @@ with one Election object.
      <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
      <StateId>st51</StateId>
    </Election>
+
+
+.. _single-xml-election-notice:
+
+ElectionNotice
+^^^^^^^^^^^^^^
+
+The ElectionNotice description. 
+
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`single-xml-internationalized-text` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|              |                                          |              |              |                                          | implementation is required to ignore the |
+|              |                                          |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                          |              |              |                                          | it.                                      |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                            | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|              |                                          |              |              | related to the Election Notice.          | then the implementation is required to   |
+|              |                                          |              |              |                                          | ignore it.                               |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-xml-ballot-selection-base:
@@ -440,8 +472,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                          |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | DateTime               | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore it. |
-|                        |                                          |              |              | to be in the timezone local to the       |                                          |
+|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                          |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
 |                        |                                          |              |              | organization.                            |                                          |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Description            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
@@ -462,7 +494,8 @@ the only required object in the feed file, and only one source object is allowed
 |                        |                                          |              |              | be found.                                | ignore it.                               |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Version                | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                          |              |              |                                          | implementation is required to ignore it. |
+|                        |                                          |              |              |                                          | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
 +------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
@@ -1566,11 +1599,6 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                          |                                        |              |              |                                           | required to ignore it.                   |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-<<<<<<< HEAD
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                          |                                        |              |              |                                           | implementation is required to ignore the |
-|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
-=======
 | IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
 |                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
 |                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
@@ -1580,10 +1608,9 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
 |                          |                                        |              |              | configured as a Drop Box.                 |                                          |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
-|                          |                                        |              |              |                                           | the implementation is required to ignore |
-|                          |                                        |              |              |                                           | the Locality element containing it.      |
->>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                          |                                        |              |              |                                           | implementation is required to ignore the |
+|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -2459,6 +2486,27 @@ UTC. The pattern is
        <EndDate>2013-11-05</EndDate>
      </Schedule>
    </HoursOpen>
+
+
+.. _single-xml-election-notice:
+
+ElectionNotice
+~~~~~~~~~~~~~~
+
+The ElectionNotice description. 
+
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`single-xml-internationalized-text` | **Required** | Single       | Text for the Election Notice.            | If the element is invalid, then the      |
+|              |                                          |              |              |                                          | implementation is required to ignore the |
+|              |                                          |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                          |              |              |                                          | it.                                      |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                            | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|              |                                          |              |              | related to the Election Notice.          | then the implementation is required to   |
+|              |                                          |              |              |                                          | ignore it.                               |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-xml-retention-contest:

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -1566,9 +1566,24 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
 |                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
 |                          |                                        |              |              |                                           | required to ignore it.                   |
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+<<<<<<< HEAD
 | Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
 |                          |                                        |              |              |                                           | implementation is required to ignore the |
 |                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
+=======
+| IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                          |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                          |                                        |              |              | may be used in addition to this flag      |                                          |
+|                          |                                        |              |              | using a :ref:`polling location            |                                          |
+|                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
+|                          |                                        |              |              | configured as a Drop Box.                 |                                          |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is not present or invalid,  |
+|                          |                                        |              |              |                                           | the implementation is required to ignore |
+|                          |                                        |              |              |                                           | the Locality element containing it.      |
+>>>>>>> 191cfa7... Updating RST files, adding IsMailOnly field to Locality
 +--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
 | PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
 |                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
@@ -1605,6 +1620,7 @@ The Locality object represents the jurisdiction below the :ref:`single-xml-state
          <Value>ocd-division/country:us/state:va/county:albemarle</Value>
        </ExternalIdentifier>
      </ExternalIdentifiers>
+     <IsMailOnly>true</IsMailOnly>
      <Name>ALBEMARLE COUNTY</Name>
      <StateId>st51</StateId>
      <Type>county</Type>

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -321,7 +321,7 @@ with one Election object.
 | ElectionNotice             | :ref:`single-xml-election-notice`        | Optional     | Single       | Allows for the publication of            | If the element is invalid or not         |
 |                            |                                          |              |              | information related to election notices, | present, then the implementation is      |
 |                            |                                          |              |              | including those attributed to natural    | required to ignore it.                   |
-|                            |                                          |              |              | disasters and other unforseen events.    |                                          |
+|                            |                                          |              |              | disasters and other unforeseen events.   |                                          |
 +----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | ElectionType               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
 |                            |                                          |              |              | authority for election (e.g., federal,   | present, then the implementation is      |

--- a/docs/yaml/elements/election.yaml
+++ b/docs/yaml/elements/election.yaml
@@ -5,8 +5,8 @@ csv-post: |-
      :linenos:
 
 
-      id,date,name,election_type,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
-      e001,10-08-2016,Best Hot Dog,State,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
+      id,date,name,election_type,election_notice_text,election_notice_uri,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
+      e001,10-08-2016,Best Hot Dog,State,There are some last minute changes for this election. For additional information see the accompanying URL,https://someelectionnotice.gov,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
 description: |-
   The Election object represents an Election Day, which usually consists of many individual contests
   and/or referenda. A feed must contain **exactly one** Election object. All relationships in the
@@ -14,6 +14,8 @@ description: |-
   the Election specified by this object. It is permissible, and recommended, to combine unrelated
   contests (e.g., a special election and a general election) that occur on the same day into one feed
   with one Election object.
+extends:
+- ElectionNotice
 post: |-
   .. code-block:: xml
      :linenos:
@@ -21,6 +23,12 @@ post: |-
      <Election id="ele30000">
        <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
        <Date>2013-11-05</Date>
+       <ElectionNotice>
+         <NoticeText>
+            <Text language="en">There are some last minute changes for this election. For additional information see the accompanying URL</Text>
+         </NoticeText>
+         <NoticeUri>https://someelectionnotice.gov</NoticeUri>
+       </ElectionNotice>
        <ElectionType>
          <Text language="en">General</Text>
          <Text language="es">Generales</Text>
@@ -43,6 +51,13 @@ tags:
     to be in the timezone local to the state holding the election.
   required: true
   type: xs:date
+- _name: ElectionNotice
+  csv-header-name: election_notice
+  csv-type: ElectionNotice
+  description: Allows for the publication of information related to election notices,
+    including those attributed to natural disasters and other unforseen events.
+  error_then: =must-ignore
+  type: ElectionNotice
 - _name: ElectionType
   csv-header-name: election_type
   csv-type: xs:string

--- a/docs/yaml/elements/election.yaml
+++ b/docs/yaml/elements/election.yaml
@@ -55,7 +55,7 @@ tags:
   csv-header-name: election_notice
   csv-type: ElectionNotice
   description: Allows for the publication of information related to election notices,
-    including those attributed to natural disasters and other unforseen events.
+    including those attributed to natural disasters and other unforeseen events.
   error_then: =must-ignore
   type: ElectionNotice
 - _name: ElectionType

--- a/docs/yaml/elements/election_notice.yaml
+++ b/docs/yaml/elements/election_notice.yaml
@@ -1,0 +1,16 @@
+_name: ElectionNotice
+csv-header-name: election_notice
+description: 'The ElectionNotice description. '
+tags:
+- _name: NoticeText
+  csv-header-name: election_notice_text
+  csv-type: xs:string
+  description: Text for the Election Notice.
+  required: true
+  type: InternationalizedText
+- _name: NoticeUri
+  csv-header-name: election_notice_uri
+  csv-type: xs:string
+  description: Optional URL for additional information related to the Election Notice.
+  error_then: =must-ignore
+  type: xs:anyURI

--- a/docs/yaml/elements/locality.yaml
+++ b/docs/yaml/elements/locality.yaml
@@ -5,9 +5,9 @@ csv-post: |-
      :linenos:
 
 
-      id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,state_id,type,other_type
-      loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,Locality #1,poll001 poll002,st51,city,
-      loc002,ea345,,,,Locality #2,,st51,other,unique type
+      id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+      loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+      loc002,ea345,,,,,Locality #2,,st51,other,unique type
 description: The Locality object represents the jurisdiction below the :ref:`$$$-state`
   (e.g. county).
 post: |-
@@ -24,6 +24,7 @@ post: |-
            <Value>ocd-division/country:us/state:va/county:albemarle</Value>
          </ExternalIdentifier>
        </ExternalIdentifiers>
+       <IsMailOnly>true</IsMailOnly>
        <Name>ALBEMARLE COUNTY</Name>
        <StateId>st51</StateId>
        <Type>county</Type>
@@ -42,6 +43,16 @@ tags:
     `OCD-ID`_)
   error_then: =must-ignore
   type: ExternalIdentifiers
+- _name: IsMailOnly
+  csv-header-name: is_mail_only
+  csv-type: xs:boolean
+  description: Determines if the locality runs mail-only elections. If this is true,
+    then all precincts a part of the locality will also run mail-only elections. Drop
+    boxes may be used in addition to this flag using a :ref:`polling location <$$$-polling-location>`
+    record configured as a Drop Box.
+  error: If the field is missing or invalid, the implementation is required to assume
+    `IsMailOnly` is false.
+  type: xs:boolean
 - _name: Name
   csv-header-name: name
   csv-type: xs:string

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -72,6 +72,20 @@
     <Type>county</Type>
   </Locality>
 
+  <Locality id="loc70002">
+    <ElectionAdministrationId>ea40001</ElectionAdministrationId>
+    <ExternalIdentifiers>
+      <ExternalIdentifier>
+        <Type>ocd-id</Type>
+        <Value>ocd-division/country:us/state:va/county:fairfax</Value>
+      </ExternalIdentifier>
+    </ExternalIdentifiers>
+    <IsMailOnly>true</IsMailOnly>
+    <Name>Fairfax COUNTY</Name>
+    <StateId>st51</StateId>
+    <Type>county</Type>
+  </Locality>
+
   <!-- Information about the election administration organizations for various jurisdictions. -->
   <ElectionAdministration id="ea40133">
     <AbsenteeUri>http://www.sbe.virginia.gov/absenteevoting.html</AbsenteeUri>

--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -27,6 +27,12 @@
   <Election id="ele30000">
     <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
     <Date>2013-11-05</Date>
+    <ElectionNotice>
+         <NoticeText>
+            <Text language="en">There are some last minute changes for this election. For additional information see the accompanying URL</Text>
+         </NoticeText>
+         <NoticeUri>https://someelectionnotice.gov</NoticeUri>
+       </ElectionNotice>
     <ElectionType>
       <Text language="en">General</Text>
       <Text language="es">Generales</Text>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -343,6 +343,13 @@
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>
 
+  <xs:complexType name="ElectionNotice">
+    <xs:sequence>
+      <xs:element name="NoticeText" type="InternationalizedText" minOccurs="1" />
+      <xs:element name="NoticeUri" type="xs:anyURI" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="ExternalIdentifiers">
     <xs:sequence>
       <xs:element name="ExternalIdentifier" maxOccurs="unbounded">
@@ -442,6 +449,7 @@
       <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
       <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
       <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+      <xs:element name="Name" type="xs:string" />
       <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
       <xs:element name="StateId" type="xs:IDREF" />
       <xs:element name="Type" type="DistrictType" minOccurs="0" />
@@ -653,6 +661,7 @@
               <xs:element name="AbsenteeRequestDeadline" type="xs:date" minOccurs="0" />
               <xs:element name="Date" type="xs:date" />
               <xs:element name="ElectionType" type="InternationalizedText" minOccurs="0" />
+              <xs:element name="ElectionNotice" type="ElectionNotice" minOccurs = "0" />
               <xs:element name="HasElectionDayRegistration" type="xs:boolean" minOccurs="0" />
               <xs:element name="HoursOpenId" type="xs:IDREF" minOccurs="0" />
               <xs:element name="IsStatewide" type="xs:boolean" minOccurs="0" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -441,7 +441,7 @@
     <xs:sequence>
       <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
       <xs:element name="ExternalIdentifiers" type="ExternalIdentifiers" minOccurs="0" />
-      <xs:element name="Name" type="xs:string" />
+      <xs:element name="IsMailOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" />
       <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
       <xs:element name="StateId" type="xs:IDREF" />
       <xs:element name="Type" type="DistrictType" minOccurs="0" />


### PR DESCRIPTION
We're adding an `ElectionNotice` type to `Election` object to provide States and Counties a way of distributing last minute notices to the public for unforeseen events