### PR TITLE
Updates HISTORY and README to 6.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # VIP Release Notes
 
 This document includes release notes for the [VIP Spec][vip] for versions
-5.1 and later.
+6.0 and later.
 
 ## Version 6.0
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The current version of the spec is defined in the file named `vip_spec.xsd`.
 For versions of the spec prior to the current version, see the [releases
 page][releases_page]. Previous releases include:
 
+* 5.2 [(Archive)][v5_2_archive_release] [(Tree)][v5_2_archive_tag]
 * 5.1 [(Archive)][v5_1_archive_release] [(Tree)][v5_1_archive_tag]
 * 5.0 [(Archive)][v5_0_archive_release] [(Tree)][v5_0_archive_tag]
 * 3.x [(Archive)][v3_archive_release] [(Tree)][v3_archive_tag]
@@ -21,6 +22,8 @@ available under a [Creative Commons-Attribution license, version
 
 
 [releases_page]: https://github.com/votinginfoproject/vip-specification/releases
+[v5_2_archive_release]: https://github.com/votinginfoproject/vip-specification/releases/tag/v5.2-release
+[v5_2_archive_tag]: https://github.com/votinginfoproject/vip-specification/tree/v5.2-release
 [v5_1_archive_release]: https://github.com/votinginfoproject/vip-specification/releases/tag/v5.1-release
 [v5_1_archive_tag]: https://github.com/votinginfoproject/vip-specification/tree/v5.1-release
 [v5_0_archive_release]: https://github.com/votinginfoproject/vip-specification/releases/tag/v5.0-release


### PR DESCRIPTION
Note the hyperlink to the 5.2 release will be broken until the following release is published: https://github.com/votinginfoproject/vip-specification/releases/edit/untagged-67c088d12182f90fda80