### PR TITLE
Replaces deprecated Sphinx.add_stylesheet with Sphinx.add_css_file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,4 +372,4 @@ epub_exclude_files = ['search.html']
 
 # Inject a custom stylesheet into the Read the Docs theme
 def setup(app):
-  app.add_stylesheet("theme_overrides.css")
+  app.add_css_file("theme_overrides.css")


### PR DESCRIPTION
Sphinx.add_stylesheet was deprecated with version 1.80. See https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file.