### PR TITLE
Fixes the rest.py script to properly order pages in the single-page doc

### DIFF
--- a/scripts/vippy/common.py
+++ b/scripts/vippy/common.py
@@ -119,8 +119,9 @@ def configure_yaml():
 
 
 def read_yaml(path):
+    #https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
     with open(path) as f:
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.FullLoader)
     return data
 
 

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -253,7 +253,8 @@ def update_rest_file_single_page(all_types,mode):
         rest += "\n\n"
         label = "{0}-{1}".format(prefix, title.lower())
         rest += make_rest_header(title, label=label, header_char="-")
-        for data_type in data_types:
+        sorted_data_types = sorted(data_types, key=lambda dt: dt.csv_name if mode == "csv" else dt.name)
+        for data_type in sorted_data_types:
             if data_type.is_sub_type and data_type.is_extends:
                 continue
             new_rest = make_type_rest(all_types, data_type, header_char="~", prefix=prefix)
@@ -267,18 +268,15 @@ def update_rest_files(type_name=None):
     Update auto-generated reST files.
     """
     for mode in ['csv','xml']:
-        prefix = "multi-{}".format(mode)
         all_types = common.get_all_types()
+        update_rest_file_single_page(all_types, mode)
+        
         type_map = all_types.type_map
-
         if type_name is None:
             type_names = sorted(type_map.keys())
         else:
             type_names = [type_name]
 
-        update_rest_file_single_page(all_types, mode)
-
-    for mode in ['csv','xml']:
         prefix = "multi-{}".format(mode)
         for type_name in type_names:
             _log.debug("updating rest files for type: {0}".format(type_name))

--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -281,8 +281,10 @@ def update_rest_files(type_name=None):
         for type_name in type_names:
             _log.debug("updating rest files for type: {0}".format(type_name))
             data_type = common.get_type(type_map, type_name)
-            update_table_file(type_map, data_type, prefix=prefix)
             update_rest_file(all_types, data_type, prefix=prefix)
+            if mode == "xml":
+                # The table file is not mode-specific, so only update it once (using the XML case)
+                update_table_file(type_map, data_type, prefix=prefix)
 
 
 def analyze_types():


### PR DESCRIPTION
The current single page doc (e.g. [the XML page](https://vip-specification.readthedocs.io/en/vip6/built_rst/xml/single_page.html)) is out of order, and the order is not deterministic. This change ensures pages are ordered before they are added to the single-page doc. 

This also updates the `update_rest_files` method to combine the outer loops over mode (xml, csv). I believe the previous implementation could yield unexpected results since `type_names` and `type_map` were assembled in the first loop and used in the second.