### PR TITLE
Fixes typo in the ElectionNotice element in sample_feed.xml. 

### DIFF
--- a/sample_feed.xml
+++ b/sample_feed.xml
@@ -120,7 +120,7 @@
       <NoticeText>
         <Text language="en">This is an emergency notification for this election.</Text>
       </NoticeText>
-      <NoticeURI>https://www.yadayada.gov</NoticeURI>
+      <NoticeUri>https://www.yadayada.gov</NoticeUri>
     </ElectionNotice>
     <ElectionsUri>http://www.albemarle.org/registrar</ElectionsUri>
     <RegistrationUri>http://www.vote.virginia.gov</RegistrationUri>


### PR DESCRIPTION
The sample feed now validates against the spec XSD.

```
/vip-specification$ xmllint --schema vip_spec.xsd sample_feed.xml --noout
sample_feed.xml validates
```