### PR TITLE
Regenerates all doc RST to align with the latest script version

### DIFF
--- a/docs/built_rst/csv/elements/election.rst
+++ b/docs/built_rst/csv/elements/election.rst
@@ -6,7 +6,7 @@ election
 ========
 
 The Election object represents an Election Day, which usually consists of many individual contests
-and/or referenda. A feed may **not** contain multiple Election objects. All relationships in the
+and/or referenda. A feed must contain **exactly one** Election object. All relationships in the
 feed (e.g., street segment to precinct to polling location) are assumed to relate only to
 the Election specified by this object. It is permissible, and recommended, to combine unrelated
 contests (e.g., a special election and a general election) that occur on the same day into one feed

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -15,383 +15,6 @@ Elements
 --------
 
 
-.. _single-csv-state:
-
-state
-~~~~~
-
-The State object includes state-wide election information. The ID attribute is
-recommended to be the state's FIPS code, along with the prefix "st".
-
-+----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                        | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+============================+========================================+==============+==============+==========================================+==========================================+
-| election_administration_id | ``xs:IDREF``                           | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
-|                            |                                        |              |              | administration object.                   | then the implementation is required to   |
-|                            |                                        |              |              |                                          | ignore it.                               |
-+----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers       | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
-|                            |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                            |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                          | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
-|                            |                                        |              |              | Alabama.                                 | implementation is required to ignore the |
-|                            |                                        |              |              |                                          | ``State`` element containing it.         |
-+----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the state's          | If the field is invalid or not present,  |
-|                            |                                        |              |              | :ref:`polling locations                  | then the implementation is required to   |
-|                            |                                        |              |              | <single-csv-polling-location>`. If early | ignore it.                               |
-|                            |                                        |              |              | vote centers or ballot drop locations    |                                          |
-|                            |                                        |              |              | are state-wide (e.g., anyone in the      |                                          |
-|                            |                                        |              |              | state can use them), they can be         |                                          |
-|                            |                                        |              |              | specified here, but you are encouraged   |                                          |
-|                            |                                        |              |              | to only use the                          |                                          |
-|                            |                                        |              |              | :ref:`single-csv-precinct` element.      |                                          |
-+----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids
-    st51,ea123,ocd-id,,ocd-division/country:us/state:va,Virginia,
-
-
-.. _single-csv-term:
-
-term
-~~~~
-
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+====================================+==============+==============+==========================================+==========================================+
-| term_type       | :ref:`single-csv-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
-|                 |                                    |              |              | :ref:`single-csv-office-term-type` for   | the implementation is required to ignore |
-|                 |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| term_start_date | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
-|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|                 |                                    |              |              |                                          | ignore it.                               |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| term_end_date   | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
-|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|                 |                                    |              |              |                                          | ignore it.                               |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-office:
-
-office
-~~~~~~
-
-``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
-School Board, et al).
-
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+========================+==============+==============+==========================================+==========================================+
-| contact_information_id   | ``xs:IDREF``           | Optional     | Repeats      | Links to the                             | If the element is invalid or not         |
-|                          |                        |              |              | :ref:`single-csv-contact-information`    | present, then the implementation is      |
-|                          |                        |              |              | element associated with the office.      | required to ignore it.                   |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description              | ``xs:string``          | Optional     | Single       | A brief description of the office and    | If the element is invalid or not         |
-|                          |                        |              |              | its purpose.                             | present, then the implementation is      |
-|                          |                        |              |              |                                          | required to ignore it.                   |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electoral_district_id    | ``xs:IDREF``           | **Required** | Single       | Links to the                             | If the field is invalid or not present,  |
-|                          |                        |              |              | :ref:`single-csv-electoral-district`     | the implementation is required to ignore |
-|                          |                        |              |              | element associated with the office.      | the ``Office`` element containing it.    |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers     | ``xs:IDREF``           | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
-|                          |                        |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
-|                          |                        |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| filing_deadline          | ``xs:date``            | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
-|                          |                        |              |              | candidate must have filed for the        | then the implementation is required to   |
-|                          |                        |              |              | contest for the office.                  | ignore it.                               |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_partisan              | ``xs:boolean``         | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
-|                          |                        |              |              | partisan.                                | then the implementation is required to   |
-|                          |                        |              |              |                                          | ignore it.                               |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                     | ``xs:string``          | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
-|                          |                        |              |              |                                          | the implementation is required to ignore |
-|                          |                        |              |              |                                          | the ``Office`` element containing it.    |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| office_holder_person_ids | ``xs:IDREFS``          | Optional     | Single       | Links to the :ref:`single-csv-person`    | If the field is invalid or not present,  |
-|                          |                        |              |              | element(s) that hold additional          | then the implementation is required to   |
-|                          |                        |              |              | information about the current office     | ignore it.                               |
-|                          |                        |              |              | holder(s).                               |                                          |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| term                     | :ref:`single-csv-term` | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
-|                          |                        |              |              |                                          | present, then the implementation is      |
-|                          |                        |              |              |                                          | required to ignore it.                   |
-+--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,electoral_district_id,external_identifier_type,external_identifier_othertype,external_identifier_value,filing_deadline,is_partisan,name,office_holder_person_ids,term_type,term_start_date,term_end_date
-    off001,ed001,,,,,true,Deputy Chief of Staff,per50003,full-term,2002-01-21,
-    off002,ed001,,,,,true,Deputy Deputy Chief of Staff,per50001,unexpired-term,2002-01-21,
-    off003,ed001,,,,,false,General Secretary of Secretaries,per50004,full-term,2002-01-21,
-
-
-.. _single-csv-term:
-
-term
-^^^^
-
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+====================================+==============+==============+==========================================+==========================================+
-| term_type       | :ref:`single-csv-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
-|                 |                                    |              |              | :ref:`single-csv-office-term-type` for   | the implementation is required to ignore |
-|                 |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| term_start_date | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
-|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|                 |                                    |              |              |                                          | ignore it.                               |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| term_end_date   | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
-|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|                 |                                    |              |              |                                          | ignore it.                               |
-+-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-contact-information:
-
-contact_information
-^^^^^^^^^^^^^^^^^^^
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
-:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+===========================+==============+==============+==========================================+==========================================+
-| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
-|               |                           |              |              | element. It is strongly encouraged that  |                                          |
-|               |                           |              |              | data providers move toward contributing  |                                          |
-|               |                           |              |              | hours in this format)*.                  |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
-|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
-|               |                           |              |              | location.                                |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|               |                           |              |              | this entity.                             | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|               |                           |              |              | location.                                | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
-    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
-    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
-
-
-.. _single-csv-election:
-
-election
-~~~~~~~~
-
-The Election object represents an Election Day, which usually consists of many individual contests
-and/or referenda. A feed may **not** contain multiple Election objects. All relationships in the
-feed (e.g., street segment to precinct to polling location) are assumed to relate only to
-the Election specified by this object. It is permissible, and recommended, to combine unrelated
-contests (e.g., a special election and a general election) that occur on the same day into one feed
-with one Election object.
-
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============================+================+==============+==============+==========================================+==========================================+
-| date                          | ``xs:date``    | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
-|                               |                |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
-|                               |                |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
-|                               |                |              |              | the election.                            |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| election_type                 | ``xs:string``  | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
-|                               |                |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
-|                               |                |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| state_id                      | ``xs:IDREF``   | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
-|                               |                |              |              | where the election is being held.        | implementation is required to ignore the |
-|                               |                |              |              |                                          | ``Election`` element containing it.      |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_statewide                  | ``xs:boolean`` | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
-|                               |                |              |              | statewide.                               | the implementation is required to        |
-|                               |                |              |              |                                          | default to "yes".                        |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                          | ``xs:string``  | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
-|                               |                |              |              | optional, this element is highly         | present, then the implementation is      |
-|                               |                |              |              | recommended).                            | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_info             | ``xs:string``  | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
-|                               |                |              |              | for this election either as text or a    | present, then the implementation is      |
-|                               |                |              |              | URI.                                     | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_ballot_info          | ``xs:string``  | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
-|                               |                |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
-|                               |                |              |              |                                          | required to ignore it.                   |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| results_uri                   | ``xs:anyURI``  | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
-|                               |                |              |              | election may be found                    | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| polling_hours                 | ``xs:string``  | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                               |                |              |              | Election Day polling locations are open. | present, then the implementation is      |
-|                               |                |              |              | If polling hours differ in specific      | required to ignore it.                   |
-|                               |                |              |              | polling locations, alternative hours may |                                          |
-|                               |                |              |              | be specified in the                      |                                          |
-|                               |                |              |              | :ref:`single-csv-polling-location`       |                                          |
-|                               |                |              |              | object *(NB: this element is deprecated  |                                          |
-|                               |                |              |              | in favor of the more structured          |                                          |
-|                               |                |              |              | :ref:`single-csv-hours-open` element. It |                                          |
-|                               |                |              |              | is strongly encouraged that data         |                                          |
-|                               |                |              |              | providers move toward contributing hours |                                          |
-|                               |                |              |              | in this format)*.                        |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_ids                | ``xs:IDREF``   | Optional     | Single       | References the                           | If the field is invalid or not present,  |
-|                               |                |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
-|                               |                |              |              | which lists the hours of operation for   | ignore it.                               |
-|                               |                |              |              | polling locations.                       |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| has_election_day_registration | ``xs:boolean`` | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
-|                               |                |              |              | same day of the election (i.e., the last | then the implementation is required to   |
-|                               |                |              |              | day of the election). Valid items are    | ignore it.                               |
-|                               |                |              |              | "yes" and "no".                          |                                          |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| registration_deadline         | ``xs:date``    | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
-|                               |                |              |              | the election with the possible exception | then the implementation is required to   |
-|                               |                |              |              | of Election Day registration.            | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| absentee_request_deadline     | ``xs:date``    | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
-|                               |                |              |              | absentee ballot.                         | then the implementation is required to   |
-|                               |                |              |              |                                          | ignore it.                               |
-+-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,date,name,election_type,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
-    e001,10-08-2016,Best Hot Dog,State,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
-
-
-.. _single-csv-ballot-selection-base:
-
-ballot_selection_base
-~~~~~~~~~~~~~~~~~~~~~
-
-A base model for all ballot selection types:
-:ref:`single-csv-ballot-measure-selection`,
-:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
-
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+================+================+==============+==============+==========================================+==========================================+
-| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-source:
-
-source
-~~~~~~
-
-The Source object represents the organization that is publishing the information. This object is
-the only required object in the feed file, and only one source object is allowed to be present.
-
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                         | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=============================+=================+==============+==============+==========================================+==========================================+
-| name                        | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                             |                 |              |              | that is providing the information.       | implementation is required to ignore the |
-|                             |                 |              |              |                                          | ``Source`` element containing it.        |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vip_id                      | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                             |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                             |                 |              |              |                                          | ``Source`` element containing it.        |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
-|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
-|                             |                 |              |              | organization.                            |                                          |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                             |                 |              |              | organization providing the data and what | present, then the implementation is      |
-|                             |                 |              |              | data is in the feed.                     | required to ignore it.                   |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| organization_uri            | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                             |                 |              |              | organization publishing the data.        | then the implementation is required to   |
-|                             |                 |              |              |                                          | ignore it.                               |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| feed_contact_information_id | ``xs:IDREF``    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
-|                             |                 |              |              | :ref:`single-csv-person` who will        | present, then the implementation is      |
-|                             |                 |              |              | respond to inquiries about the           | required to ignore it.                   |
-|                             |                 |              |              | information contained within the file.   |                                          |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| terms_of_use_uri            | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                             |                 |              |              | Use for the information in this file can | then the implementation is required to   |
-|                             |                 |              |              | be found.                                | ignore it.                               |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                             |                 |              |              |                                          | implementation is required to ignore the |
-|                             |                 |              |              |                                          | ``Source`` element containing it.        |
-+-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,date_time,description,name,organization_uri,terms_of_use_uri,vip_id,version
-    source01,2016-06-02T10:24:08,SBE is the official source for Virginia data,"State Board of Elections, Commonwealth of Virginia",http://www.sbe.virginia.gov/,http://example.com/terms,51,5.1
-
-
 .. _single-csv-ballot-measure-contest:
 
 ballot_measure_contest
@@ -532,6 +155,429 @@ and :ref:`single-csv-retention-contest` (NB: the latter because it extends
 +--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
+.. _single-csv-ballot-measure-selection:
+
+ballot_measure_selection
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for a
+:ref:`single-csv-ballot-measure-contest` that would appear on the ballot.
+BallotMeasureSelection extends :ref:`single-csv-ballot-selection-base`.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| selection    | ``xs:string`` | **Required** | Single       | Selection text for a                     | If the element is invalid or not         |
+|              |               |              |              | :ref:`single-csv-ballot-measure-contest` | present, the implementation is required  |
+|              |               |              |              |                                          | to ignore the BallotMeasureSelection     |
+|              |               |              |              |                                          | containing it.                           |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,sequence_order,selection
+    bms001,1,Proposition A
+    bms002,2,Proposition B
+
+
+.. _single-csv-ballot-selection-base:
+
+ballot_selection_base
+^^^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-csv-ballot-measure-selection`,
+:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
+
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++================+================+==============+==============+==========================================+==========================================+
+| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-ballot-selection-base:
+
+ballot_selection_base
+~~~~~~~~~~~~~~~~~~~~~
+
+A base model for all ballot selection types:
+:ref:`single-csv-ballot-measure-selection`,
+:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
+
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++================+================+==============+==============+==========================================+==========================================+
+| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-ballot-style:
+
+ballot_style
+~~~~~~~~~~~~
+
+A container for the contests/measures on the ballot.
+
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+===============+==============+==============+==========================================+==========================================+
+| image_uri            | ``xs:anyURI`` | Optional     | Single       | Specifies a URI that returns an image of | If the field is invalid or not present,  |
+|                      |               |              |              | the sample ballot.                       | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ordered_contests_ids | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
+|                      |               |              |              | :ref:`single-csv-ordered-contest`        | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| party_ids            | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
+|                      |               |              |              | :ref:`single-csv-party`s.                | then the implementation is required to   |
+|                      |               |              |              |                                          | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,image_uri,ordered_contest_ids,party_ids
+    bs00010,http://i.giphy.com/26BoCh3PgT8ai45ji.gif,oc2025,par02
+    bs00011,http://i.giphy.com/3oEjHYDWEICgEpAOjK.gif,oc3000 oc2025,par01
+
+
+.. _single-csv-candidate-selection:
+
+candiate_selection
+~~~~~~~~~~~~~~~~~~
+
+CandidateSelection extends :ref:`single-csv-ballot-selection-base` and represents a
+ballot selection for a candidate contest.
+
++-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                   | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++=======================+================+==============+==============+==========================================+==========================================+
+| candidate_ids         | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                       |                |              |              | :ref:`single-csv-candidate` elements.    | then the implementation is required to   |
+|                       |                |              |              | The number of candidates that can be     | ignore it.                               |
+|                       |                |              |              | references is unbounded in cases where   |                                          |
+|                       |                |              |              | the ballot selection is for a ticket     |                                          |
+|                       |                |              |              | (e.g. "President/Vice President",        |                                          |
+|                       |                |              |              | "Governor/Lt Governor").                 |                                          |
++-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| endorsement_party_ids | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                       |                |              |              | :ref:`single-csv-party` elements, which  | then the implementation is required to   |
+|                       |                |              |              | signifies one or more endorsing parties  | ignore it.                               |
+|                       |                |              |              | for the candidate(s).                    |                                          |
++-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_write_in           | ``xs:boolean`` | Optional     | Single       | Signifies if the particular ballot       | If the field is invalid or not present,  |
+|                       |                |              |              | selection allows for write-in            | then the implementation is required to   |
+|                       |                |              |              | candidates. If true, one or more         | ignore it.                               |
+|                       |                |              |              | write-in candidates are allowed for this |                                          |
+|                       |                |              |              | contest.                                 |                                          |
++-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,sequence_order,candidate_ids,endorsement_party_ids,is_write_in
+    cs001,3,can004,par01,false
+    cs002,2,can001 can002,par03 par02,false
+    cs003,1,can003,par02 par03,true
+
+
+.. _single-csv-ballot-selection-base:
+
+ballot_selection_base
+^^^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-csv-ballot-measure-selection`,
+:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
+
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++================+================+==============+==============+==========================================+==========================================+
+| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-candidate:
+
+candidate
+~~~~~~~~~
+
+The Candidate object represents a candidate in a contest. If a candidate is
+running in multiple contests, each contest **must** have its own Candidate
+object. Candidate objects may **not** be reused between Contests.
+
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+==================================================+==============+==============+==========================================+==========================================+
+| ballot_name          | ``xs:string``                                    | **Required** | Single       | The candidate's name as it will be       | If the element is invalid, then the      |
+|                      |                                                  |              |              | displayed on the official ballot (e.g.   | implementation is required to ignore the |
+|                      |                                                  |              |              | "Ken T. Cuccinelli II").                 | ``Candidate`` element containing it.     |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| contact_information  | ``xs:string``                                    | Optional     | Single       | Contact and physical address information | If the element is invalid or not         |
+|                      |                                                  |              |              | for this Candidate and/or their campaign | present, then the implementation is      |
+|                      |                                                  |              |              | (see                                     | required to ignore it.                   |
+|                      |                                                  |              |              | :ref:`single-csv-contact-information`).  |                                          |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers | :ref:`single-csv-external-identifiers`           | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
+|                      |                                                  |              |              | links to another source of information   | present, then the implementation is      |
+|                      |                                                  |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
+|                      |                                                  |              |              | to a campaign finance system).           |                                          |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| file_date            | ``xs:date``                                      | Optional     | Single       | Date when the candidate filed for the    | If the field is invalid or not present,  |
+|                      |                                                  |              |              | contest.                                 | then the implementation is required to   |
+|                      |                                                  |              |              |                                          | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_incumbent         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                      |                                                  |              |              | incumbent for the office associated with | then the implementation is required to   |
+|                      |                                                  |              |              | the contest.                             | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_top_ticket        | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                      |                                                  |              |              | top of a ticket that includes multiple   | then the implementation is required to   |
+|                      |                                                  |              |              | candidates.                              | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| party_id             | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-csv-party`   | If the field is invalid or not present,  |
+|                      |                                                  |              |              | element with additional information      | then the implementation is required to   |
+|                      |                                                  |              |              | about the candidate's affiliated party.  | ignore it.                               |
+|                      |                                                  |              |              | This is the party affiliation that is    |                                          |
+|                      |                                                  |              |              | intended to be presented as part of      |                                          |
+|                      |                                                  |              |              | ballot information.                      |                                          |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| person_id            | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-csv-person`  | If the field is invalid or not present,  |
+|                      |                                                  |              |              | element with additional information      | then the implementation is required to   |
+|                      |                                                  |              |              | about the candidate.                     | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| post_election_status | :ref:`single-csv-candidate-post-election-status` | Optional     | Single       | Final status of the candidate (e.g.      | If the field is invalid or not present,  |
+|                      |                                                  |              |              | winner, withdrawn, etc...).              | then the implementation is required to   |
+|                      |                                                  |              |              |                                          | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| pre_election_status  | :ref:`single-csv-candidate-pre-election-status`  | Optional     | Single       | Registration status of the candidate     | If the field is invalid or not present,  |
+|                      |                                                  |              |              | (e.g. filed, qualified, etc...).         | then the implementation is required to   |
+|                      |                                                  |              |              |                                          | ignore it.                               |
++----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,ballot_name,external_identifier_type,external_identifier_othertype,external_identifier_value,file_date,is_incumbent,is_top_ticket,party_id,person_id,post_election_status,pre_election_status
+    can001,Jude Fawley,,,,2016-12-01,true,false,par01,per50001,,filed
+    can002,Arabella Donn,,,,2016-12-01,false,false,par02,per50002,,qualified
+    can003,John Coltrane,,,,2016-09-23,false,false,par02,per50003,,qualified
+    can004,Miles Davis,,,,2016-05-26,false,false,par01,per50004,,qualified
+
+
+.. _single-csv-candidate-contest:
+
+candidate_contest
+~~~~~~~~~~~~~~~~~
+
+CandidateContest extends :ref:`single-csv-contest-base` and represents a contest among
+candidates.
+
++-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+================+==============+==============+==========================================+==========================================+
+| number_elected    | ``xs:integer`` | Optional     | Single       | Number of candidates that are elected in | If the field is invalid or not present,  |
+|                   |                |              |              | the contest (i.e. "N" of N-of-M).        | then the implementation is required to   |
+|                   |                |              |              |                                          | ignore it.                               |
++-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| office_ids        | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                   |                |              |              | :ref:`single-csv-office` elements, if    | then the implementation is required to   |
+|                   |                |              |              | available, which give additional         | ignore it.                               |
+|                   |                |              |              | information about the offices. **Note:** |                                          |
+|                   |                |              |              | the order of the office IDs **must** be  |                                          |
+|                   |                |              |              | in the same order as the candidates      |                                          |
+|                   |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
+|                   |                |              |              | the various `BallotSelectionIds`         |                                          |
+|                   |                |              |              | reference                                |                                          |
+|                   |                |              |              | :ref:`single-csv-candidate-selection`    |                                          |
+|                   |                |              |              | elements which reference the candidate   |                                          |
+|                   |                |              |              | for President first and Vice-President   |                                          |
+|                   |                |              |              | second, the `OfficeIds` should reference |                                          |
+|                   |                |              |              | the office of President first and the    |                                          |
+|                   |                |              |              | office of Vice-President second.         |                                          |
++-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| primary_party_ids | ``xs:IDREFS``  | Optional     | Single       | References :ref:`single-csv-party`       | If the field is invalid or not present,  |
+|                   |                |              |              | elements, if the contest is related to a | then the implementation is required to   |
+|                   |                |              |              | particular party.                        | ignore it.                               |
++-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| votes_allowed     | ``xs:integer`` | Optional     | Single       | Maximum number of votes/write-ins per    | If the field is invalid or not present,  |
+|                   |                |              |              | voter in this contest.                   | then the implementation is required to   |
+|                   |                |              |              |                                          | ignore it.                               |
++-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation,number_elected,office_ids,primary_party_ids,votes_allowed
+    cancon001,SE-1,bs001 bs002,,Governor of Virginia,ed001,all registered voters,fips,,49,true,Governor,1,,,1,off001,par01,1
+    cancon002,SE-2,bs003 bs004,,Lieutenant Governor of Virginia,ed001,all registered voters,fips,,49,true,Lt Governor,2,,,1,off002,par01,1
+
+
+.. _single-csv-contest-base:
+
+contest_base
+^^^^^^^^^^^^
+
+A base model for all Contest types: :ref:`single-csv-ballot-measure-contest`,
+:ref:`single-csv-candidate-contest`, :ref:`single-csv-party-contest`,
+and :ref:`single-csv-retention-contest` (NB: the latter because it extends
+:ref:`single-csv-ballot-measure-contest`).
+
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+==================================+==============+==============+==========================================+==========================================+
+| abbreviation             | ``xs:string``                    | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                          |                                  |              |              |                                          | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_selection_ids     | ``xs:IDREFS``                    | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
+|                          |                                  |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                          |                                  |              |              | that extends                             | it.                                      |
+|                          |                                  |              |              | :ref:`single-csv-ballot-selection-base`. |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_sub_title         | ``xs:string``                    | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_title             | ``xs:string``                    | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electoral_district_id    | ``xs:IDREF``                     | **Required** | Single       | References an                            | If the field is invalid, then the        |
+|                          |                                  |              |              | :ref:`single-csv-electoral-district`     | implementation is required to ignore the |
+|                          |                                  |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
+|                          |                                  |              |              | scope of the contest.                    |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electorate_specification | ``xs:string``                    | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                          |                                  |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                          |                                  |              |              | usual, "all registered voters"           | ignore it.                               |
+|                          |                                  |              |              | electorate. This subtag will most often  |                                          |
+|                          |                                  |              |              | be used for primaries and local          |                                          |
+|                          |                                  |              |              | elections. In primaries, voters may have |                                          |
+|                          |                                  |              |              | to be registered as a specific party to  |                                          |
+|                          |                                  |              |              | vote, or there may be special rules for  |                                          |
+|                          |                                  |              |              | which ballot a voter can pull. In some   |                                          |
+|                          |                                  |              |              | local elections, non-citizens can vote.  |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers     | ``xs:string``                    | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                          |                                  |              |              | links to another source of information.  | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| has_rotation             | ``xs:boolean``                   | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                          |                                  |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                     | ``xs:string``                    | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
+|                          |                                  |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
+|                          |                                  |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
+|                          |                                  |              |              | purpose).                                |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| sequence_order           | ``xs:integer``                   | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
+|                          |                                  |              |              | on the ballot. This is the default       | then the implementation should ignore    |
+|                          |                                  |              |              | ordering, and can be overrides by data   | it.                                      |
+|                          |                                  |              |              | in a :ref:`single-csv-ballot-style`      |                                          |
+|                          |                                  |              |              | element.                                 |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vote_variation           | :ref:`single-csv-vote-variation` | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                          |                                  |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| other_vote_variation     | ``other_vote_variation``         | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                          |                                  |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                          |                                  |              |              | variation can be specified here.         | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-contact-information:
+
+contact_information
+~~~~~~~~~~~~~~~~~~~
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
+:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+===========================+==============+==============+==========================================+==========================================+
+| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
+|               |                           |              |              | element. It is strongly encouraged that  |                                          |
+|               |                           |              |              | data providers move toward contributing  |                                          |
+|               |                           |              |              | hours in this format)*.                  |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
+|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
+|               |                           |              |              | location.                                |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|               |                           |              |              | this entity.                             | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|               |                           |              |              | location.                                | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
+    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
+    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
+
+
 .. _single-csv-contest-base:
 
 contest_base
@@ -605,779 +651,6 @@ and :ref:`single-csv-retention-contest` (NB: the latter because it extends
 |                          |                                  |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
 |                          |                                  |              |              | variation can be specified here.         | it.                                      |
 +--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-time-with-zone:
-
-time_with_zone
-~~~~~~~~~~~~~~
-
-A string pattern restricting the value to a time with an included offset from
-UTC. The pattern is
-
-``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
-
-.. code-block:: xml
-   :linenos:
-
-   <HoursOpen id="hours0001">
-     <Schedule>
-       <Hours>
-         <StartTime>06:00:00-05:00</StartTime>
-         <EndTime>12:00:00-05:00</EndTime>
-       </Hours>
-       <Hours>
-         <StartTime>13:00:00-05:00</StartTime>
-         <EndTime>19:00:00-05:00</EndTime>
-       </Hours>
-       <StartDate>2013-11-05</StartDate>
-       <EndDate>2013-11-05</EndDate>
-     </Schedule>
-   </HoursOpen>
-
-
-.. _single-csv-language-string:
-
-language_string
-~~~~~~~~~~~~~~~
-
-``LanguageString`` extends xs:string and can contain text from any language. ``LanguageString``
-has one required attribute, ``language``, that must contain the 2-character `language code`_ for the
-type of language ``LanguageString`` contains.
-
-.. _`language code`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-
-.. code-block:: xml
-   :linenos:
-
-   <BallotTitle>
-      <Text language="en">Retention of Supreme Court Justice</Text>
-      <Text language="es">La retención de juez de la Corte Suprema</Text>
-   </BallotTitle>
-
-
-.. _single-csv-ballot-style:
-
-ballot_style
-~~~~~~~~~~~~
-
-A container for the contests/measures on the ballot.
-
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+===============+==============+==============+==========================================+==========================================+
-| image_uri            | ``xs:anyURI`` | Optional     | Single       | Specifies a URI that returns an image of | If the field is invalid or not present,  |
-|                      |               |              |              | the sample ballot.                       | then the implementation is required to   |
-|                      |               |              |              |                                          | ignore it.                               |
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ordered_contests_ids | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
-|                      |               |              |              | :ref:`single-csv-ordered-contest`        | then the implementation is required to   |
-|                      |               |              |              |                                          | ignore it.                               |
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| party_ids            | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
-|                      |               |              |              | :ref:`single-csv-party`s.                | then the implementation is required to   |
-|                      |               |              |              |                                          | ignore it.                               |
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,image_uri,ordered_contest_ids,party_ids
-    bs00010,http://i.giphy.com/26BoCh3PgT8ai45ji.gif,oc2025,par02
-    bs00011,http://i.giphy.com/3oEjHYDWEICgEpAOjK.gif,oc3000 oc2025,par01
-
-
-.. _single-csv-external-identifier:
-
-external_identifier
-~~~~~~~~~~~~~~~~~~~
-
-+--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type           | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+=====================+==============+==============+==========================================+==========================================+
-| type         | ``identifier_type`` | **Required** | Single       | Specifies the type of identifier. Must   | If the field is invalid or not present,  |
-|              |                     |              |              | be one of the valid types as defined by  | the implementation is required to ignore |
-|              |                     |              |              | :ref:`single-csv-identifier-type`.       | the ``ElectionIdentifier`` containing    |
-|              |                     |              |              |                                          | it.                                      |
-+--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| other_type   | ``xs:string``       | Optional     | Single       | Allows for cataloging an                 | If the field is invalid or not present,  |
-|              |                     |              |              | ``ExternalIdentifier`` type that falls   | then the implementation is required to   |
-|              |                     |              |              | outside the options listed in            | ignore it.                               |
-|              |                     |              |              | :ref:`single-csv-identifier-type`.       |                                          |
-|              |                     |              |              | ``Type`` should be set to "other" when   |                                          |
-|              |                     |              |              | using this field.                        |                                          |
-+--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| value        | ``xs:string``       | **Required** | Single       | Specifies the identifier.                | If the field is invalid or not present,  |
-|              |                     |              |              |                                          | the implementation is required to ignore |
-|              |                     |              |              |                                          | the ``ElectionIdentifier`` containing    |
-|              |                     |              |              |                                          | it.                                      |
-+--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-person:
-
-person
-~~~~~~
-
-``Person`` defines information about a person. The person may be a candidate, election administrator,
-or elected official. These elements reference ``Person``:
-
-* :ref:`single-csv-candidate`
-
-* :ref:`single-csv-election-administration`
-
-* :ref:`single-csv-office`
-
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                    | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+========================+========================================+==============+==============+==========================================+==========================================+
-| contact_information_id | ``xs:IDREF``                           | Optional     | Repeats      | Refers to the associated                 | If the element is invalid or not         |
-|                        |                                        |              |              | :ref:`single-csv-contact-information`.   | present, then the implementation is      |
-|                        |                                        |              |              |                                          | required to ignore it.                   |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| date_of_birth          | ``xs:date``                            | Optional     | Single       | Represents the individual's date of      | If the field is invalid or not present,  |
-|                        |                                        |              |              | birth.                                   | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers   | :ref:`single-csv-external-identifiers` | Optional     | Single       | Identifiers for this person.             | If the element is invalid or not         |
-|                        |                                        |              |              |                                          | present, then the implementation is      |
-|                        |                                        |              |              |                                          | required to ignore it.                   |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| first_name             | ``xs:string``                          | Optional     | Single       | Represents an individual's first name.   | If the field is invalid or not present,  |
-|                        |                                        |              |              |                                          | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| full_name              | ``xs:string``                          | Optional     | Single       | Specifies a person's full name (**NB:**  | If the element is invalid or not         |
-|                        |                                        |              |              | this information is                      | present, then the implementation is      |
-|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
-|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
-|                        |                                        |              |              | in multiple languages).                  |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| gender                 | ``xs:string``                          | Optional     | Single       | Specifies a person's gender.             | If the field is invalid or not present,  |
-|                        |                                        |              |              |                                          | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| last_name              | ``xs:string``                          | Optional     | Single       | Represents an individual's last name.    | If the field is invalid or not present,  |
-|                        |                                        |              |              |                                          | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| middle_name            | ``xs:string``                          | Optional     | Repeats      | Represents any number of names between   | If the field is invalid or not present,  |
-|                        |                                        |              |              | an individual's first and last names     | then the implementation is required to   |
-|                        |                                        |              |              | (e.g. John **Ronald Reuel** Tolkien).    | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| nickname               | ``xs:string``                          | Optional     | Single       | Represents an individual's nickname.     | If the field is invalid or not present,  |
-|                        |                                        |              |              |                                          | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| party_id               | ``xs:IDREF``                           | Optional     | Single       | Refers to the associated                 | If the field is invalid or not present,  |
-|                        |                                        |              |              | :ref:`single-csv-party`. This            | then the implementation is required to   |
-|                        |                                        |              |              | information is intended to be used by    | ignore it.                               |
-|                        |                                        |              |              | feed consumers to help them disambiguate |                                          |
-|                        |                                        |              |              | the person's identity, but not to be     |                                          |
-|                        |                                        |              |              | presented as part of any ballot          |                                          |
-|                        |                                        |              |              | information. For that see                |                                          |
-|                        |                                        |              |              | :ref:`single-csv-candidate` **PartyId**. |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| prefix                 | ``xs:string``                          | Optional     | Single       | Specifies a prefix associated with a     | If the field is invalid or not present,  |
-|                        |                                        |              |              | person (e.g. Dr.).                       | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| profession             | ``xs:string``                          | Optional     | Single       | Specifies a person's profession (**NB:** | If the element is invalid or not         |
-|                        |                                        |              |              | this information is                      | present, then the implementation is      |
-|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
-|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
-|                        |                                        |              |              | in multiple languages).                  |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| suffix                 | ``xs:string``                          | Optional     | Single       | Specifies a suffix associated with a     | If the field is invalid or not present,  |
-|                        |                                        |              |              | person (e.g. Jr.).                       | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| title                  | ``xs:string``                          | Optional     | Single       | A title associated with a person         | If the element is invalid or not         |
-|                        |                                        |              |              | (**NB:** this information is             | present, then the implementation is      |
-|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
-|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
-|                        |                                        |              |              | in multiple languages).                  |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,date_of_birth,first_name,gender,last_name,middle_name,nickname,party_id,prefix,profession,suffix,title
-    per50001,1961-08-04,Barack,male,Obama,Hussein,,par02,,President,II,Mr. President
-    per50002,1985-11-21,Carly,female,Jepsen,Rae,,par01,,Recording Artist,,
-    per50003,1926-09-23,John,male,Coltrane,William,Trane,par02,,Recording Artist,Saint,
-    per50004,1926-05-26,Miles,male,Davis,Dewey,,par01,,Recording Artist,III,
-
-
-.. _single-csv-contact-information:
-
-contact_information
-^^^^^^^^^^^^^^^^^^^
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
-:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+===========================+==============+==============+==========================================+==========================================+
-| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
-|               |                           |              |              | element. It is strongly encouraged that  |                                          |
-|               |                           |              |              | data providers move toward contributing  |                                          |
-|               |                           |              |              | hours in this format)*.                  |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
-|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
-|               |                           |              |              | location.                                |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|               |                           |              |              | this entity.                             | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|               |                           |              |              | location.                                | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
-    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
-    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
-
-
-.. _single-csv-external-identifiers:
-
-external_identifiers
-~~~~~~~~~~~~~~~~~~~~
-
-The ``ExternalIdentifiers`` element allows VIP data to connect with external datasets (e.g.
-candidates with campaign finance datasets, electoral geographies with `OCD-IDs`_ that allow for
-greater connectivity with additional datasets, etc...). Examples for ``ExternalIdentifiers`` can be
-found on the objects that support them:
-
-* :ref:`single-csv-candidate`
-
-* Any element that extends :ref:`single-csv-contest-base`
-
-* :ref:`single-csv-electoral-district`
-
-* :ref:`single-csv-locality`
-
-* :ref:`single-csv-office`
-
-* :ref:`single-csv-party`
-
-* :ref:`single-csv-precinct`
-
-* :ref:`single-csv-state`
-
-.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-+---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=======================================+==============+==============+==========================================+==========================================+
-| external_identifier | :ref:`single-csv-external-identifier` | **Required** | Repeats      | Defines the identifier and the type of   | At least one valid `ExternalIdentifier`_ |
-|                     |                                       |              |              | identifier it is (see                    | must be present for                      |
-|                     |                                       |              |              | `ExternalIdentifier`_ for complete       | ``ExternalIdentifiers`` to be valid. If  |
-|                     |                                       |              |              | information).                            | no valid `ExternalIdentifier`_ is        |
-|                     |                                       |              |              |                                          | present, the implementation is required  |
-|                     |                                       |              |              |                                          | to ignore the ``ExternalIdentifiers``    |
-|                     |                                       |              |              |                                          | element.                                 |
-+---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-voter-service:
-
-voter_service
-~~~~~~~~~~~~~
-
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                         | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=============================+=======================================+==============+==============+==========================================+==========================================+
-| contact_information         | :ref:`single-csv-contact-information` | Optional     | Single       | The contact for a particular voter       | If the element is invalid or not         |
-|                             |                                       |              |              | service.                                 | present, then the implementation is      |
-|                             |                                       |              |              |                                          | required to ignore it.                   |
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| description                 | ``xs:string``                         | Optional     | Single       | Long description of the services         | If the element is invalid or not         |
-|                             |                                       |              |              | available.                               | present, then the implementation is      |
-|                             |                                       |              |              |                                          | required to ignore it.                   |
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| election_official_person_id | ``xs:IDREF``                          | Optional     | Single       | The :ref:`authority <single-csv-person>` | If the field is invalid or not present,  |
-|                             |                                       |              |              | for a particular voter service.          | then the implementation is required to   |
-|                             |                                       |              |              |                                          | ignore it.                               |
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| type                        | :ref:`single-csv-voter-service-type`  | Optional     | Single       | The type of :ref:`voter service          | If the field is invalid or not present,  |
-|                             |                                       |              |              | <single-csv-voter-service-type>`.        | then the implementation is required to   |
-|                             |                                       |              |              |                                          | ignore it.                               |
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| other_type                  | ``xs:string``                         | Optional     | Single       | If Type is "other", OtherType allows for | If the field is invalid or not present,  |
-|                             |                                       |              |              | cataloging another type of voter         | then the implementation is required to   |
-|                             |                                       |              |              | service.                                 | ignore it.                               |
-+-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,description,election_official_person_id,type,other_type,department_id
-    vs01,A service we provide,per50002,other,overseas-voting,dep01
-    vs00,Elections notifications,per50002,other,voter-registration,dep02
-    vs02,Pencil sharpening,per50002,other,office-help,dep03
-    vs03,Guided hike to polling place,per50002,other,polling-places,dep03
-    vs04,Bike messenger ballot delivery,per50002,other,absentee-ballots,dep03
-
-
-.. _single-csv-contact-information:
-
-contact_information
-~~~~~~~~~~~~~~~~~~~
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
-:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+===========================+==============+==============+==========================================+==========================================+
-| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
-|               |                           |              |              | element. It is strongly encouraged that  |                                          |
-|               |                           |              |              | data providers move toward contributing  |                                          |
-|               |                           |              |              | hours in this format)*.                  |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
-|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
-|               |                           |              |              | location.                                |                                          |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|               |                           |              |              | this entity.                             | present, then the implementation is      |
-|               |                           |              |              |                                          | required to ignore it.                   |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|               |                           |              |              |                                          | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|               |                           |              |              | location.                                | then the implementation is required to   |
-|               |                           |              |              |                                          | ignore it.                               |
-+---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
-    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
-    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
-
-
-.. _single-csv-candidate-selection:
-
-candiate_selection
-~~~~~~~~~~~~~~~~~~
-
-CandidateSelection extends :ref:`single-csv-ballot-selection-base` and represents a
-ballot selection for a candidate contest.
-
-+-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                   | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=======================+================+==============+==============+==========================================+==========================================+
-| candidate_ids         | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                       |                |              |              | :ref:`single-csv-candidate` elements.    | then the implementation is required to   |
-|                       |                |              |              | The number of candidates that can be     | ignore it.                               |
-|                       |                |              |              | references is unbounded in cases where   |                                          |
-|                       |                |              |              | the ballot selection is for a ticket     |                                          |
-|                       |                |              |              | (e.g. "President/Vice President",        |                                          |
-|                       |                |              |              | "Governor/Lt Governor").                 |                                          |
-+-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| endorsement_party_ids | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                       |                |              |              | :ref:`single-csv-party` elements, which  | then the implementation is required to   |
-|                       |                |              |              | signifies one or more endorsing parties  | ignore it.                               |
-|                       |                |              |              | for the candidate(s).                    |                                          |
-+-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_write_in           | ``xs:boolean`` | Optional     | Single       | Signifies if the particular ballot       | If the field is invalid or not present,  |
-|                       |                |              |              | selection allows for write-in            | then the implementation is required to   |
-|                       |                |              |              | candidates. If true, one or more         | ignore it.                               |
-|                       |                |              |              | write-in candidates are allowed for this |                                          |
-|                       |                |              |              | contest.                                 |                                          |
-+-----------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,sequence_order,candidate_ids,endorsement_party_ids,is_write_in
-    cs001,3,can004,par01,false
-    cs002,2,can001 can002,par03 par02,false
-    cs003,1,can003,par02 par03,true
-
-
-.. _single-csv-ballot-selection-base:
-
-ballot_selection_base
-^^^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-csv-ballot-measure-selection`,
-:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
-
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+================+================+==============+==============+==========================================+==========================================+
-| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-lat-lng:
-
-lat_long
-~~~~~~~~
-
-The latitude and longitude of a polling location in `WGS 84`_ format. Both
-latitude and longitude values are measured in decimal degrees.
-
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+===============+==============+==============+==========================================+==========================================+
-| latitude      | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
-|               |               |              |              |                                          | implementation is required to ignore it. |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| longitude     | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
-|               |               |              |              |                                          | implementation is required to ignore it. |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| latlng_source | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
-|               |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
-|               |               |              |              | example, this could be the name of a     | ignore it.                               |
-|               |               |              |              | geocoding service.                       |                                          |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-candidate:
-
-candidate
-~~~~~~~~~
-
-The Candidate object represents a candidate in a contest. If a candidate is
-running in multiple contests, each contest **must** have its own Candidate
-object. Candidate objects may **not** be reused between Contests.
-
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+==================================================+==============+==============+==========================================+==========================================+
-| ballot_name          | ``xs:string``                                    | **Required** | Single       | The candidate's name as it will be       | If the element is invalid, then the      |
-|                      |                                                  |              |              | displayed on the official ballot (e.g.   | implementation is required to ignore the |
-|                      |                                                  |              |              | "Ken T. Cuccinelli II").                 | ``Candidate`` element containing it.     |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| contact_information  | ``xs:string``                                    | Optional     | Single       | Contact and physical address information | If the element is invalid or not         |
-|                      |                                                  |              |              | for this Candidate and/or their campaign | present, then the implementation is      |
-|                      |                                                  |              |              | (see                                     | required to ignore it.                   |
-|                      |                                                  |              |              | :ref:`single-csv-contact-information`).  |                                          |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers | :ref:`single-csv-external-identifiers`           | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
-|                      |                                                  |              |              | links to another source of information   | present, then the implementation is      |
-|                      |                                                  |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
-|                      |                                                  |              |              | to a campaign finance system).           |                                          |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| file_date            | ``xs:date``                                      | Optional     | Single       | Date when the candidate filed for the    | If the field is invalid or not present,  |
-|                      |                                                  |              |              | contest.                                 | then the implementation is required to   |
-|                      |                                                  |              |              |                                          | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_incumbent         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
-|                      |                                                  |              |              | incumbent for the office associated with | then the implementation is required to   |
-|                      |                                                  |              |              | the contest.                             | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_top_ticket        | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
-|                      |                                                  |              |              | top of a ticket that includes multiple   | then the implementation is required to   |
-|                      |                                                  |              |              | candidates.                              | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| party_id             | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-csv-party`   | If the field is invalid or not present,  |
-|                      |                                                  |              |              | element with additional information      | then the implementation is required to   |
-|                      |                                                  |              |              | about the candidate's affiliated party.  | ignore it.                               |
-|                      |                                                  |              |              | This is the party affiliation that is    |                                          |
-|                      |                                                  |              |              | intended to be presented as part of      |                                          |
-|                      |                                                  |              |              | ballot information.                      |                                          |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| person_id            | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-csv-person`  | If the field is invalid or not present,  |
-|                      |                                                  |              |              | element with additional information      | then the implementation is required to   |
-|                      |                                                  |              |              | about the candidate.                     | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| post_election_status | :ref:`single-csv-candidate-post-election-status` | Optional     | Single       | Final status of the candidate (e.g.      | If the field is invalid or not present,  |
-|                      |                                                  |              |              | winner, withdrawn, etc...).              | then the implementation is required to   |
-|                      |                                                  |              |              |                                          | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| pre_election_status  | :ref:`single-csv-candidate-pre-election-status`  | Optional     | Single       | Registration status of the candidate     | If the field is invalid or not present,  |
-|                      |                                                  |              |              | (e.g. filed, qualified, etc...).         | then the implementation is required to   |
-|                      |                                                  |              |              |                                          | ignore it.                               |
-+----------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,ballot_name,external_identifier_type,external_identifier_othertype,external_identifier_value,file_date,is_incumbent,is_top_ticket,party_id,person_id,post_election_status,pre_election_status
-    can001,Jude Fawley,,,,2016-12-01,true,false,par01,per50001,,filed
-    can002,Arabella Donn,,,,2016-12-01,false,false,par02,per50002,,qualified
-    can003,John Coltrane,,,,2016-09-23,false,false,par02,per50003,,qualified
-    can004,Miles Davis,,,,2016-05-26,false,false,par01,per50004,,qualified
-
-
-.. _single-csv-polling-location:
-
-polling_location
-~~~~~~~~~~~~~~~~
-
-The PollingLocation object represents a site where voters cast or drop off ballots.
-
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=======================================+===========================+==============+==============+==========================================+==========================================+
-| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
-|                                       |                           |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
-|                                       |                           |              |              |                                          | given Polling Location. If none is       |
-|                                       |                           |              |              |                                          | present, the implementation is required  |
-|                                       |                           |              |              |                                          | to ignore the ``PollingLocation``        |
-|                                       |                           |              |              |                                          | element containing it.                   |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| address_line                          | ``xs:string``             | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
-|                                       |                           |              |              | address to a polling location.           | should be present for a given Polling    |
-|                                       |                           |              |              |                                          | Location. If none is present, the        |
-|                                       |                           |              |              |                                          | implementation is required to ignore the |
-|                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
-|                                       |                           |              |              |                                          | it.                                      |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| directions                            | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                                       |                           |              |              | locating the polling location.           | present, then the implementation is      |
-|                                       |                           |              |              |                                          | required to ignore it.                   |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours                                 | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-|                                       |                           |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                                       |                           |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                                       |                           |              |              | the more structured                      |                                          |
-|                                       |                           |              |              | :ref:`single-csv-hours-open` element. It |                                          |
-|                                       |                           |              |              | is strongly encouraged that data         |                                          |
-|                                       |                           |              |              | providers move toward contributing hours |                                          |
-|                                       |                           |              |              | in this format).                         |                                          |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| hours_open_id                         | ``xs:IDREF``              | Optional     | Single       | Links to an :ref:`single-csv-hours-open` | If the field is invalid or not present,  |
-|                                       |                           |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                                       |                           |              |              | and hours during which the polling       | ignore it.                               |
-|                                       |                           |              |              | location is available.                   |                                          |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_drop_box                           | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                                       |                           |              |              | drop box.                                | then the implementation is required to   |
-|                                       |                           |              |              |                                          | ignore it.                               |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_early_voting                       | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                                       |                           |              |              | early vote site.                         | then the implementation is required to   |
-|                                       |                           |              |              |                                          | ignore it.                               |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_lng                               | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                                       |                           |              |              | this polling location.                   | present, then the implementation is      |
-|                                       |                           |              |              |                                          | required to ignore it.                   |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                                  | ``xs:string``             | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                                       |                           |              |              |                                          | then the implementation is required to   |
-|                                       |                           |              |              |                                          | ignore it.                               |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| photo_uri                             | ``xs:string``             | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                                       |                           |              |              | polling location.                        | then the implementation is required to   |
-|                                       |                           |              |              |                                          | ignore it.                               |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,name,address_line,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
-    poll001,ALBERMARLE HIGH SCHOOL,,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
-    poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
-
-
-.. _single-csv-lat-lng:
-
-lat_long
-^^^^^^^^
-
-The latitude and longitude of a polling location in `WGS 84`_ format. Both
-latitude and longitude values are measured in decimal degrees.
-
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+===============+==============+==============+==========================================+==========================================+
-| latitude      | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
-|               |               |              |              |                                          | implementation is required to ignore it. |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| longitude     | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
-|               |               |              |              |                                          | implementation is required to ignore it. |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| latlng_source | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
-|               |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
-|               |               |              |              | example, this could be the name of a     | ignore it.                               |
-|               |               |              |              | geocoding service.                       |                                          |
-+---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-simple-address-type:
-
-simple_address_type
-^^^^^^^^^^^^^^^^^^^
-
-A ``SimpleAddressType`` represents a structured address.
-
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===================+===============+==============+==============+==========================================+==========================================+
-| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|                   |               |              |              | suffix.                                  |                                          |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
-|                   |               |              |              |                                          | implementation should ignore it.         |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
-|                   |               |              |              |                                          | implementation should ignore it.         |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-locality:
-
-locality
-~~~~~~~~
-
-The Locality object represents the jurisdiction below the :ref:`single-csv-state` (e.g. county).
-
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Tag                        | Data Type                              | Required?    | Repeats?     | Description                               | Error Handling                           |
-+============================+========================================+==============+==============+===========================================+==========================================+
-| election_administration_id | ``xs:IDREF``                           | Optional     | Single       | Links to the locality's                   | If the field is invalid or not present,  |
-|                            |                                        |              |              | :ref:`single-csv-election-administration` | then the implementation is required to   |
-|                            |                                        |              |              | object.                                   | ignore it.                               |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| external_identifiers       | :ref:`single-csv-external-identifiers` | Optional     | Single       | Another identifier for a locality that    | If the element is invalid or not         |
-|                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
-|                            |                                        |              |              |                                           | required to ignore it.                   |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
-|                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
-|                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
-|                            |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
-|                            |                                        |              |              | may be used in addition to this flag      |                                          |
-|                            |                                        |              |              | using a :ref:`polling location            |                                          |
-|                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
-|                            |                                        |              |              | configured as a Drop Box.                 |                                          |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                            |                                        |              |              |                                           | implementation is required to ignore the |
-|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
-|                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
-|                            |                                        |              |              | <single-csv-polling-location>`s. If early | it. However, the implementation should   |
-|                            |                                        |              |              | vote centers or ballot drop locations are | still check to see if there are any      |
-|                            |                                        |              |              | locality-wide, they should be specified   | polling locations associated with this   |
-|                            |                                        |              |              | here.                                     | locality's state.                        |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| state_id                   | ``xs:IDREF``                           | **Required** | Single       | References the locality's                 | If the field is invalid, then the        |
-|                            |                                        |              |              | :ref:`single-csv-state`.                  | implementation is required to ignore the |
-|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| type                       | :ref:`single-csv-district-type`        | Optional     | Single       | Defines the kind of locality (e.g.        | If the field is invalid or not present,  |
-|                            |                                        |              |              | county, town, et al.), which is one of    | then the implementation is required to   |
-|                            |                                        |              |              | the various :ref:`DistrictType            | ignore it.                               |
-|                            |                                        |              |              | enumerations <single-csv-district-type>`. |                                          |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| other_type                 | ``xs:string``                          | Optional     | Single       | Allows for defining a type of locality    | If the field is invalid or not present,  |
-|                            |                                        |              |              | that falls outside the options listed in  | then the implementation is required to   |
-|                            |                                        |              |              | :ref:`DistrictType                        | ignore it.                               |
-|                            |                                        |              |              | <single-csv-district-type>`.              |                                          |
-+----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
-    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
-    loc002,ea345,,,,,Locality #2,,st51,other,unique type
 
 
 .. _single-csv-department:
@@ -1526,325 +799,92 @@ organizations, etc. ContactInformation is always a sub-element of another object
     ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
 
 
-.. _single-csv-html-color-string:
+.. _single-csv-election:
 
-html_color_string
-~~~~~~~~~~~~~~~~~
-
-A restricted string pattern for a six-character hex code representing an HTML
-color string. The pattern is:
-
-``[0-9a-f]{6}``
-
-
-.. _single-csv-schedule:
-
-schedule
+election
 ~~~~~~~~
 
-A sub-portion of the schedule. This describes a range of days, along with one or
-more set of open and close times for those days, as well as the options
-describing whether or not appointments are necessary or possible.
+The Election object represents an Election Day, which usually consists of many individual contests
+and/or referenda. A feed must contain **exactly one** Election object. All relationships in the
+feed (e.g., street segment to precinct to polling location) are assumed to relate only to
+the Election specified by this object. It is permissible, and recommended, to combine unrelated
+contests (e.g., a special election and a general election) that occur on the same day into one feed
+with one Election object.
 
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                    | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+========================+=========================+==============+==============+==========================================+==========================================+
-| hours                  | :ref:`single-csv-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
-|                        |                         |              |              | which the place is open.                 | present, then the implementation is      |
-|                        |                         |              |              |                                          | required to ignore it.                   |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_only_by_appointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
-|                        |                         |              |              | the specified time window with an        | then the implementation is required to   |
-|                        |                         |              |              | appointment.                             | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_or_by_appointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
-|                        |                         |              |              | hours specified time window and may also | then the implementation is required to   |
-|                        |                         |              |              | be open with an appointment.             | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_subject_to_change   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
-|                        |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
-|                        |                         |              |              | subject to change. People should contact | ignore it.                               |
-|                        |                         |              |              | prior to arrival to confirm hours are    |                                          |
-|                        |                         |              |              | still accurate.                          |                                          |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| start_date             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                        |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
-|                        |                         |              |              |                                          | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| end_date               | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                        |                         |              |              | start and end times and options end.     | then the implementation is required to   |
-|                        |                         |              |              |                                          | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,start_time,end_time,is_only_by_appointment,is_or_by_appointment,is_subject_to_change,start_date,end_date,hours_open_id
-    sch001,07:00:00-06:00,22:00:00-06:00,,true,,2016-10-10,2016-10-12,ho001
-    sch002,09:00:00-06:00,20:00:00-06:00,true,,,2016-10-13,2016-10-15,ho001
-    sch003,08:00:00-06:00,14:00:00-06:00,,,true,2016-10-10,2016-10-15,ho002
-
-
-.. _single-csv-hours:
-
-hours
-^^^^^
-
-The open and close time for this place. All times must be fully specified,
-including a timezone offset from UTC.
-
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==================================+==============+==============+==========================================+==========================================+
-| start_time   | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| end_time     | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-time-with-zone:
-
-time_with_zone
-%%%%%%%%%%%%%%
-
-A string pattern restricting the value to a time with an included offset from
-UTC. The pattern is
-
-``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
-
-.. code-block:: xml
-   :linenos:
-
-   <HoursOpen id="hours0001">
-     <Schedule>
-       <Hours>
-         <StartTime>06:00:00-05:00</StartTime>
-         <EndTime>12:00:00-05:00</EndTime>
-       </Hours>
-       <Hours>
-         <StartTime>13:00:00-05:00</StartTime>
-         <EndTime>19:00:00-05:00</EndTime>
-       </Hours>
-       <StartDate>2013-11-05</StartDate>
-       <EndDate>2013-11-05</EndDate>
-     </Schedule>
-   </HoursOpen>
-
-
-.. _single-csv-precinct:
-
-precinct
-~~~~~~~~
-
-The Precinct object represents a precinct, which is contained within a Locality. While the id
-attribute does not have to be static across feeds for one election, the combination of
-:ref:`Source.VipId <single-csv-source>`, :ref:`Locality.Name <single-csv-locality>`, :ref:`Precinct.Ward <single-csv-precinct>`,
-:ref:`Precinct.Name <single-csv-precinct>`, and :ref:`Precinct.Number <single-csv-precinct>` should remain constant across
-feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
-non-required fields is fine).
-
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                    | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+========================+========================================+==============+==============+==========================================+==========================================+
-| ballot_style_id        | ``xs:IDREF``                           | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
-|                        |                                        |              |              | :ref:`single-csv-ballot-style`, which a  | then the implementation is required to   |
-|                        |                                        |              |              | person who lives in this precinct will   | ignore it.                               |
-|                        |                                        |              |              | vote.                                    |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electoral_district_ids | ``xs:IDREFS``                          | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
-|                        |                                        |              |              | :ref:`single-csv-electoral-district`s    | then the implementation is required to   |
-|                        |                                        |              |              | (e.g., congressional district, state     | ignore it.                               |
-|                        |                                        |              |              | house district, school board district)   |                                          |
-|                        |                                        |              |              | to which the entire precinct/precinct    |                                          |
-|                        |                                        |              |              | split belongs. **Highly Recommended** if |                                          |
-|                        |                                        |              |              | candidate information is to be provided. |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers   | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
-|                        |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                        |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_mail_only           | ``xs:boolean``                         | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
-|                        |                                        |              |              | mail-only elections.                     | implementation is required to assume     |
-|                        |                                        |              |              |                                          | `IsMailOnly` is false.                   |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| locality_id            | ``xs:IDREF``                           | **Required** | Single       | Links to the :ref:`single-csv-locality`  | If the field is invalid, then the        |
-|                        |                                        |              |              | that comprises the precinct.             | implementation is required to ignore the |
-|                        |                                        |              |              |                                          | ``Precinct`` element containing it.      |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                   | ``xs:string``                          | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid, then the        |
-|                        |                                        |              |              | if no name exists).                      | implementation is required to ignore the |
-|                        |                                        |              |              |                                          | ``Precinct`` element containing it.      |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| number                 | ``xs:string``                          | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
-|                        |                                        |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
-|                        |                                        |              |              | legal). Should be used if the `Name`     | ignore it.                               |
-|                        |                                        |              |              | field is populated by a name and not a   |                                          |
-|                        |                                        |              |              | number.                                  |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| polling_location_ids   | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the precinct's       | If the field is invalid or not present,  |
-|                        |                                        |              |              | :ref:`single-csv-polling-location`       | then the implementation is required to   |
-|                        |                                        |              |              | object(s).                               | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| precinct_split_name    | ``xs:string``                          | Optional     | Single       | If this field is empty, then this        | If the field is invalid or not present,  |
-|                        |                                        |              |              | `Precinct` object represents a full      | then the implementation is required to   |
-|                        |                                        |              |              | precinct. If this field is present, then | ignore it.                               |
-|                        |                                        |              |              | this `Precinct` object represents one    |                                          |
-|                        |                                        |              |              | portion of a split precinct. Each        |                                          |
-|                        |                                        |              |              | `Precinct` object that represents one    |                                          |
-|                        |                                        |              |              | portion of a split precinct **must**     |                                          |
-|                        |                                        |              |              | have the same `Name` value, but          |                                          |
-|                        |                                        |              |              | different `PrecinctSplitName` values.    |                                          |
-|                        |                                        |              |              | See the `sample_feed.xml` file for       |                                          |
-|                        |                                        |              |              | examples.                                |                                          |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ward                   | ``xs:string``                          | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
-|                        |                                        |              |              | contained within.                        | then the implementation is required to   |
-|                        |                                        |              |              |                                          | ignore it.                               |
-+------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============================+================+==============+==============+==========================================+==========================================+
+| date                          | ``xs:date``    | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
+|                               |                |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
+|                               |                |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
+|                               |                |              |              | the election.                            |                                          |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_type                 | ``xs:string``  | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
+|                               |                |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
+|                               |                |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| state_id                      | ``xs:IDREF``   | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
+|                               |                |              |              | where the election is being held.        | implementation is required to ignore the |
+|                               |                |              |              |                                          | ``Election`` element containing it.      |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_statewide                  | ``xs:boolean`` | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
+|                               |                |              |              | statewide.                               | the implementation is required to        |
+|                               |                |              |              |                                          | default to "yes".                        |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                          | ``xs:string``  | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
+|                               |                |              |              | optional, this element is highly         | present, then the implementation is      |
+|                               |                |              |              | recommended).                            | required to ignore it.                   |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_info             | ``xs:string``  | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
+|                               |                |              |              | for this election either as text or a    | present, then the implementation is      |
+|                               |                |              |              | URI.                                     | required to ignore it.                   |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_ballot_info          | ``xs:string``  | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
+|                               |                |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
+|                               |                |              |              |                                          | required to ignore it.                   |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| results_uri                   | ``xs:anyURI``  | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
+|                               |                |              |              | election may be found                    | then the implementation is required to   |
+|                               |                |              |              |                                          | ignore it.                               |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| polling_hours                 | ``xs:string``  | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                               |                |              |              | Election Day polling locations are open. | present, then the implementation is      |
+|                               |                |              |              | If polling hours differ in specific      | required to ignore it.                   |
+|                               |                |              |              | polling locations, alternative hours may |                                          |
+|                               |                |              |              | be specified in the                      |                                          |
+|                               |                |              |              | :ref:`single-csv-polling-location`       |                                          |
+|                               |                |              |              | object *(NB: this element is deprecated  |                                          |
+|                               |                |              |              | in favor of the more structured          |                                          |
+|                               |                |              |              | :ref:`single-csv-hours-open` element. It |                                          |
+|                               |                |              |              | is strongly encouraged that data         |                                          |
+|                               |                |              |              | providers move toward contributing hours |                                          |
+|                               |                |              |              | in this format)*.                        |                                          |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_ids                | ``xs:IDREF``   | Optional     | Single       | References the                           | If the field is invalid or not present,  |
+|                               |                |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
+|                               |                |              |              | which lists the hours of operation for   | ignore it.                               |
+|                               |                |              |              | polling locations.                       |                                          |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| has_election_day_registration | ``xs:boolean`` | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
+|                               |                |              |              | same day of the election (i.e., the last | then the implementation is required to   |
+|                               |                |              |              | day of the election). Valid items are    | ignore it.                               |
+|                               |                |              |              | "yes" and "no".                          |                                          |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| registration_deadline         | ``xs:date``    | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
+|                               |                |              |              | the election with the possible exception | then the implementation is required to   |
+|                               |                |              |              | of Election Day registration.            | ignore it.                               |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| absentee_request_deadline     | ``xs:date``    | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
+|                               |                |              |              | absentee ballot.                         | then the implementation is required to   |
+|                               |                |              |              |                                          | ignore it.                               |
++-------------------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,ballot_style_id,electoral_district_ids,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,locality_id,name,number,polling_location_ids,precinct_split_name,ward
-    pre90111,bs00010,ed001,ocd-id,,ocd-division/country:us,false,loc001,203 - GEORGETOWN,0203,poll001 poll002,split13,5
-    pre90112,bs00011,ed002,fips,,42,false,loc001,203 - GEORGETOWN,0203,poll003,split26,6
-    pre90113,bs00010,ed003,,,,false,loc002,203 - GEORGETOWN,0203,poll004,split54,7
-
-
-.. _single-csv-ordered-contest:
-
-ordered_contest
-~~~~~~~~~~~~~~~
-
-``OrderedContest`` encapsulates links to the information that comprises a contest and potential
-ballot selections. ``OrderedContest`` elements can be collected within a
-:ref:`single-csv-ballot-style` to accurate depict exactly what will show up on a particular
-ballot in the proper order.
-
-+------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-| Tag                          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                                   |
-+==============================+==============+==============+==============+==========================================+==================================================+
-| contest_id                   | ``xs:IDREF`` | **Required** | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
-|                              |              |              |              | :ref:`single-csv-contest-base`.          | implementation is required to ignore the         |
-|                              |              |              |              |                                          | ``OrderedContest`` element containing it.        |
-+------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-| ordered_ballot_selection_ids | ``IDREFS``   | Optional     | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
-|                              |              |              |              | :ref:`single-csv-ballot-selection-base`. | implementation is required to ignore it. If an   |
-|                              |              |              |              |                                          | ``OrderedBallotSelectionIds`` element is not     |
-|                              |              |              |              |                                          | present, the presumed order of the selection     |
-|                              |              |              |              |                                          | will be the order of                             |
-|                              |              |              |              |                                          | :ref:`single-csv-ballot-selection-base`-extended |
-|                              |              |              |              |                                          | elements referenced by the underlying            |
-|                              |              |              |              |                                          | :ref:`single-csv-contest-base`-extended          |
-|                              |              |              |              |                                          | elements.                                        |
-+------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,contest_id,ordered_ballot_selection_ids
-    oc2025,con001,bs001 bs002 bs003
-    oc3000,con002,bs001
-
-
-.. _single-csv-party-contest:
-
-party_contest
-~~~~~~~~~~~~~
-
-An extension of :ref:`single-csv-contest-base` which describes a contest in
-which the possible ballot selections are of type :ref:`single-csv-party-selection`. These could include contests in which straight-party
-selections are allowed, or party-list contests (although these are more common
-outside of the United States).
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation
-    pcon001,PC1071,bs001 bs002,,Party Election,ed001,all registered voters,,,,false,Straight Party Vote,3,,
-
-
-.. _single-csv-contest-base:
-
-contest_base
-^^^^^^^^^^^^
-
-A base model for all Contest types: :ref:`single-csv-ballot-measure-contest`,
-:ref:`single-csv-candidate-contest`, :ref:`single-csv-party-contest`,
-and :ref:`single-csv-retention-contest` (NB: the latter because it extends
-:ref:`single-csv-ballot-measure-contest`).
-
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+==================================+==============+==============+==========================================+==========================================+
-| abbreviation             | ``xs:string``                    | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
-|                          |                                  |              |              |                                          | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_selection_ids     | ``xs:IDREFS``                    | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
-|                          |                                  |              |              | which could be of any selection type     | then the implementation should ignore    |
-|                          |                                  |              |              | that extends                             | it.                                      |
-|                          |                                  |              |              | :ref:`single-csv-ballot-selection-base`. |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_sub_title         | ``xs:string``                    | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
-|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_title             | ``xs:string``                    | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
-|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electoral_district_id    | ``xs:IDREF``                     | **Required** | Single       | References an                            | If the field is invalid, then the        |
-|                          |                                  |              |              | :ref:`single-csv-electoral-district`     | implementation is required to ignore the |
-|                          |                                  |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
-|                          |                                  |              |              | scope of the contest.                    |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electorate_specification | ``xs:string``                    | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
-|                          |                                  |              |              | electorate for this contest past the     | present, then the implementation should  |
-|                          |                                  |              |              | usual, "all registered voters"           | ignore it.                               |
-|                          |                                  |              |              | electorate. This subtag will most often  |                                          |
-|                          |                                  |              |              | be used for primaries and local          |                                          |
-|                          |                                  |              |              | elections. In primaries, voters may have |                                          |
-|                          |                                  |              |              | to be registered as a specific party to  |                                          |
-|                          |                                  |              |              | vote, or there may be special rules for  |                                          |
-|                          |                                  |              |              | which ballot a voter can pull. In some   |                                          |
-|                          |                                  |              |              | local elections, non-citizens can vote.  |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers     | ``xs:string``                    | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
-|                          |                                  |              |              | links to another source of information.  | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| has_rotation             | ``xs:boolean``                   | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
-|                          |                                  |              |              | contest are rotated.                     | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                     | ``xs:string``                    | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
-|                          |                                  |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
-|                          |                                  |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
-|                          |                                  |              |              | purpose).                                |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| sequence_order           | ``xs:integer``                   | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
-|                          |                                  |              |              | on the ballot. This is the default       | then the implementation should ignore    |
-|                          |                                  |              |              | ordering, and can be overrides by data   | it.                                      |
-|                          |                                  |              |              | in a :ref:`single-csv-ballot-style`      |                                          |
-|                          |                                  |              |              | element.                                 |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vote_variation           | :ref:`single-csv-vote-variation` | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
-|                          |                                  |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| other_vote_variation     | ``other_vote_variation``         | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
-|                          |                                  |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
-|                          |                                  |              |              | variation can be specified here.         | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+    id,date,name,election_type,state_id,is_statewide,registration_info,absentee_ballot_info,results_uri,polling_hours,has_election_day_registration,registration_deadline,absentee_request_deadline,hours_open_id
+    e001,10-08-2016,Best Hot Dog,State,st51,true,www.registrationinfo.com,You can vote absentee,http://hotdogcontest.gov/results,Noon to 3p.m.,true,10/08/2016,,ho002
 
 
 .. _single-csv-election-administration:
@@ -2123,6 +1163,142 @@ voter_service
     vs04,Bike messenger ballot delivery,per50002,other,absentee-ballots,dep03
 
 
+.. _single-csv-election-notice:
+
+election_notice
+~~~~~~~~~~~~~~~
+
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+===============+==============+==============+==========================================+==========================================+
+| election_notice_text | ``xs:string`` | **Required** | Single       | The last minute or emergency             | If the element is invalid, then the      |
+|                      |               |              |              | notification text should be placed here. | implementation is required to ignore the |
+|                      |               |              |              |                                          | ``ElectionNotice`` element containing    |
+|                      |               |              |              |                                          | it.                                      |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_notice_uri  | ``xs:string`` | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|                      |               |              |              | related to the last minute or emergency  | then the implementation is required to   |
+|                      |               |              |              | notification.                            | ignore it.                               |
++----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-electoral-district:
+
+electoral_district
+~~~~~~~~~~~~~~~~~~
+
+The ``ElectoralDistrict`` object represents the geographic area in which contests are held. Examples
+of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congressional District",
+or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
+which precincts link to the ``ElectoralDistrict``.
+
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+========================================+==============+==============+==========================================+==========================================+
+| external_identifiers | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
+|                      |                                        |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
+|                      |                                        |              |              |                                          | required to ignore it.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                 | ``xs:string``                          | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
+|                      |                                        |              |              |                                          | then the implementation is required to   |
+|                      |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                      |                                        |              |              |                                          | containing it.                           |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| number               | ``xs:integer``                         | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
+|                      |                                        |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
+|                      |                                        |              |              | 34th State Senate District). If a number | ignore it.                               |
+|                      |                                        |              |              | is not applicable, instead of leaving    |                                          |
+|                      |                                        |              |              | the field blank, leave this field out of |                                          |
+|                      |                                        |              |              | the object; empty strings are not valid  |                                          |
+|                      |                                        |              |              | for xs:integer fields.                   |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| type                 | :ref:`single-csv-district-type`        | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
+|                      |                                        |              |              |                                          | then the implementation is required to   |
+|                      |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                      |                                        |              |              |                                          | containing it.                           |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| other_type           | ``xs:string``                          | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
+|                      |                                        |              |              | :ref:`single-csv-district-type` option   | then the implementation is required to   |
+|                      |                                        |              |              | when ``Type`` is specified as "other".   | ignore it.                               |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,number,type,other_type
+    ed001,ocd-id,,ocd-division/country:us/state:ny/borough:brooklyn,Brooklyn,1,borough,
+    ed002,other,community-board,4,CB 4,2,other,community-board
+
+
+.. _single-csv-external-identifier:
+
+external_identifier
+~~~~~~~~~~~~~~~~~~~
+
++--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type           | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+=====================+==============+==============+==========================================+==========================================+
+| type         | ``identifier_type`` | **Required** | Single       | Specifies the type of identifier. Must   | If the field is invalid or not present,  |
+|              |                     |              |              | be one of the valid types as defined by  | the implementation is required to ignore |
+|              |                     |              |              | :ref:`single-csv-identifier-type`.       | the ``ElectionIdentifier`` containing    |
+|              |                     |              |              |                                          | it.                                      |
++--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| other_type   | ``xs:string``       | Optional     | Single       | Allows for cataloging an                 | If the field is invalid or not present,  |
+|              |                     |              |              | ``ExternalIdentifier`` type that falls   | then the implementation is required to   |
+|              |                     |              |              | outside the options listed in            | ignore it.                               |
+|              |                     |              |              | :ref:`single-csv-identifier-type`.       |                                          |
+|              |                     |              |              | ``Type`` should be set to "other" when   |                                          |
+|              |                     |              |              | using this field.                        |                                          |
++--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| value        | ``xs:string``       | **Required** | Single       | Specifies the identifier.                | If the field is invalid or not present,  |
+|              |                     |              |              |                                          | the implementation is required to ignore |
+|              |                     |              |              |                                          | the ``ElectionIdentifier`` containing    |
+|              |                     |              |              |                                          | it.                                      |
++--------------+---------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-external-identifiers:
+
+external_identifiers
+~~~~~~~~~~~~~~~~~~~~
+
+The ``ExternalIdentifiers`` element allows VIP data to connect with external datasets (e.g.
+candidates with campaign finance datasets, electoral geographies with `OCD-IDs`_ that allow for
+greater connectivity with additional datasets, etc...). Examples for ``ExternalIdentifiers`` can be
+found on the objects that support them:
+
+* :ref:`single-csv-candidate`
+
+* Any element that extends :ref:`single-csv-contest-base`
+
+* :ref:`single-csv-electoral-district`
+
+* :ref:`single-csv-locality`
+
+* :ref:`single-csv-office`
+
+* :ref:`single-csv-party`
+
+* :ref:`single-csv-precinct`
+
+* :ref:`single-csv-state`
+
+.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=======================================+==============+==============+==========================================+==========================================+
+| external_identifier | :ref:`single-csv-external-identifier` | **Required** | Repeats      | Defines the identifier and the type of   | At least one valid `ExternalIdentifier`_ |
+|                     |                                       |              |              | identifier it is (see                    | must be present for                      |
+|                     |                                       |              |              | `ExternalIdentifier`_ for complete       | ``ExternalIdentifiers`` to be valid. If  |
+|                     |                                       |              |              | information).                            | no valid `ExternalIdentifier`_ is        |
+|                     |                                       |              |              |                                          | present, the implementation is required  |
+|                     |                                       |              |              |                                          | to ignore the ``ExternalIdentifiers``    |
+|                     |                                       |              |              |                                          | element.                                 |
++---------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
 .. _single-csv-hours:
 
 hours
@@ -2173,23 +1349,1047 @@ UTC. The pattern is
    </HoursOpen>
 
 
-.. _single-csv-election-notice:
+.. _single-csv-hours-open:
 
-election_notice
+hours_open
+~~~~~~~~~~
+
+A structured way of describing the days and hours that a place such as a
+:ref:`single-csv-office` or :ref:`single-csv-polling-location` is open, or
+that an event such as an :ref:`single-csv-election` is happening. The range of days
+indicated by the `StartDate` and `EndDate` in each `Schedule`_ element
+should not overlap with peer `Schedule`_ elements. For example, it is
+invalid to specify a schedule from 10/01/2016 to 10/31/2016 and also
+specify a schedule from 10/10/2016 to 10/11/2016 within the same `HoursOpen`
+element.
+
++--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                  | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+============================+==============+==============+==========================================+==========================================+
+| schedule     | :ref:`single-csv-schedule` | **Required** | Repeats      | Defines a block of days and hours that a | At least one valid `Schedule`_ must be   |
+|              |                            |              |              | place will be open.                      | present for ``HoursOpen`` to be valid.   |
+|              |                            |              |              |                                          | If no valid `Schedule`_ is present, the  |
+|              |                            |              |              |                                          | implementation is required to ignore the |
+|              |                            |              |              |                                          | ``HoursOpen`` element.                   |
++--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-schedule:
+
+schedule
+^^^^^^^^
+
+A sub-portion of the schedule. This describes a range of days, along with one or
+more set of open and close times for those days, as well as the options
+describing whether or not appointments are necessary or possible.
+
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+=========================+==============+==============+==========================================+==========================================+
+| hours                  | :ref:`single-csv-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
+|                        |                         |              |              | which the place is open.                 | present, then the implementation is      |
+|                        |                         |              |              |                                          | required to ignore it.                   |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_only_by_appointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
+|                        |                         |              |              | the specified time window with an        | then the implementation is required to   |
+|                        |                         |              |              | appointment.                             | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_or_by_appointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
+|                        |                         |              |              | hours specified time window and may also | then the implementation is required to   |
+|                        |                         |              |              | be open with an appointment.             | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_subject_to_change   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
+|                        |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
+|                        |                         |              |              | subject to change. People should contact | ignore it.                               |
+|                        |                         |              |              | prior to arrival to confirm hours are    |                                          |
+|                        |                         |              |              | still accurate.                          |                                          |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| start_date             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                        |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
+|                        |                         |              |              |                                          | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| end_date               | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                        |                         |              |              | start and end times and options end.     | then the implementation is required to   |
+|                        |                         |              |              |                                          | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,start_time,end_time,is_only_by_appointment,is_or_by_appointment,is_subject_to_change,start_date,end_date,hours_open_id
+    sch001,07:00:00-06:00,22:00:00-06:00,,true,,2016-10-10,2016-10-12,ho001
+    sch002,09:00:00-06:00,20:00:00-06:00,true,,,2016-10-13,2016-10-15,ho001
+    sch003,08:00:00-06:00,14:00:00-06:00,,,true,2016-10-10,2016-10-15,ho002
+
+
+.. _single-csv-hours:
+
+hours
+%%%%%
+
+The open and close time for this place. All times must be fully specified,
+including a timezone offset from UTC.
+
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==================================+==============+==============+==========================================+==========================================+
+| start_time   | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| end_time     | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-time-with-zone:
+
+time_with_zone
+^^^^^^^^^^^^^^
+
+A string pattern restricting the value to a time with an included offset from
+UTC. The pattern is
+
+``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
+
+.. code-block:: xml
+   :linenos:
+
+   <HoursOpen id="hours0001">
+     <Schedule>
+       <Hours>
+         <StartTime>06:00:00-05:00</StartTime>
+         <EndTime>12:00:00-05:00</EndTime>
+       </Hours>
+       <Hours>
+         <StartTime>13:00:00-05:00</StartTime>
+         <EndTime>19:00:00-05:00</EndTime>
+       </Hours>
+       <StartDate>2013-11-05</StartDate>
+       <EndDate>2013-11-05</EndDate>
+     </Schedule>
+   </HoursOpen>
+
+
+.. _single-csv-html-color-string:
+
+html_color_string
+~~~~~~~~~~~~~~~~~
+
+A restricted string pattern for a six-character hex code representing an HTML
+color string. The pattern is:
+
+``[0-9a-f]{6}``
+
+
+.. _single-csv-internationalized-text:
+
+internationalized_text
+~~~~~~~~~~~~~~~~~~~~~~
+
+``InternationalizedText`` allows for support of multiple languages for a string.
+``InternationalizedText`` has an optional attribute ``label``, which allows the feed to refer
+back to the original label for the information (e.g. if the contact information came from a
+CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can be seen in:
+* Any element that extends :ref:`single-csv-contest-base`
+* Any element that extends :ref:`single-csv-ballot-selection-base`
+* :ref:`single-csv-candidate`
+* :ref:`single-csv-contact-information`
+* :ref:`single-csv-election`
+* :ref:`single-csv-election-administration`
+* :ref:`single-csv-office`
+* :ref:`single-csv-party`
+* :ref:`single-csv-person`
+* :ref:`single-csv-polling-location`
+* :ref:`single-csv-source`
+NOTE: Internationalized Text is not currently supported for CSV submissions. 
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| text         | ``xs:string`` | **Required** | Repeats      | Contains the translations of a           | At least one valid ``Text`` must be      |
+|              |               |              |              | particular string of text.               | present for ``InternationalizedText`` to |
+|              |               |              |              |                                          | be valid. If no valid ``Text`` is        |
+|              |               |              |              |                                          | present, the implementation is required  |
+|              |               |              |              |                                          | to ignore the ``InternationalizedText``  |
+|              |               |              |              |                                          | element.                                 |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-language-string:
+
+language_string
 ~~~~~~~~~~~~~~~
 
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+===============+==============+==============+==========================================+==========================================+
-| election_notice_text | ``xs:string`` | **Required** | Single       | The last minute or emergency             | If the element is invalid, then the      |
-|                      |               |              |              | notification text should be placed here. | implementation is required to ignore the |
-|                      |               |              |              |                                          | ``ElectionNotice`` element containing    |
-|                      |               |              |              |                                          | it.                                      |
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| election_notice_uri  | ``xs:string`` | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
-|                      |               |              |              | related to the last minute or emergency  | then the implementation is required to   |
-|                      |               |              |              | notification.                            | ignore it.                               |
-+----------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+``LanguageString`` extends xs:string and can contain text from any language. ``LanguageString``
+has one required attribute, ``language``, that must contain the 2-character `language code`_ for the
+type of language ``LanguageString`` contains.
+
+.. _`language code`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+
+.. code-block:: xml
+   :linenos:
+
+   <BallotTitle>
+      <Text language="en">Retention of Supreme Court Justice</Text>
+      <Text language="es">La retención de juez de la Corte Suprema</Text>
+   </BallotTitle>
+
+
+.. _single-csv-lat-lng:
+
+lat_long
+~~~~~~~~
+
+The latitude and longitude of a polling location in `WGS 84`_ format. Both
+latitude and longitude values are measured in decimal degrees.
+
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+===============+==============+==============+==========================================+==========================================+
+| latitude      | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
+|               |               |              |              |                                          | implementation is required to ignore it. |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| longitude     | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
+|               |               |              |              |                                          | implementation is required to ignore it. |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| latlng_source | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
+|               |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
+|               |               |              |              | example, this could be the name of a     | ignore it.                               |
+|               |               |              |              | geocoding service.                       |                                          |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-locality:
+
+locality
+~~~~~~~~
+
+The Locality object represents the jurisdiction below the :ref:`single-csv-state` (e.g. county).
+
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Tag                        | Data Type                              | Required?    | Repeats?     | Description                               | Error Handling                           |
++============================+========================================+==============+==============+===========================================+==========================================+
+| election_administration_id | ``xs:IDREF``                           | Optional     | Single       | Links to the locality's                   | If the field is invalid or not present,  |
+|                            |                                        |              |              | :ref:`single-csv-election-administration` | then the implementation is required to   |
+|                            |                                        |              |              | object.                                   | ignore it.                               |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| external_identifiers       | :ref:`single-csv-external-identifiers` | Optional     | Single       | Another identifier for a locality that    | If the element is invalid or not         |
+|                            |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
+|                            |                                        |              |              |                                           | required to ignore it.                   |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| is_mail_only               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                            |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                            |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                            |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                            |                                        |              |              | may be used in addition to this flag      |                                          |
+|                            |                                        |              |              | using a :ref:`polling location            |                                          |
+|                            |                                        |              |              | <single-csv-polling-location>` record     |                                          |
+|                            |                                        |              |              | configured as a Drop Box.                 |                                          |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                            |                                        |              |              |                                           | implementation is required to ignore the |
+|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
+|                            |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
+|                            |                                        |              |              | <single-csv-polling-location>`s. If early | it. However, the implementation should   |
+|                            |                                        |              |              | vote centers or ballot drop locations are | still check to see if there are any      |
+|                            |                                        |              |              | locality-wide, they should be specified   | polling locations associated with this   |
+|                            |                                        |              |              | here.                                     | locality's state.                        |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| state_id                   | ``xs:IDREF``                           | **Required** | Single       | References the locality's                 | If the field is invalid, then the        |
+|                            |                                        |              |              | :ref:`single-csv-state`.                  | implementation is required to ignore the |
+|                            |                                        |              |              |                                           | ``Locality`` element containing it.      |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| type                       | :ref:`single-csv-district-type`        | Optional     | Single       | Defines the kind of locality (e.g.        | If the field is invalid or not present,  |
+|                            |                                        |              |              | county, town, et al.), which is one of    | then the implementation is required to   |
+|                            |                                        |              |              | the various :ref:`DistrictType            | ignore it.                               |
+|                            |                                        |              |              | enumerations <single-csv-district-type>`. |                                          |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| other_type                 | ``xs:string``                          | Optional     | Single       | Allows for defining a type of locality    | If the field is invalid or not present,  |
+|                            |                                        |              |              | that falls outside the options listed in  | then the implementation is required to   |
+|                            |                                        |              |              | :ref:`DistrictType                        | ignore it.                               |
+|                            |                                        |              |              | <single-csv-district-type>`.              |                                          |
++----------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,name,polling_location_ids,state_id,type,other_type
+    loc001,ea123,ocd-id,,ocd-division/country:us/state:co/county:denver,true,Locality #1,poll001 poll002,st51,city,
+    loc002,ea345,,,,,Locality #2,,st51,other,unique type
+
+
+.. _single-csv-office:
+
+office
+~~~~~~
+
+``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
+School Board, et al).
+
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type              | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+========================+==============+==============+==========================================+==========================================+
+| contact_information_id   | ``xs:IDREF``           | Optional     | Repeats      | Links to the                             | If the element is invalid or not         |
+|                          |                        |              |              | :ref:`single-csv-contact-information`    | present, then the implementation is      |
+|                          |                        |              |              | element associated with the office.      | required to ignore it.                   |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description              | ``xs:string``          | Optional     | Single       | A brief description of the office and    | If the element is invalid or not         |
+|                          |                        |              |              | its purpose.                             | present, then the implementation is      |
+|                          |                        |              |              |                                          | required to ignore it.                   |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electoral_district_id    | ``xs:IDREF``           | **Required** | Single       | Links to the                             | If the field is invalid or not present,  |
+|                          |                        |              |              | :ref:`single-csv-electoral-district`     | the implementation is required to ignore |
+|                          |                        |              |              | element associated with the office.      | the ``Office`` element containing it.    |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers     | ``xs:IDREF``           | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
+|                          |                        |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
+|                          |                        |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| filing_deadline          | ``xs:date``            | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
+|                          |                        |              |              | candidate must have filed for the        | then the implementation is required to   |
+|                          |                        |              |              | contest for the office.                  | ignore it.                               |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_partisan              | ``xs:boolean``         | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
+|                          |                        |              |              | partisan.                                | then the implementation is required to   |
+|                          |                        |              |              |                                          | ignore it.                               |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                     | ``xs:string``          | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
+|                          |                        |              |              |                                          | the implementation is required to ignore |
+|                          |                        |              |              |                                          | the ``Office`` element containing it.    |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| office_holder_person_ids | ``xs:IDREFS``          | Optional     | Single       | Links to the :ref:`single-csv-person`    | If the field is invalid or not present,  |
+|                          |                        |              |              | element(s) that hold additional          | then the implementation is required to   |
+|                          |                        |              |              | information about the current office     | ignore it.                               |
+|                          |                        |              |              | holder(s).                               |                                          |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| term                     | :ref:`single-csv-term` | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
+|                          |                        |              |              |                                          | present, then the implementation is      |
+|                          |                        |              |              |                                          | required to ignore it.                   |
++--------------------------+------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,electoral_district_id,external_identifier_type,external_identifier_othertype,external_identifier_value,filing_deadline,is_partisan,name,office_holder_person_ids,term_type,term_start_date,term_end_date
+    off001,ed001,,,,,true,Deputy Chief of Staff,per50003,full-term,2002-01-21,
+    off002,ed001,,,,,true,Deputy Deputy Chief of Staff,per50001,unexpired-term,2002-01-21,
+    off003,ed001,,,,,false,General Secretary of Secretaries,per50004,full-term,2002-01-21,
+
+
+.. _single-csv-term:
+
+term
+^^^^
+
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag             | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
++=================+====================================+==============+==============+==========================================+==========================================+
+| term_type       | :ref:`single-csv-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
+|                 |                                    |              |              | :ref:`single-csv-office-term-type` for   | the implementation is required to ignore |
+|                 |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| term_start_date | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
+|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|                 |                                    |              |              |                                          | ignore it.                               |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| term_end_date   | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
+|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|                 |                                    |              |              |                                          | ignore it.                               |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-contact-information:
+
+contact_information
+^^^^^^^^^^^^^^^^^^^
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
+:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+===========================+==============+==============+==========================================+==========================================+
+| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
+|               |                           |              |              | element. It is strongly encouraged that  |                                          |
+|               |                           |              |              | data providers move toward contributing  |                                          |
+|               |                           |              |              | hours in this format)*.                  |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
+|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
+|               |                           |              |              | location.                                |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|               |                           |              |              | this entity.                             | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|               |                           |              |              | location.                                | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
+    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
+    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
+
+
+.. _single-csv-ordered-contest:
+
+ordered_contest
+~~~~~~~~~~~~~~~
+
+``OrderedContest`` encapsulates links to the information that comprises a contest and potential
+ballot selections. ``OrderedContest`` elements can be collected within a
+:ref:`single-csv-ballot-style` to accurate depict exactly what will show up on a particular
+ballot in the proper order.
+
++------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+| Tag                          | Data Type    | Required?    | Repeats?     | Description                              | Error Handling                                   |
++==============================+==============+==============+==============+==========================================+==================================================+
+| contest_id                   | ``xs:IDREF`` | **Required** | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
+|                              |              |              |              | :ref:`single-csv-contest-base`.          | implementation is required to ignore the         |
+|                              |              |              |              |                                          | ``OrderedContest`` element containing it.        |
++------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+| ordered_ballot_selection_ids | ``IDREFS``   | Optional     | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
+|                              |              |              |              | :ref:`single-csv-ballot-selection-base`. | implementation is required to ignore it. If an   |
+|                              |              |              |              |                                          | ``OrderedBallotSelectionIds`` element is not     |
+|                              |              |              |              |                                          | present, the presumed order of the selection     |
+|                              |              |              |              |                                          | will be the order of                             |
+|                              |              |              |              |                                          | :ref:`single-csv-ballot-selection-base`-extended |
+|                              |              |              |              |                                          | elements referenced by the underlying            |
+|                              |              |              |              |                                          | :ref:`single-csv-contest-base`-extended          |
+|                              |              |              |              |                                          | elements.                                        |
++------------------------------+--------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,contest_id,ordered_ballot_selection_ids
+    oc2025,con001,bs001 bs002 bs003
+    oc3000,con002,bs001
+
+
+.. _single-csv-party:
+
+party
+~~~~~
+
+This element describes a political party and the metadata associated with them. These can also include "dummy" parties to indicate a type of contest (e.g., a Voter Nominated :ref:`single-csv-candidate-contest` can use the **PrimaryPartyIds** field and a dummy Party object to indicate that the contest is a "Top-Two" primary).
+
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+========================================+==============+==============+==========================================+==========================================+
+| abbreviation         | ``xs:string``                          | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
+|                      |                                        |              |              |                                          | then the implementation is required to   |
+|                      |                                        |              |              |                                          | ignore it.                               |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| color                | :ref:`single-csv-html-color-string`    | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
+|                      |                                        |              |              | party, for use in maps and other         | present, then the implementation is      |
+|                      |                                        |              |              | displays.                                | required to ignore it.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
+|                      |                                        |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
+|                      |                                        |              |              | campaign finance system, etc).           | required to ignore it.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_write_in          | ``xs:boolean``                         | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
+|                      |                                        |              |              | that is officially recognized by a       | then the implementation is required to   |
+|                      |                                        |              |              | local, state, or federal organization,   | ignore it.                               |
+|                      |                                        |              |              | or is a "write-in" in jurisdictions      |                                          |
+|                      |                                        |              |              | which allow candidates to free-form      |                                          |
+|                      |                                        |              |              | enter their political affiliation. If    |                                          |
+|                      |                                        |              |              | this field is not present then it is     |                                          |
+|                      |                                        |              |              | assumed to be false.                     |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| logo_uri             | ``xs:anyURI``                          | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
+|                      |                                        |              |              | displays.                                | then the implementation is required to   |
+|                      |                                        |              |              |                                          | ignore it.                               |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                 | ``xs:string``                          | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
+|                      |                                        |              |              |                                          | present, then the implementation is      |
+|                      |                                        |              |              |                                          | required to ignore it.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,abbreviation,color,external_identifier_type,external_identifier_othertype,external_identifier_value,logo_uri,name
+    par01,REP,ff0000,,,,http://example.com/elephant.png,Republican
+    par02,DEM,0000ff,,,,http://example.com/donkey.png,Democrat
+    par03,GRN,efefef,,,,http://example.com/tree.png,Green
+    par04,WFP,ee99aa,,,,http://example.com/worker.png,Working Families Party
+
+
+.. _single-csv-html-color-string:
+
+html_color_string
+^^^^^^^^^^^^^^^^^
+
+A restricted string pattern for a six-character hex code representing an HTML
+color string. The pattern is:
+
+``[0-9a-f]{6}``
+
+
+.. _single-csv-party-contest:
+
+party_contest
+~~~~~~~~~~~~~
+
+An extension of :ref:`single-csv-contest-base` which describes a contest in
+which the possible ballot selections are of type :ref:`single-csv-party-selection`. These could include contests in which straight-party
+selections are allowed, or party-list contests (although these are more common
+outside of the United States).
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation
+    pcon001,PC1071,bs001 bs002,,Party Election,ed001,all registered voters,,,,false,Straight Party Vote,3,,
+
+
+.. _single-csv-contest-base:
+
+contest_base
+^^^^^^^^^^^^
+
+A base model for all Contest types: :ref:`single-csv-ballot-measure-contest`,
+:ref:`single-csv-candidate-contest`, :ref:`single-csv-party-contest`,
+and :ref:`single-csv-retention-contest` (NB: the latter because it extends
+:ref:`single-csv-ballot-measure-contest`).
+
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+==================================+==============+==============+==========================================+==========================================+
+| abbreviation             | ``xs:string``                    | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                          |                                  |              |              |                                          | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_selection_ids     | ``xs:IDREFS``                    | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
+|                          |                                  |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                          |                                  |              |              | that extends                             | it.                                      |
+|                          |                                  |              |              | :ref:`single-csv-ballot-selection-base`. |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_sub_title         | ``xs:string``                    | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ballot_title             | ``xs:string``                    | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electoral_district_id    | ``xs:IDREF``                     | **Required** | Single       | References an                            | If the field is invalid, then the        |
+|                          |                                  |              |              | :ref:`single-csv-electoral-district`     | implementation is required to ignore the |
+|                          |                                  |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
+|                          |                                  |              |              | scope of the contest.                    |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electorate_specification | ``xs:string``                    | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                          |                                  |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                          |                                  |              |              | usual, "all registered voters"           | ignore it.                               |
+|                          |                                  |              |              | electorate. This subtag will most often  |                                          |
+|                          |                                  |              |              | be used for primaries and local          |                                          |
+|                          |                                  |              |              | elections. In primaries, voters may have |                                          |
+|                          |                                  |              |              | to be registered as a specific party to  |                                          |
+|                          |                                  |              |              | vote, or there may be special rules for  |                                          |
+|                          |                                  |              |              | which ballot a voter can pull. In some   |                                          |
+|                          |                                  |              |              | local elections, non-citizens can vote.  |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers     | ``xs:string``                    | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                          |                                  |              |              | links to another source of information.  | present, then the implementation should  |
+|                          |                                  |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| has_rotation             | ``xs:boolean``                   | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                          |                                  |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                     | ``xs:string``                    | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
+|                          |                                  |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
+|                          |                                  |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
+|                          |                                  |              |              | purpose).                                |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| sequence_order           | ``xs:integer``                   | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
+|                          |                                  |              |              | on the ballot. This is the default       | then the implementation should ignore    |
+|                          |                                  |              |              | ordering, and can be overrides by data   | it.                                      |
+|                          |                                  |              |              | in a :ref:`single-csv-ballot-style`      |                                          |
+|                          |                                  |              |              | element.                                 |                                          |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vote_variation           | :ref:`single-csv-vote-variation` | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                          |                                  |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                          |                                  |              |              |                                          | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| other_vote_variation     | ``other_vote_variation``         | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                          |                                  |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                          |                                  |              |              | variation can be specified here.         | it.                                      |
++--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-party-selection:
+
+party_selection
+~~~~~~~~~~~~~~~
+
+This element extends :ref:`single-csv-ballot-selection-base` to
+support contests in which the selections can be groups of one or more parties.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| party_ids    | ``xs:IDREFS`` | **Required** | Single       | One or more :ref:`single-csv-party` IDs  | If one or more parties referenced are    |
+|              |               |              |              | which collectively represent a ballot    | invalid or not present, the              |
+|              |               |              |              | selection.                               | implementation is required to ignore the |
+|              |               |              |              |                                          | PartySelection containing it.            |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,sequence_order,party_ids
+    ps001,1,par01 par04
+    ps002,2,par02
+    ps003,3,par03
+
+
+.. _single-csv-ballot-selection-base:
+
+ballot_selection_base
+^^^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-csv-ballot-measure-selection`,
+:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
+
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++================+================+==============+==============+==========================================+==========================================+
+| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
++----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-person:
+
+person
+~~~~~~
+
+``Person`` defines information about a person. The person may be a candidate, election administrator,
+or elected official. These elements reference ``Person``:
+
+* :ref:`single-csv-candidate`
+
+* :ref:`single-csv-election-administration`
+
+* :ref:`single-csv-office`
+
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+========================================+==============+==============+==========================================+==========================================+
+| contact_information_id | ``xs:IDREF``                           | Optional     | Repeats      | Refers to the associated                 | If the element is invalid or not         |
+|                        |                                        |              |              | :ref:`single-csv-contact-information`.   | present, then the implementation is      |
+|                        |                                        |              |              |                                          | required to ignore it.                   |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_of_birth          | ``xs:date``                            | Optional     | Single       | Represents the individual's date of      | If the field is invalid or not present,  |
+|                        |                                        |              |              | birth.                                   | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers   | :ref:`single-csv-external-identifiers` | Optional     | Single       | Identifiers for this person.             | If the element is invalid or not         |
+|                        |                                        |              |              |                                          | present, then the implementation is      |
+|                        |                                        |              |              |                                          | required to ignore it.                   |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| first_name             | ``xs:string``                          | Optional     | Single       | Represents an individual's first name.   | If the field is invalid or not present,  |
+|                        |                                        |              |              |                                          | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| full_name              | ``xs:string``                          | Optional     | Single       | Specifies a person's full name (**NB:**  | If the element is invalid or not         |
+|                        |                                        |              |              | this information is                      | present, then the implementation is      |
+|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
+|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
+|                        |                                        |              |              | in multiple languages).                  |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| gender                 | ``xs:string``                          | Optional     | Single       | Specifies a person's gender.             | If the field is invalid or not present,  |
+|                        |                                        |              |              |                                          | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| last_name              | ``xs:string``                          | Optional     | Single       | Represents an individual's last name.    | If the field is invalid or not present,  |
+|                        |                                        |              |              |                                          | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| middle_name            | ``xs:string``                          | Optional     | Repeats      | Represents any number of names between   | If the field is invalid or not present,  |
+|                        |                                        |              |              | an individual's first and last names     | then the implementation is required to   |
+|                        |                                        |              |              | (e.g. John **Ronald Reuel** Tolkien).    | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| nickname               | ``xs:string``                          | Optional     | Single       | Represents an individual's nickname.     | If the field is invalid or not present,  |
+|                        |                                        |              |              |                                          | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| party_id               | ``xs:IDREF``                           | Optional     | Single       | Refers to the associated                 | If the field is invalid or not present,  |
+|                        |                                        |              |              | :ref:`single-csv-party`. This            | then the implementation is required to   |
+|                        |                                        |              |              | information is intended to be used by    | ignore it.                               |
+|                        |                                        |              |              | feed consumers to help them disambiguate |                                          |
+|                        |                                        |              |              | the person's identity, but not to be     |                                          |
+|                        |                                        |              |              | presented as part of any ballot          |                                          |
+|                        |                                        |              |              | information. For that see                |                                          |
+|                        |                                        |              |              | :ref:`single-csv-candidate` **PartyId**. |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| prefix                 | ``xs:string``                          | Optional     | Single       | Specifies a prefix associated with a     | If the field is invalid or not present,  |
+|                        |                                        |              |              | person (e.g. Dr.).                       | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| profession             | ``xs:string``                          | Optional     | Single       | Specifies a person's profession (**NB:** | If the element is invalid or not         |
+|                        |                                        |              |              | this information is                      | present, then the implementation is      |
+|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
+|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
+|                        |                                        |              |              | in multiple languages).                  |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| suffix                 | ``xs:string``                          | Optional     | Single       | Specifies a suffix associated with a     | If the field is invalid or not present,  |
+|                        |                                        |              |              | person (e.g. Jr.).                       | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| title                  | ``xs:string``                          | Optional     | Single       | A title associated with a person         | If the element is invalid or not         |
+|                        |                                        |              |              | (**NB:** this information is             | present, then the implementation is      |
+|                        |                                        |              |              | :ref:`single-csv-internationalized-text` | required to ignore it.                   |
+|                        |                                        |              |              | because it sometimes appears on ballots  |                                          |
+|                        |                                        |              |              | in multiple languages).                  |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,date_of_birth,first_name,gender,last_name,middle_name,nickname,party_id,prefix,profession,suffix,title
+    per50001,1961-08-04,Barack,male,Obama,Hussein,,par02,,President,II,Mr. President
+    per50002,1985-11-21,Carly,female,Jepsen,Rae,,par01,,Recording Artist,,
+    per50003,1926-09-23,John,male,Coltrane,William,Trane,par02,,Recording Artist,Saint,
+    per50004,1926-05-26,Miles,male,Davis,Dewey,,par01,,Recording Artist,III,
+
+
+.. _single-csv-contact-information:
+
+contact_information
+^^^^^^^^^^^^^^^^^^^
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-csv-election-administration`, :ref:`single-csv-office`,
+:ref:`single-csv-person`, :ref:`single-csv-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+===========================+==============+==============+==========================================+==========================================+
+| address_line  | ``xs:string``             | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|               |                           |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions    | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|               |                           |              |              | locating this entity.                    | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| email         | ``xs:string``             | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| fax           | ``xs:string``             | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours         | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|               |                           |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|               |                           |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|               |                           |              |              | structured :ref:`single-csv-hours-open`  |                                          |
+|               |                           |              |              | element. It is strongly encouraged that  |                                          |
+|               |                           |              |              | data providers move toward contributing  |                                          |
+|               |                           |              |              | hours in this format)*.                  |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id | ``xs:IDREF``              | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`single-csv-hours-open` element,    | then the implementation is required to   |
+|               |                           |              |              | which lists the hours of operation for a | ignore it.                               |
+|               |                           |              |              | location.                                |                                          |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_long      | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|               |                           |              |              | this entity.                             | present, then the implementation is      |
+|               |                           |              |              |                                          | required to ignore it.                   |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name          | ``xs:string``             | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|               |                           |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|               |                           |              |              | <single-csv-name-address-line-usage>`    | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| phone         | ``xs:string``             | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|               |                           |              |              |                                          | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| uri           | ``xs:anyURI``             | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|               |                           |              |              | location.                                | then the implementation is required to   |
+|               |                           |              |              |                                          | ignore it.                               |
++---------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,address_line_1,address_line_2,address_line_3,directions,email,fax,hours,hours_open_id,latitude,longitude,latlng_source,name,phone,uri,parent_id
+    ci0827,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,off001
+    ci0828,The White House,1600 Pennsylvania Ave,,,josh@example.com,,Early to very late,,,,,Josh Lyman,555-111-2222,http://lemonlyman.example.com,vs01
+
+
+.. _single-csv-polling-location:
+
+polling_location
+~~~~~~~~~~~~~~~~
+
+The PollingLocation object represents a site where voters cast or drop off ballots.
+
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
++=======================================+===========================+==============+==============+==========================================+==========================================+
+| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                                       |                           |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                                       |                           |              |              |                                          | given Polling Location. If none is       |
+|                                       |                           |              |              |                                          | present, the implementation is required  |
+|                                       |                           |              |              |                                          | to ignore the ``PollingLocation``        |
+|                                       |                           |              |              |                                          | element containing it.                   |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| address_line                          | ``xs:string``             | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                                       |                           |              |              | address to a polling location.           | should be present for a given Polling    |
+|                                       |                           |              |              |                                          | Location. If none is present, the        |
+|                                       |                           |              |              |                                          | implementation is required to ignore the |
+|                                       |                           |              |              |                                          | ``PollingLocation`` element containing   |
+|                                       |                           |              |              |                                          | it.                                      |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| directions                            | ``xs:string``             | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                                       |                           |              |              | locating the polling location.           | present, then the implementation is      |
+|                                       |                           |              |              |                                          | required to ignore it.                   |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours                                 | ``xs:string``             | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+|                                       |                           |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                                       |                           |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                                       |                           |              |              | the more structured                      |                                          |
+|                                       |                           |              |              | :ref:`single-csv-hours-open` element. It |                                          |
+|                                       |                           |              |              | is strongly encouraged that data         |                                          |
+|                                       |                           |              |              | providers move toward contributing hours |                                          |
+|                                       |                           |              |              | in this format).                         |                                          |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| hours_open_id                         | ``xs:IDREF``              | Optional     | Single       | Links to an :ref:`single-csv-hours-open` | If the field is invalid or not present,  |
+|                                       |                           |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                                       |                           |              |              | and hours during which the polling       | ignore it.                               |
+|                                       |                           |              |              | location is available.                   |                                          |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_drop_box                           | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                                       |                           |              |              | drop box.                                | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_early_voting                       | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                                       |                           |              |              | early vote site.                         | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| lat_lng                               | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                                       |                           |              |              | this polling location.                   | present, then the implementation is      |
+|                                       |                           |              |              |                                          | required to ignore it.                   |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                                  | ``xs:string``             | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                                       |                           |              |              |                                          | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| photo_uri                             | ``xs:string``             | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                                       |                           |              |              | polling location.                        | then the implementation is required to   |
+|                                       |                           |              |              |                                          | ignore it.                               |
++---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,name,address_line,structured_line_1,structured_city,structured_state,structured_zip,directions,hours,photo_uri,hours_open_id,is_drop_box,is_early_voting,latitude,longitude,latlng_source
+    poll001,ALBERMARLE HIGH SCHOOL,,2775 Hydraulic Rd,Charlottesville,VA,22901,Use back door,7am-8pm,www.picture.com,ho001,false,true,38.0754627,78.5014875,Google Maps
+    poll002,Public Library,Main St Denver CO,,,,,,next to the checkout counter,7am-8pm,www.picture.com,,false,true,38.0754627,78.5014875,Google Maps
+
+
+.. _single-csv-lat-lng:
+
+lat_long
+^^^^^^^^
+
+The latitude and longitude of a polling location in `WGS 84`_ format. Both
+latitude and longitude values are measured in decimal degrees.
+
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+===============+==============+==============+==========================================+==========================================+
+| latitude      | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
+|               |               |              |              |                                          | implementation is required to ignore it. |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| longitude     | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
+|               |               |              |              |                                          | implementation is required to ignore it. |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| latlng_source | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
+|               |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
+|               |               |              |              | example, this could be the name of a     | ignore it.                               |
+|               |               |              |              | geocoding service.                       |                                          |
++---------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-simple-address-type:
+
+simple_address_type
+^^^^^^^^^^^^^^^^^^^
+
+A ``SimpleAddressType`` represents a structured address.
+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|                   |               |              |              | suffix.                                  |                                          |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-precinct:
+
+precinct
+~~~~~~~~
+
+The Precinct object represents a precinct, which is contained within a Locality. While the id
+attribute does not have to be static across feeds for one election, the combination of
+:ref:`Source.VipId <single-csv-source>`, :ref:`Locality.Name <single-csv-locality>`, :ref:`Precinct.Ward <single-csv-precinct>`,
+:ref:`Precinct.Name <single-csv-precinct>`, and :ref:`Precinct.Number <single-csv-precinct>` should remain constant across
+feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
+non-required fields is fine).
+
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+========================================+==============+==============+==========================================+==========================================+
+| ballot_style_id        | ``xs:IDREF``                           | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
+|                        |                                        |              |              | :ref:`single-csv-ballot-style`, which a  | then the implementation is required to   |
+|                        |                                        |              |              | person who lives in this precinct will   | ignore it.                               |
+|                        |                                        |              |              | vote.                                    |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| electoral_district_ids | ``xs:IDREFS``                          | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
+|                        |                                        |              |              | :ref:`single-csv-electoral-district`s    | then the implementation is required to   |
+|                        |                                        |              |              | (e.g., congressional district, state     | ignore it.                               |
+|                        |                                        |              |              | house district, school board district)   |                                          |
+|                        |                                        |              |              | to which the entire precinct/precinct    |                                          |
+|                        |                                        |              |              | split belongs. **Highly Recommended** if |                                          |
+|                        |                                        |              |              | candidate information is to be provided. |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers   | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
+|                        |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                        |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_mail_only           | ``xs:boolean``                         | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
+|                        |                                        |              |              | mail-only elections.                     | implementation is required to assume     |
+|                        |                                        |              |              |                                          | `IsMailOnly` is false.                   |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| locality_id            | ``xs:IDREF``                           | **Required** | Single       | Links to the :ref:`single-csv-locality`  | If the field is invalid, then the        |
+|                        |                                        |              |              | that comprises the precinct.             | implementation is required to ignore the |
+|                        |                                        |              |              |                                          | ``Precinct`` element containing it.      |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                   | ``xs:string``                          | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid, then the        |
+|                        |                                        |              |              | if no name exists).                      | implementation is required to ignore the |
+|                        |                                        |              |              |                                          | ``Precinct`` element containing it.      |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| number                 | ``xs:string``                          | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
+|                        |                                        |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
+|                        |                                        |              |              | legal). Should be used if the `Name`     | ignore it.                               |
+|                        |                                        |              |              | field is populated by a name and not a   |                                          |
+|                        |                                        |              |              | number.                                  |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| polling_location_ids   | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the precinct's       | If the field is invalid or not present,  |
+|                        |                                        |              |              | :ref:`single-csv-polling-location`       | then the implementation is required to   |
+|                        |                                        |              |              | object(s).                               | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| precinct_split_name    | ``xs:string``                          | Optional     | Single       | If this field is empty, then this        | If the field is invalid or not present,  |
+|                        |                                        |              |              | `Precinct` object represents a full      | then the implementation is required to   |
+|                        |                                        |              |              | precinct. If this field is present, then | ignore it.                               |
+|                        |                                        |              |              | this `Precinct` object represents one    |                                          |
+|                        |                                        |              |              | portion of a split precinct. Each        |                                          |
+|                        |                                        |              |              | `Precinct` object that represents one    |                                          |
+|                        |                                        |              |              | portion of a split precinct **must**     |                                          |
+|                        |                                        |              |              | have the same `Name` value, but          |                                          |
+|                        |                                        |              |              | different `PrecinctSplitName` values.    |                                          |
+|                        |                                        |              |              | See the `sample_feed.xml` file for       |                                          |
+|                        |                                        |              |              | examples.                                |                                          |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ward                   | ``xs:string``                          | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
+|                        |                                        |              |              | contained within.                        | then the implementation is required to   |
+|                        |                                        |              |              |                                          | ignore it.                               |
++------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,ballot_style_id,electoral_district_ids,external_identifier_type,external_identifier_othertype,external_identifier_value,is_mail_only,locality_id,name,number,polling_location_ids,precinct_split_name,ward
+    pre90111,bs00010,ed001,ocd-id,,ocd-division/country:us,false,loc001,203 - GEORGETOWN,0203,poll001 poll002,split13,5
+    pre90112,bs00011,ed002,fips,,42,false,loc001,203 - GEORGETOWN,0203,poll003,split26,6
+    pre90113,bs00010,ed003,,,,false,loc002,203 - GEORGETOWN,0203,poll004,split54,7
 
 
 .. _single-csv-retention-contest:
@@ -2212,6 +2412,236 @@ contest where a candidate is retained in a position (e.g. a judge).
 |              |              |              |              | office.                                  | then the implementation is required to   |
 |              |              |              |              |                                          | ignore it.                               |
 +--------------+--------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-schedule:
+
+schedule
+~~~~~~~~
+
+A sub-portion of the schedule. This describes a range of days, along with one or
+more set of open and close times for those days, as well as the options
+describing whether or not appointments are necessary or possible.
+
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+=========================+==============+==============+==========================================+==========================================+
+| hours                  | :ref:`single-csv-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
+|                        |                         |              |              | which the place is open.                 | present, then the implementation is      |
+|                        |                         |              |              |                                          | required to ignore it.                   |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_only_by_appointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
+|                        |                         |              |              | the specified time window with an        | then the implementation is required to   |
+|                        |                         |              |              | appointment.                             | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_or_by_appointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
+|                        |                         |              |              | hours specified time window and may also | then the implementation is required to   |
+|                        |                         |              |              | be open with an appointment.             | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| is_subject_to_change   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
+|                        |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
+|                        |                         |              |              | subject to change. People should contact | ignore it.                               |
+|                        |                         |              |              | prior to arrival to confirm hours are    |                                          |
+|                        |                         |              |              | still accurate.                          |                                          |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| start_date             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                        |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
+|                        |                         |              |              |                                          | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| end_date               | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                        |                         |              |              | start and end times and options end.     | then the implementation is required to   |
+|                        |                         |              |              |                                          | ignore it.                               |
++------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,start_time,end_time,is_only_by_appointment,is_or_by_appointment,is_subject_to_change,start_date,end_date,hours_open_id
+    sch001,07:00:00-06:00,22:00:00-06:00,,true,,2016-10-10,2016-10-12,ho001
+    sch002,09:00:00-06:00,20:00:00-06:00,true,,,2016-10-13,2016-10-15,ho001
+    sch003,08:00:00-06:00,14:00:00-06:00,,,true,2016-10-10,2016-10-15,ho002
+
+
+.. _single-csv-hours:
+
+hours
+^^^^^
+
+The open and close time for this place. All times must be fully specified,
+including a timezone offset from UTC.
+
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==================================+==============+==============+==========================================+==========================================+
+| start_time   | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| end_time     | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-time-with-zone:
+
+time_with_zone
+%%%%%%%%%%%%%%
+
+A string pattern restricting the value to a time with an included offset from
+UTC. The pattern is
+
+``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
+
+.. code-block:: xml
+   :linenos:
+
+   <HoursOpen id="hours0001">
+     <Schedule>
+       <Hours>
+         <StartTime>06:00:00-05:00</StartTime>
+         <EndTime>12:00:00-05:00</EndTime>
+       </Hours>
+       <Hours>
+         <StartTime>13:00:00-05:00</StartTime>
+         <EndTime>19:00:00-05:00</EndTime>
+       </Hours>
+       <StartDate>2013-11-05</StartDate>
+       <EndDate>2013-11-05</EndDate>
+     </Schedule>
+   </HoursOpen>
+
+
+.. _single-csv-simple-address-type:
+
+simple_address_type
+~~~~~~~~~~~~~~~~~~~
+
+A ``SimpleAddressType`` represents a structured address.
+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
+|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|                   |               |              |              | suffix.                                  |                                          |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|                   |               |              |              |                                          | implementation should ignore it.         |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|                   |               |              |              |                                          | implementation should ignore the         |
+|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-csv-source:
+
+source
+~~~~~~
+
+The Source object represents the organization that is publishing the information. This object is
+the only required object in the feed file, and only one source object is allowed to be present.
+
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                         | Data Type       | Required?    | Repeats?     | Description                              | Error Handling                           |
++=============================+=================+==============+==============+==========================================+==========================================+
+| name                        | ``xs:string``   | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                             |                 |              |              | that is providing the information.       | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| vip_id                      | ``xs:string``   | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                             |                 |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| date_time                   | ``xs:dateTime`` | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                             |                 |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                             |                 |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
+|                             |                 |              |              | organization.                            |                                          |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description                 | ``xs:string``   | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                             |                 |              |              | organization providing the data and what | present, then the implementation is      |
+|                             |                 |              |              | data is in the feed.                     | required to ignore it.                   |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| organization_uri            | ``xs:string``   | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                             |                 |              |              | organization publishing the data.        | then the implementation is required to   |
+|                             |                 |              |              |                                          | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| feed_contact_information_id | ``xs:IDREF``    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
+|                             |                 |              |              | :ref:`single-csv-person` who will        | present, then the implementation is      |
+|                             |                 |              |              | respond to inquiries about the           | required to ignore it.                   |
+|                             |                 |              |              | information contained within the file.   |                                          |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| terms_of_use_uri            | ``xs:anyURI``   | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                             |                 |              |              | Use for the information in this file can | then the implementation is required to   |
+|                             |                 |              |              | be found.                                | ignore it.                               |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| version                     | ``xs:string``   | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                             |                 |              |              |                                          | implementation is required to ignore the |
+|                             |                 |              |              |                                          | ``Source`` element containing it.        |
++-----------------------------+-----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,date_time,description,name,organization_uri,terms_of_use_uri,vip_id,version
+    source01,2016-06-02T10:24:08,SBE is the official source for Virginia data,"State Board of Elections, Commonwealth of Virginia",http://www.sbe.virginia.gov/,http://example.com/terms,51,5.1
+
+
+.. _single-csv-state:
+
+state
+~~~~~
+
+The State object includes state-wide election information. The ID attribute is
+recommended to be the state's FIPS code, along with the prefix "st".
+
++----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                        | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++============================+========================================+==============+==============+==========================================+==========================================+
+| election_administration_id | ``xs:IDREF``                           | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
+|                            |                                        |              |              | administration object.                   | then the implementation is required to   |
+|                            |                                        |              |              |                                          | ignore it.                               |
++----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| external_identifiers       | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
+|                            |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                            |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| name                       | ``xs:string``                          | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
+|                            |                                        |              |              | Alabama.                                 | implementation is required to ignore the |
+|                            |                                        |              |              |                                          | ``State`` element containing it.         |
++----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| polling_location_ids       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the state's          | If the field is invalid or not present,  |
+|                            |                                        |              |              | :ref:`polling locations                  | then the implementation is required to   |
+|                            |                                        |              |              | <single-csv-polling-location>`. If early | ignore it.                               |
+|                            |                                        |              |              | vote centers or ballot drop locations    |                                          |
+|                            |                                        |              |              | are state-wide (e.g., anyone in the      |                                          |
+|                            |                                        |              |              | state can use them), they can be         |                                          |
+|                            |                                        |              |              | specified here, but you are encouraged   |                                          |
+|                            |                                        |              |              | to only use the                          |                                          |
+|                            |                                        |              |              | :ref:`single-csv-precinct` element.      |                                          |
++----------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: csv-table
+   :linenos:
+
+
+    id,election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids
+    st51,ea123,ocd-id,,ocd-division/country:us/state:va,Virginia,
 
 
 .. _single-csv-street-segment:
@@ -2346,372 +2776,32 @@ are equal.
     ss000003,N,Washington,false,false,even,pre90113,100,100,A,1/2,DC,NW,Delaware,St,,20001
 
 
-.. _single-csv-candidate-contest:
+.. _single-csv-term:
 
-candidate_contest
-~~~~~~~~~~~~~~~~~
+term
+~~~~
 
-CandidateContest extends :ref:`single-csv-contest-base` and represents a contest among
-candidates.
-
-+-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag               | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===================+================+==============+==============+==========================================+==========================================+
-| number_elected    | ``xs:integer`` | Optional     | Single       | Number of candidates that are elected in | If the field is invalid or not present,  |
-|                   |                |              |              | the contest (i.e. "N" of N-of-M).        | then the implementation is required to   |
-|                   |                |              |              |                                          | ignore it.                               |
-+-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| office_ids        | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                   |                |              |              | :ref:`single-csv-office` elements, if    | then the implementation is required to   |
-|                   |                |              |              | available, which give additional         | ignore it.                               |
-|                   |                |              |              | information about the offices. **Note:** |                                          |
-|                   |                |              |              | the order of the office IDs **must** be  |                                          |
-|                   |                |              |              | in the same order as the candidates      |                                          |
-|                   |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
-|                   |                |              |              | the various `BallotSelectionIds`         |                                          |
-|                   |                |              |              | reference                                |                                          |
-|                   |                |              |              | :ref:`single-csv-candidate-selection`    |                                          |
-|                   |                |              |              | elements which reference the candidate   |                                          |
-|                   |                |              |              | for President first and Vice-President   |                                          |
-|                   |                |              |              | second, the `OfficeIds` should reference |                                          |
-|                   |                |              |              | the office of President first and the    |                                          |
-|                   |                |              |              | office of Vice-President second.         |                                          |
-+-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| primary_party_ids | ``xs:IDREFS``  | Optional     | Single       | References :ref:`single-csv-party`       | If the field is invalid or not present,  |
-|                   |                |              |              | elements, if the contest is related to a | then the implementation is required to   |
-|                   |                |              |              | particular party.                        | ignore it.                               |
-+-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| votes_allowed     | ``xs:integer`` | Optional     | Single       | Maximum number of votes/write-ins per    | If the field is invalid or not present,  |
-|                   |                |              |              | voter in this contest.                   | then the implementation is required to   |
-|                   |                |              |              |                                          | ignore it.                               |
-+-------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,abbreviation,ballot_selection_ids,ballot_sub_title,ballot_title,electoral_district_id,electorate_specification,external_identifier_type,external_identifier_othertype,external_identifier_value,has_rotation,name,sequence_order,vote_variation,other_vote_variation,number_elected,office_ids,primary_party_ids,votes_allowed
-    cancon001,SE-1,bs001 bs002,,Governor of Virginia,ed001,all registered voters,fips,,49,true,Governor,1,,,1,off001,par01,1
-    cancon002,SE-2,bs003 bs004,,Lieutenant Governor of Virginia,ed001,all registered voters,fips,,49,true,Lt Governor,2,,,1,off002,par01,1
-
-
-.. _single-csv-contest-base:
-
-contest_base
-^^^^^^^^^^^^
-
-A base model for all Contest types: :ref:`single-csv-ballot-measure-contest`,
-:ref:`single-csv-candidate-contest`, :ref:`single-csv-party-contest`,
-and :ref:`single-csv-retention-contest` (NB: the latter because it extends
-:ref:`single-csv-ballot-measure-contest`).
-
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+==================================+==============+==============+==========================================+==========================================+
-| abbreviation             | ``xs:string``                    | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
-|                          |                                  |              |              |                                          | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_selection_ids     | ``xs:IDREFS``                    | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
-|                          |                                  |              |              | which could be of any selection type     | then the implementation should ignore    |
-|                          |                                  |              |              | that extends                             | it.                                      |
-|                          |                                  |              |              | :ref:`single-csv-ballot-selection-base`. |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_sub_title         | ``xs:string``                    | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
-|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ballot_title             | ``xs:string``                    | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
-|                          |                                  |              |              | the ballot.                              | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electoral_district_id    | ``xs:IDREF``                     | **Required** | Single       | References an                            | If the field is invalid, then the        |
-|                          |                                  |              |              | :ref:`single-csv-electoral-district`     | implementation is required to ignore the |
-|                          |                                  |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
-|                          |                                  |              |              | scope of the contest.                    |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| electorate_specification | ``xs:string``                    | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
-|                          |                                  |              |              | electorate for this contest past the     | present, then the implementation should  |
-|                          |                                  |              |              | usual, "all registered voters"           | ignore it.                               |
-|                          |                                  |              |              | electorate. This subtag will most often  |                                          |
-|                          |                                  |              |              | be used for primaries and local          |                                          |
-|                          |                                  |              |              | elections. In primaries, voters may have |                                          |
-|                          |                                  |              |              | to be registered as a specific party to  |                                          |
-|                          |                                  |              |              | vote, or there may be special rules for  |                                          |
-|                          |                                  |              |              | which ballot a voter can pull. In some   |                                          |
-|                          |                                  |              |              | local elections, non-citizens can vote.  |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers     | ``xs:string``                    | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
-|                          |                                  |              |              | links to another source of information.  | present, then the implementation should  |
-|                          |                                  |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| has_rotation             | ``xs:boolean``                   | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
-|                          |                                  |              |              | contest are rotated.                     | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                     | ``xs:string``                    | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
-|                          |                                  |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
-|                          |                                  |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
-|                          |                                  |              |              | purpose).                                |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| sequence_order           | ``xs:integer``                   | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
-|                          |                                  |              |              | on the ballot. This is the default       | then the implementation should ignore    |
-|                          |                                  |              |              | ordering, and can be overrides by data   | it.                                      |
-|                          |                                  |              |              | in a :ref:`single-csv-ballot-style`      |                                          |
-|                          |                                  |              |              | element.                                 |                                          |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| vote_variation           | :ref:`single-csv-vote-variation` | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
-|                          |                                  |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
-|                          |                                  |              |              |                                          | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| other_vote_variation     | ``other_vote_variation``         | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
-|                          |                                  |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
-|                          |                                  |              |              | variation can be specified here.         | it.                                      |
-+--------------------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-party:
-
-party
-~~~~~
-
-This element describes a political party and the metadata associated with them. These can also include "dummy" parties to indicate a type of contest (e.g., a Voter Nominated :ref:`single-csv-candidate-contest` can use the **PrimaryPartyIds** field and a dummy Party object to indicate that the contest is a "Top-Two" primary).
-
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+========================================+==============+==============+==========================================+==========================================+
-| abbreviation         | ``xs:string``                          | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
-|                      |                                        |              |              |                                          | then the implementation is required to   |
-|                      |                                        |              |              |                                          | ignore it.                               |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| color                | :ref:`single-csv-html-color-string`    | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
-|                      |                                        |              |              | party, for use in maps and other         | present, then the implementation is      |
-|                      |                                        |              |              | displays.                                | required to ignore it.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| external_identifiers | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
-|                      |                                        |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
-|                      |                                        |              |              | campaign finance system, etc).           | required to ignore it.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_write_in          | ``xs:boolean``                         | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
-|                      |                                        |              |              | that is officially recognized by a       | then the implementation is required to   |
-|                      |                                        |              |              | local, state, or federal organization,   | ignore it.                               |
-|                      |                                        |              |              | or is a "write-in" in jurisdictions      |                                          |
-|                      |                                        |              |              | which allow candidates to free-form      |                                          |
-|                      |                                        |              |              | enter their political affiliation. If    |                                          |
-|                      |                                        |              |              | this field is not present then it is     |                                          |
-|                      |                                        |              |              | assumed to be false.                     |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| logo_uri             | ``xs:anyURI``                          | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
-|                      |                                        |              |              | displays.                                | then the implementation is required to   |
-|                      |                                        |              |              |                                          | ignore it.                               |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                 | ``xs:string``                          | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
-|                      |                                        |              |              |                                          | present, then the implementation is      |
-|                      |                                        |              |              |                                          | required to ignore it.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,abbreviation,color,external_identifier_type,external_identifier_othertype,external_identifier_value,logo_uri,name
-    par01,REP,ff0000,,,,http://example.com/elephant.png,Republican
-    par02,DEM,0000ff,,,,http://example.com/donkey.png,Democrat
-    par03,GRN,efefef,,,,http://example.com/tree.png,Green
-    par04,WFP,ee99aa,,,,http://example.com/worker.png,Working Families Party
-
-
-.. _single-csv-html-color-string:
-
-html_color_string
-^^^^^^^^^^^^^^^^^
-
-A restricted string pattern for a six-character hex code representing an HTML
-color string. The pattern is:
-
-``[0-9a-f]{6}``
-
-
-.. _single-csv-internationalized-text:
-
-internationalized_text
-~~~~~~~~~~~~~~~~~~~~~~
-
-``InternationalizedText`` allows for support of multiple languages for a string.
-``InternationalizedText`` has an optional attribute ``label``, which allows the feed to refer
-back to the original label for the information (e.g. if the contact information came from a
-CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can be seen in:
-* Any element that extends :ref:`single-csv-contest-base`
-* Any element that extends :ref:`single-csv-ballot-selection-base`
-* :ref:`single-csv-candidate`
-* :ref:`single-csv-contact-information`
-* :ref:`single-csv-election`
-* :ref:`single-csv-election-administration`
-* :ref:`single-csv-office`
-* :ref:`single-csv-party`
-* :ref:`single-csv-person`
-* :ref:`single-csv-polling-location`
-* :ref:`single-csv-source`
-NOTE: Internationalized Text is not currently supported for CSV submissions. 
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| text         | ``xs:string`` | **Required** | Repeats      | Contains the translations of a           | At least one valid ``Text`` must be      |
-|              |               |              |              | particular string of text.               | present for ``InternationalizedText`` to |
-|              |               |              |              |                                          | be valid. If no valid ``Text`` is        |
-|              |               |              |              |                                          | present, the implementation is required  |
-|              |               |              |              |                                          | to ignore the ``InternationalizedText``  |
-|              |               |              |              |                                          | element.                                 |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-ballot-measure-selection:
-
-ballot_measure_selection
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for a
-:ref:`single-csv-ballot-measure-contest` that would appear on the ballot.
-BallotMeasureSelection extends :ref:`single-csv-ballot-selection-base`.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| selection    | ``xs:string`` | **Required** | Single       | Selection text for a                     | If the element is invalid or not         |
-|              |               |              |              | :ref:`single-csv-ballot-measure-contest` | present, the implementation is required  |
-|              |               |              |              |                                          | to ignore the BallotMeasureSelection     |
-|              |               |              |              |                                          | containing it.                           |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,sequence_order,selection
-    bms001,1,Proposition A
-    bms002,2,Proposition B
-
-
-.. _single-csv-ballot-selection-base:
-
-ballot_selection_base
-^^^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-csv-ballot-measure-selection`,
-:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
-
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+================+================+==============+==============+==========================================+==========================================+
-| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-hours-open:
-
-hours_open
-~~~~~~~~~~
-
-A structured way of describing the days and hours that a place such as a
-:ref:`single-csv-office` or :ref:`single-csv-polling-location` is open, or
-that an event such as an :ref:`single-csv-election` is happening. The range of days
-indicated by the `StartDate` and `EndDate` in each `Schedule`_ element
-should not overlap with peer `Schedule`_ elements. For example, it is
-invalid to specify a schedule from 10/01/2016 to 10/31/2016 and also
-specify a schedule from 10/10/2016 to 10/11/2016 within the same `HoursOpen`
-element.
-
-+--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                  | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+============================+==============+==============+==========================================+==========================================+
-| schedule     | :ref:`single-csv-schedule` | **Required** | Repeats      | Defines a block of days and hours that a | At least one valid `Schedule`_ must be   |
-|              |                            |              |              | place will be open.                      | present for ``HoursOpen`` to be valid.   |
-|              |                            |              |              |                                          | If no valid `Schedule`_ is present, the  |
-|              |                            |              |              |                                          | implementation is required to ignore the |
-|              |                            |              |              |                                          | ``HoursOpen`` element.                   |
-+--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-schedule:
-
-schedule
-^^^^^^^^
-
-A sub-portion of the schedule. This describes a range of days, along with one or
-more set of open and close times for those days, as well as the options
-describing whether or not appointments are necessary or possible.
-
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                    | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+========================+=========================+==============+==============+==========================================+==========================================+
-| hours                  | :ref:`single-csv-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
-|                        |                         |              |              | which the place is open.                 | present, then the implementation is      |
-|                        |                         |              |              |                                          | required to ignore it.                   |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_only_by_appointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
-|                        |                         |              |              | the specified time window with an        | then the implementation is required to   |
-|                        |                         |              |              | appointment.                             | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_or_by_appointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
-|                        |                         |              |              | hours specified time window and may also | then the implementation is required to   |
-|                        |                         |              |              | be open with an appointment.             | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| is_subject_to_change   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
-|                        |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
-|                        |                         |              |              | subject to change. People should contact | ignore it.                               |
-|                        |                         |              |              | prior to arrival to confirm hours are    |                                          |
-|                        |                         |              |              | still accurate.                          |                                          |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| start_date             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                        |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
-|                        |                         |              |              |                                          | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| end_date               | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                        |                         |              |              | start and end times and options end.     | then the implementation is required to   |
-|                        |                         |              |              |                                          | ignore it.                               |
-+------------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,start_time,end_time,is_only_by_appointment,is_or_by_appointment,is_subject_to_change,start_date,end_date,hours_open_id
-    sch001,07:00:00-06:00,22:00:00-06:00,,true,,2016-10-10,2016-10-12,ho001
-    sch002,09:00:00-06:00,20:00:00-06:00,true,,,2016-10-13,2016-10-15,ho001
-    sch003,08:00:00-06:00,14:00:00-06:00,,,true,2016-10-10,2016-10-15,ho002
-
-
-.. _single-csv-hours:
-
-hours
-%%%%%
-
-The open and close time for this place. All times must be fully specified,
-including a timezone offset from UTC.
-
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==================================+==============+==============+==========================================+==========================================+
-| start_time   | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| end_time     | :ref:`single-csv-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag             | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
++=================+====================================+==============+==============+==========================================+==========================================+
+| term_type       | :ref:`single-csv-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
+|                 |                                    |              |              | :ref:`single-csv-office-term-type` for   | the implementation is required to ignore |
+|                 |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| term_start_date | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
+|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|                 |                                    |              |              |                                          | ignore it.                               |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| term_end_date   | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
+|                 |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|                 |                                    |              |              |                                          | ignore it.                               |
++-----------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-csv-time-with-zone:
 
 time_with_zone
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 A string pattern restricting the value to a time with an included offset from
 UTC. The pattern is
@@ -2737,135 +2827,45 @@ UTC. The pattern is
    </HoursOpen>
 
 
-.. _single-csv-electoral-district:
+.. _single-csv-voter-service:
 
-electoral_district
-~~~~~~~~~~~~~~~~~~
+voter_service
+~~~~~~~~~~~~~
 
-The ``ElectoralDistrict`` object represents the geographic area in which contests are held. Examples
-of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congressional District",
-or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
-which precincts link to the ``ElectoralDistrict``.
-
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+========================================+==============+==============+==========================================+==========================================+
-| external_identifiers | :ref:`single-csv-external-identifiers` | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
-|                      |                                        |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
-|                      |                                        |              |              |                                          | required to ignore it.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| name                 | ``xs:string``                          | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
-|                      |                                        |              |              |                                          | then the implementation is required to   |
-|                      |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                      |                                        |              |              |                                          | containing it.                           |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| number               | ``xs:integer``                         | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
-|                      |                                        |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
-|                      |                                        |              |              | 34th State Senate District). If a number | ignore it.                               |
-|                      |                                        |              |              | is not applicable, instead of leaving    |                                          |
-|                      |                                        |              |              | the field blank, leave this field out of |                                          |
-|                      |                                        |              |              | the object; empty strings are not valid  |                                          |
-|                      |                                        |              |              | for xs:integer fields.                   |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| type                 | :ref:`single-csv-district-type`        | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
-|                      |                                        |              |              |                                          | then the implementation is required to   |
-|                      |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                      |                                        |              |              |                                          | containing it.                           |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| other_type           | ``xs:string``                          | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
-|                      |                                        |              |              | :ref:`single-csv-district-type` option   | then the implementation is required to   |
-|                      |                                        |              |              | when ``Type`` is specified as "other".   | ignore it.                               |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                         | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++=============================+=======================================+==============+==============+==========================================+==========================================+
+| contact_information         | :ref:`single-csv-contact-information` | Optional     | Single       | The contact for a particular voter       | If the element is invalid or not         |
+|                             |                                       |              |              | service.                                 | present, then the implementation is      |
+|                             |                                       |              |              |                                          | required to ignore it.                   |
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| description                 | ``xs:string``                         | Optional     | Single       | Long description of the services         | If the element is invalid or not         |
+|                             |                                       |              |              | available.                               | present, then the implementation is      |
+|                             |                                       |              |              |                                          | required to ignore it.                   |
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| election_official_person_id | ``xs:IDREF``                          | Optional     | Single       | The :ref:`authority <single-csv-person>` | If the field is invalid or not present,  |
+|                             |                                       |              |              | for a particular voter service.          | then the implementation is required to   |
+|                             |                                       |              |              |                                          | ignore it.                               |
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| type                        | :ref:`single-csv-voter-service-type`  | Optional     | Single       | The type of :ref:`voter service          | If the field is invalid or not present,  |
+|                             |                                       |              |              | <single-csv-voter-service-type>`.        | then the implementation is required to   |
+|                             |                                       |              |              |                                          | ignore it.                               |
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| other_type                  | ``xs:string``                         | Optional     | Single       | If Type is "other", OtherType allows for | If the field is invalid or not present,  |
+|                             |                                       |              |              | cataloging another type of voter         | then the implementation is required to   |
+|                             |                                       |              |              | service.                                 | ignore it.                               |
++-----------------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: csv-table
    :linenos:
 
 
-    id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,number,type,other_type
-    ed001,ocd-id,,ocd-division/country:us/state:ny/borough:brooklyn,Brooklyn,1,borough,
-    ed002,other,community-board,4,CB 4,2,other,community-board
-
-
-.. _single-csv-party-selection:
-
-party_selection
-~~~~~~~~~~~~~~~
-
-This element extends :ref:`single-csv-ballot-selection-base` to
-support contests in which the selections can be groups of one or more parties.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| party_ids    | ``xs:IDREFS`` | **Required** | Single       | One or more :ref:`single-csv-party` IDs  | If one or more parties referenced are    |
-|              |               |              |              | which collectively represent a ballot    | invalid or not present, the              |
-|              |               |              |              | selection.                               | implementation is required to ignore the |
-|              |               |              |              |                                          | PartySelection containing it.            |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: csv-table
-   :linenos:
-
-
-    id,sequence_order,party_ids
-    ps001,1,par01 par04
-    ps002,2,par02
-    ps003,3,par03
-
-
-.. _single-csv-ballot-selection-base:
-
-ballot_selection_base
-^^^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-csv-ballot-measure-selection`,
-:ref:`single-csv-candidate-selection`, and :ref:`single-csv-party-selection`.
-
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag            | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+================+================+==============+==============+==========================================+==========================================+
-| sequence_order | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|                |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|                |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|                |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|                |                |              |              | in :ref:`single-csv-ordered-contest`.    |                                          |
-+----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-csv-simple-address-type:
-
-simple_address_type
-~~~~~~~~~~~~~~~~~~~
-
-A ``SimpleAddressType`` represents a structured address.
-
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===================+===============+==============+==============+==========================================+==========================================+
-| structured_line_1 | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|                   |               |              |              | address. Should include the street       | implementation should ignore the         |
-|                   |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|                   |               |              |              | suffix.                                  |                                          |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_2 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
-|                   |               |              |              |                                          | implementation should ignore it.         |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_line_3 | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
-|                   |               |              |              |                                          | implementation should ignore it.         |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_city   | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_state  | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| structured_zip    | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
-|                   |               |              |              |                                          | implementation should ignore the         |
-|                   |               |              |              |                                          | ``SimpleAddressType``.                   |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+    id,description,election_official_person_id,type,other_type,department_id
+    vs01,A service we provide,per50002,other,overseas-voting,dep01
+    vs00,Elections notifications,per50002,other,voter-registration,dep02
+    vs02,Pencil sharpening,per50002,other,office-help,dep03
+    vs03,Guided hike to polling place,per50002,other,polling-places,dep03
+    vs04,Bike messenger ballot delivery,per50002,other,absentee-ballots,dep03
 
 
 .. _single-csv-enumerations:
@@ -2874,30 +2874,36 @@ Enumerations
 ------------
 
 
-.. _single-csv-identifier-type:
+.. _single-csv-ballot-measure-type:
 
-identifier_type
-~~~~~~~~~~~~~~~
+ballot_measure_type
+~~~~~~~~~~~~~~~~~~~
+
+A list of the various types of ballot measures. States may have different legal
+definitions of each type; Wikipedia_ has more details about each type.  These
+values are to help states with multiple types of non-candidate-based contests
+distinguish between each type; as such, the definitions in this table are simple
+guidelines. Ultimately it is up to the state or local election official to
+choose the value which best describes the ballot measure(s) in their
+jurisdiction.
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| fips           | Federal Information Processing Standards codes for |
-|                | states_, counties_, and cities_.                   |
+| ballot-measure | A catch-all for generic types of                   |
+|                | non-candidate-based contests.                      |
 +----------------+----------------------------------------------------+
-| local-level    | An identifier generated or used by local           |
-|                | governments or organizations.                      |
+| initiative     | These are usually citizen-driven measures to be    |
+|                | placed on the ballot. These could include both     |
+|                | statutory changes and constitutional amendments.   |
 +----------------+----------------------------------------------------+
-| national-level | An identifier generated or used by national        |
-|                | organizations.                                     |
+| referendum     | These could include measures to repeal existing    |
+|                | acts of legislation, legislative referrals, and    |
+|                | legislatively-referred state constitutional        |
+|                | amendments.                                        |
 +----------------+----------------------------------------------------+
-| ocd-id         | An `Open Civic Data Division Identifier`_.         |
-+----------------+----------------------------------------------------+
-| state-level    | An identifier generated or used by state           |
-|                | governments or organizations.                      |
-+----------------+----------------------------------------------------+
-| other          | Any identifier which doesn't fall into any of the  |
-|                | above categories.                                  |
+| other          | Anything that does not fall into the above         |
+|                | categories.                                        |
 +----------------+----------------------------------------------------+
 
 
@@ -2939,30 +2945,6 @@ candidate_pre_election_status
 +--------------+----------------------------------------------------+
 | write-in     |                                                    |
 +--------------+----------------------------------------------------+
-
-
-.. _single-csv-voter-service-type:
-
-voter_service_type
-~~~~~~~~~~~~~~~~~~
-
-+--------------------+----------------------------------------------------+
-| Tag                | Description                                        |
-+====================+====================================================+
-| absentee-ballots   | This department handles the dispatch, tracking,    |
-|                    | and return of absentee ballots.                    |
-+--------------------+----------------------------------------------------+
-| overseas-voting    | The department for overseas, military, and other   |
-|                    | outside-the-U.S. voters.                           |
-+--------------------+----------------------------------------------------+
-| polling-places     | This deparment handles the selection and           |
-|                    | management of polling places.                      |
-+--------------------+----------------------------------------------------+
-| voter-registration | The deparment that manages voter registration.     |
-+--------------------+----------------------------------------------------+
-| other              | Any other service not covered by the above         |
-|                    | descriptions.                                      |
-+--------------------+----------------------------------------------------+
 
 
 .. _single-csv-district-type:
@@ -3030,19 +3012,30 @@ state, so please use the definition which best matches your local meaning.
 +----------------+----------------------------------------------------+
 
 
-.. _single-csv-office-term-type:
+.. _single-csv-identifier-type:
 
-office_term_type
-~~~~~~~~~~~~~~~~
+identifier_type
+~~~~~~~~~~~~~~~
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| full-term      | This election is for an office for which the       |
-|                | existing term has been completed.                  |
+| fips           | Federal Information Processing Standards codes for |
+|                | states_, counties_, and cities_.                   |
 +----------------+----------------------------------------------------+
-| unexpired-term | This election is for an office for which the       |
-|                | original term is not yet complete.                 |
+| local-level    | An identifier generated or used by local           |
+|                | governments or organizations.                      |
++----------------+----------------------------------------------------+
+| national-level | An identifier generated or used by national        |
+|                | organizations.                                     |
++----------------+----------------------------------------------------+
+| ocd-id         | An `Open Civic Data Division Identifier`_.         |
++----------------+----------------------------------------------------+
+| state-level    | An identifier generated or used by state           |
+|                | governments or organizations.                      |
++----------------+----------------------------------------------------+
+| other          | Any identifier which doesn't fall into any of the  |
+|                | above categories.                                  |
 +----------------+----------------------------------------------------+
 
 
@@ -3062,36 +3055,19 @@ oeb_enum
 +--------------+----------------------------------------------------+
 
 
-.. _single-csv-ballot-measure-type:
+.. _single-csv-office-term-type:
 
-ballot_measure_type
-~~~~~~~~~~~~~~~~~~~
-
-A list of the various types of ballot measures. States may have different legal
-definitions of each type; Wikipedia_ has more details about each type.  These
-values are to help states with multiple types of non-candidate-based contests
-distinguish between each type; as such, the definitions in this table are simple
-guidelines. Ultimately it is up to the state or local election official to
-choose the value which best describes the ballot measure(s) in their
-jurisdiction.
+office_term_type
+~~~~~~~~~~~~~~~~
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| ballot-measure | A catch-all for generic types of                   |
-|                | non-candidate-based contests.                      |
+| full-term      | This election is for an office for which the       |
+|                | existing term has been completed.                  |
 +----------------+----------------------------------------------------+
-| initiative     | These are usually citizen-driven measures to be    |
-|                | placed on the ballot. These could include both     |
-|                | statutory changes and constitutional amendments.   |
-+----------------+----------------------------------------------------+
-| referendum     | These could include measures to repeal existing    |
-|                | acts of legislation, legislative referrals, and    |
-|                | legislatively-referred state constitutional        |
-|                | amendments.                                        |
-+----------------+----------------------------------------------------+
-| other          | Anything that does not fall into the above         |
-|                | categories.                                        |
+| unexpired-term | This election is for an office for which the       |
+|                | original term is not yet complete.                 |
 +----------------+----------------------------------------------------+
 
 
@@ -3154,3 +3130,27 @@ to be assigned to a contest.
 | other          | Used when the vote variation type is not included  |
 |                | in this enumeration.                               |
 +----------------+----------------------------------------------------+
+
+
+.. _single-csv-voter-service-type:
+
+voter_service_type
+~~~~~~~~~~~~~~~~~~
+
++--------------------+----------------------------------------------------+
+| Tag                | Description                                        |
++====================+====================================================+
+| absentee-ballots   | This department handles the dispatch, tracking,    |
+|                    | and return of absentee ballots.                    |
++--------------------+----------------------------------------------------+
+| overseas-voting    | The department for overseas, military, and other   |
+|                    | outside-the-U.S. voters.                           |
++--------------------+----------------------------------------------------+
+| polling-places     | This deparment handles the selection and           |
+|                    | management of polling places.                      |
++--------------------+----------------------------------------------------+
+| voter-registration | The deparment that manages voter registration.     |
++--------------------+----------------------------------------------------+
+| other              | Any other service not covered by the above         |
+|                    | descriptions.                                      |
++--------------------+----------------------------------------------------+

--- a/docs/built_rst/xml/single_page.rst
+++ b/docs/built_rst/xml/single_page.rst
@@ -15,474 +15,6 @@ Elements
 --------
 
 
-.. _single-xml-state:
-
-State
-~~~~~
-
-The State object includes state-wide election information. The ID attribute is
-recommended to be the state's FIPS code, along with the prefix "st".
-
-+--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+========================================+==============+==============+==========================================+==========================================+
-| ElectionAdministrationId | ``xs:IDREF``                           | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
-|                          |                                        |              |              | administration object.                   | then the implementation is required to   |
-|                          |                                        |              |              |                                          | ignore it.                               |
-+--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers      | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
-|                          |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                          |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
-|                          |                                        |              |              | Alabama.                                 | implementation is required to ignore the |
-|                          |                                        |              |              |                                          | ``State`` element containing it.         |
-+--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the state's          | If the field is invalid or not present,  |
-|                          |                                        |              |              | :ref:`polling locations                  | then the implementation is required to   |
-|                          |                                        |              |              | <single-xml-polling-location>`. If early | ignore it.                               |
-|                          |                                        |              |              | vote centers or ballot drop locations    |                                          |
-|                          |                                        |              |              | are state-wide (e.g., anyone in the      |                                          |
-|                          |                                        |              |              | state can use them), they can be         |                                          |
-|                          |                                        |              |              | specified here, but you are encouraged   |                                          |
-|                          |                                        |              |              | to only use the                          |                                          |
-|                          |                                        |              |              | :ref:`single-xml-precinct` element.      |                                          |
-+--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-.. code-block:: xml
-   :linenos:
-
-   <State id="st51">
-      <ElectionAdministrationId>ea40133</ElectionAdministrationId>
-      <ExternalIdentifiers>
-        <ExternalIdentifier>
-          <Type>ocd-id</Type>
-          <Value>ocd-division/country:us/state:va</Value>
-        </ExternalIdentifier>
-      </ExternalIdentifiers>
-      <Name>Virginia</Name>
-   </State>
-
-
-.. _single-xml-term:
-
-Term
-~~~~
-
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+====================================+==============+==============+==========================================+==========================================+
-| Type         | :ref:`single-xml-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
-|              |                                    |              |              | :ref:`single-xml-office-term-type` for   | the implementation is required to ignore |
-|              |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StartDate    | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
-|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|              |                                    |              |              |                                          | ignore it.                               |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndDate      | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
-|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|              |                                    |              |              |                                          | ignore it.                               |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <Office id="off0000">
-     <ElectoralDistrictId>ed60129</ElectoralDistrictId>
-     <FilingDeadline>2013-01-01</FilingDeadline>
-     <IsPartisan>false</IsPartisan>
-     <Name>
-       <Text language="en">Governor</Text>
-     </Name>
-     <Term>
-       <Type>full-term</Type>
-     </Term>
-   </Office>
-
-
-.. _single-xml-office:
-
-Office
-~~~~~~
-
-``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
-School Board, et al).
-
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                   | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=======================+==========================================+==============+==============+==========================================+==========================================+
-| ContactInformation    | :ref:`single-xml-contact-information`    | Optional     | Repeats      | Links to the                             | If the element is invalid or not         |
-|                       |                                          |              |              | :ref:`single-xml-contact-information`    | present, then the implementation is      |
-|                       |                                          |              |              | element associated with the office.      | required to ignore it.                   |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description           | :ref:`single-xml-internationalized-text` | Optional     | Single       | A brief description of the office and    | If the element is invalid or not         |
-|                       |                                          |              |              | its purpose.                             | present, then the implementation is      |
-|                       |                                          |              |              |                                          | required to ignore it.                   |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId   | ``xs:IDREF``                             | **Required** | Single       | Links to the                             | If the field is invalid or not present,  |
-|                       |                                          |              |              | :ref:`single-xml-electoral-district`     | the implementation is required to ignore |
-|                       |                                          |              |              | element associated with the office.      | the ``Office`` element containing it.    |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers   | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
-|                       |                                          |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
-|                       |                                          |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FilingDeadline        | ``xs:date``                              | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
-|                       |                                          |              |              | candidate must have filed for the        | then the implementation is required to   |
-|                       |                                          |              |              | contest for the office.                  | ignore it.                               |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsPartisan            | ``xs:boolean``                           | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
-|                       |                                          |              |              | partisan.                                | then the implementation is required to   |
-|                       |                                          |              |              |                                          | ignore it.                               |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                  | :ref:`single-xml-internationalized-text` | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
-|                       |                                          |              |              |                                          | the implementation is required to ignore |
-|                       |                                          |              |              |                                          | the ``Office`` element containing it.    |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OfficeHolderPersonIds | ``xs:IDREFS``                            | Optional     | Single       | Links to the :ref:`single-xml-person`    | If the field is invalid or not present,  |
-|                       |                                          |              |              | element(s) that hold additional          | then the implementation is required to   |
-|                       |                                          |              |              | information about the current office     | ignore it.                               |
-|                       |                                          |              |              | holder(s).                               |                                          |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Term                  | :ref:`single-xml-term`                   | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
-|                       |                                          |              |              |                                          | present, then the implementation is      |
-|                       |                                          |              |              |                                          | required to ignore it.                   |
-+-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-term:
-
-Term
-^^^^
-
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+====================================+==============+==============+==========================================+==========================================+
-| Type         | :ref:`single-xml-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
-|              |                                    |              |              | :ref:`single-xml-office-term-type` for   | the implementation is required to ignore |
-|              |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StartDate    | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
-|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|              |                                    |              |              |                                          | ignore it.                               |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndDate      | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
-|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
-|              |                                    |              |              |                                          | ignore it.                               |
-+--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <Office id="off0000">
-     <ElectoralDistrictId>ed60129</ElectoralDistrictId>
-     <FilingDeadline>2013-01-01</FilingDeadline>
-     <IsPartisan>false</IsPartisan>
-     <Name>
-       <Text language="en">Governor</Text>
-     </Name>
-     <Term>
-       <Type>full-term</Type>
-     </Term>
-   </Office>
-
-
-.. _single-xml-contact-information:
-
-ContactInformation
-^^^^^^^^^^^^^^^^^^
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
-:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+==========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
-|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
-|                  |                                          |              |              | data providers move toward contributing  |                                          |
-|                  |                                          |              |              | hours in this format)*.                  |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
-|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
-|                  |                                          |              |              | location.                                |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|                  |                                          |              |              | location.                                | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _single-xml-name-address-line-usage:
-
-``Name`` and ``AddressLine`` Usage Note
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``Name`` and ``AddressLine`` fields should be chosen so that a display
-or mailing address can be constructed programmatically by joining the
-``Name`` and ``AddressLine`` fields together.  For example, for the
-following address::
-
-    Department of Elections
-    1 Dr. Carlton B. Goodlett Place, Room 48
-    San Francisco, CA 94102
-
-The name could be "Department of Elections" and the first address line
-could be "1 Dr. Carlton B. Goodlett Place, Room 48."
-
-However, VIP does not yet support the representation of mailing addresses
-whose "name" portion spans more than one line, for example::
-
-    California Secretary of State
-    Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-For addresses like the above, we recommend choosing a name like, "California
-Secretary of State, Elections Division" with "1500 11th Street" as the
-first address line. This would result in a programmatically constructed
-address like the following::
-
-    California Secretary of State, Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-.. code-block:: xml
-   :linenos:
-
-   <ContactInformation label="ci10861a">
-      <AddressLine>1600 Pennsylvania Ave</AddressLine>
-      <AddressLine>Washington, DC 20006</AddressLine>
-      <Email>president@whitehouse.gov</Email>
-      <Phone>202-456-1111</Phone>
-      <Phone annotation="TDD">202-456-6213</Phone>
-      <Uri>http://www.whitehouse.gov</Uri>
-   </ContactInformation>
-
-
-.. _single-xml-election:
-
-Election
-~~~~~~~~
-
-The Election object represents an Election Day, which usually consists of many individual contests
-and/or referenda. A feed may **not** contain multiple Election objects. All relationships in the
-feed (e.g., street segment to precinct to polling location) are assumed to relate only to
-the Election specified by this object. It is permissible, and recommended, to combine unrelated
-contests (e.g., a special election and a general election) that occur on the same day into one feed
-with one Election object.
-
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                        | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+============================+==========================================+==============+==============+==========================================+==========================================+
-| Date                       | ``xs:date``                              | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
-|                            |                                          |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
-|                            |                                          |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
-|                            |                                          |              |              | the election.                            |                                          |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectionType               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
-|                            |                                          |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
-|                            |                                          |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StateId                    | ``xs:IDREF``                             | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
-|                            |                                          |              |              | where the election is being held.        | implementation is required to ignore the |
-|                            |                                          |              |              |                                          | ``Election`` element containing it.      |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsStatewide                | ``xs:boolean``                           | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
-|                            |                                          |              |              | statewide.                               | the implementation is required to        |
-|                            |                                          |              |              |                                          | default to "yes".                        |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                       | :ref:`single-xml-internationalized-text` | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
-|                            |                                          |              |              | optional, this element is highly         | present, then the implementation is      |
-|                            |                                          |              |              | recommended).                            | required to ignore it.                   |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RegistrationInfo           | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
-|                            |                                          |              |              | for this election either as text or a    | present, then the implementation is      |
-|                            |                                          |              |              | URI.                                     | required to ignore it.                   |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AbsenteeBallotInfo         | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
-|                            |                                          |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
-|                            |                                          |              |              |                                          | required to ignore it.                   |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ResultsUri                 | ``xs:anyURI``                            | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
-|                            |                                          |              |              | election may be found                    | then the implementation is required to   |
-|                            |                                          |              |              |                                          | ignore it.                               |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingHours               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]**           |                                          |              |              | Election Day polling locations are open. | present, then the implementation is      |
-|                            |                                          |              |              | If polling hours differ in specific      | required to ignore it.                   |
-|                            |                                          |              |              | polling locations, alternative hours may |                                          |
-|                            |                                          |              |              | be specified in the                      |                                          |
-|                            |                                          |              |              | :ref:`single-xml-polling-location`       |                                          |
-|                            |                                          |              |              | object *(NB: this element is deprecated  |                                          |
-|                            |                                          |              |              | in favor of the more structured          |                                          |
-|                            |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
-|                            |                                          |              |              | is strongly encouraged that data         |                                          |
-|                            |                                          |              |              | providers move toward contributing hours |                                          |
-|                            |                                          |              |              | in this format)*.                        |                                          |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId                | ``xs:IDREF``                             | Optional     | Single       | References the                           | If the field is invalid or not present,  |
-|                            |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
-|                            |                                          |              |              | which lists the hours of operation for   | ignore it.                               |
-|                            |                                          |              |              | polling locations.                       |                                          |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HasElectionDayRegistration | ``xs:boolean``                           | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
-|                            |                                          |              |              | same day of the election (i.e., the last | then the implementation is required to   |
-|                            |                                          |              |              | day of the election). Valid items are    | ignore it.                               |
-|                            |                                          |              |              | "yes" and "no".                          |                                          |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| RegistrationDeadline       | ``xs:date``                              | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
-|                            |                                          |              |              | the election with the possible exception | then the implementation is required to   |
-|                            |                                          |              |              | of Election Day registration.            | ignore it.                               |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AbsenteeRequestDeadline    | ``xs:date``                              | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
-|                            |                                          |              |              | absentee ballot.                         | then the implementation is required to   |
-|                            |                                          |              |              |                                          | ignore it.                               |
-+----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <Election id="ele30000">
-     <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
-     <Date>2013-11-05</Date>
-     <ElectionType>
-       <Text language="en">General</Text>
-       <Text language="es">Generales</Text>
-     </ElectionType>
-     <HasElectionDayRegistration>false</HasElectionDayRegistration>
-     <HoursOpenId>hours0001</HoursOpenId>
-     <IsStatewide>true</IsStatewide>
-     <Name>
-       <Text language="en">2013 Statewide General</Text>
-     </Name>
-     <RegistrationDeadline>2013-10-15</RegistrationDeadline>
-     <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
-     <StateId>st51</StateId>
-   </Election>
-
-
-.. _single-xml-ballot-selection-base:
-
-BallotSelectionBase
-~~~~~~~~~~~~~~~~~~~
-
-A base model for all ballot selection types:
-:ref:`single-xml-ballot-measure-selection`,
-:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
-
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+================+==============+==============+==========================================+==========================================+
-| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-source:
-
-Source
-~~~~~~
-
-The Source object represents the organization that is publishing the information. This object is
-the only required object in the feed file, and only one source object is allowed to be present.
-
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                    | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+========================+==========================================+==============+==============+==========================================+==========================================+
-| Name                   | ``xs:string``                            | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
-|                        |                                          |              |              | that is providing the information.       | implementation is required to ignore the |
-|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VipId                  | ``xs:string``                            | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
-|                        |                                          |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
-|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| DateTime               | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
-|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore the |
-|                        |                                          |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
-|                        |                                          |              |              | organization.                            |                                          |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
-|                        |                                          |              |              | organization providing the data and what | present, then the implementation is      |
-|                        |                                          |              |              | data is in the feed.                     | required to ignore it.                   |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OrganizationUri        | ``xs:string``                            | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
-|                        |                                          |              |              | organization publishing the data.        | then the implementation is required to   |
-|                        |                                          |              |              |                                          | ignore it.                               |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FeedContactInformation | :ref:`single-xml-contact-information`    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
-|                        |                                          |              |              | :ref:`single-xml-person` who will        | present, then the implementation is      |
-|                        |                                          |              |              | respond to inquiries about the           | required to ignore it.                   |
-|                        |                                          |              |              | information contained within the file.   |                                          |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| TouUri                 | ``xs:anyURI``                            | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
-|                        |                                          |              |              | Use for the information in this file can | then the implementation is required to   |
-|                        |                                          |              |              | be found.                                | ignore it.                               |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Version                | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
-|                        |                                          |              |              |                                          | implementation is required to ignore the |
-|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
-+------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
-
-.. code-block:: xml
-   :linenos:
-
-   <Source id="src1">
-      <DateTime>2013-10-24T14:25:28</DateTime>
-      <Description>
-         <Text language="en">SBE is the official source for Virginia data</Text>
-      </Description>
-      <Name>State Board of Elections, Commonwealth of Virginia</Name>
-      <OrganizationUri>http://www.sbe.virginia.gov/</OrganizationUri>
-      <VipId>51</VipId>
-      <Version>5.0</Version>
-   </Source>
-
-
 .. _single-xml-ballot-measure-contest:
 
 BallotMeasureContest
@@ -644,6 +176,481 @@ and :ref:`single-xml-retention-contest` (NB: the latter because it extends
 +-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
+.. _single-xml-ballot-measure-selection:
+
+BallotMeasureSelection
+~~~~~~~~~~~~~~~~~~~~~~
+
+Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for a
+:ref:`single-xml-ballot-measure-contest` that would appear on the ballot.
+BallotMeasureSelection extends :ref:`single-xml-ballot-selection-base`.
+
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==========================================+==============+==============+==========================================+==========================================+
+| Selection    | :ref:`single-xml-internationalized-text` | **Required** | Single       | Selection text for a                     | If the element is invalid or not         |
+|              |                                          |              |              | :ref:`single-xml-ballot-measure-contest` | present, the implementation is required  |
+|              |                                          |              |              |                                          | to ignore the BallotMeasureSelection     |
+|              |                                          |              |              |                                          | containing it.                           |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <BallotMeasureSelection id="bms30001a">
+      <Selection label="bms30001at">
+         <Text language="en">Yes</Text>
+         <Text language="es">Sí</Text>
+      </Selection>
+   </BallotMeasureSelection>
+   <BallotMeasureSelection id="bms30001b">
+      <Selection label="bms30001bt">
+         <Text language="en">No</Text>
+         <Text language="es">No</Text>
+      </Selection>
+   </BallotMeasureSelection>
+
+
+.. _single-xml-ballot-selection-base:
+
+BallotSelectionBase
+^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-xml-ballot-measure-selection`,
+:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
+
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+================+==============+==============+==========================================+==========================================+
+| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-ballot-selection-base:
+
+BallotSelectionBase
+~~~~~~~~~~~~~~~~~~~
+
+A base model for all ballot selection types:
+:ref:`single-xml-ballot-measure-selection`,
+:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
+
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+================+==============+==============+==========================================+==========================================+
+| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-ballot-style:
+
+BallotStyle
+~~~~~~~~~~~
+
+A container for the contests/measures on the ballot.
+
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+===============+==============+==============+==========================================+==========================================+
+| ImageUri          | ``xs:anyURI`` | Optional     | Single       | Specifies a URI that returns an image of | If the field is invalid or not present,  |
+|                   |               |              |              | the sample ballot.                       | then the implementation is required to   |
+|                   |               |              |              |                                          | ignore it.                               |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrderedContestIds | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
+|                   |               |              |              | :ref:`single-xml-ordered-contest`        | then the implementation is required to   |
+|                   |               |              |              |                                          | ignore it.                               |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyIds          | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
+|                   |               |              |              | :ref:`single-xml-party`s.                | then the implementation is required to   |
+|                   |               |              |              |                                          | ignore it.                               |
++-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <BallotStyle id="bs00000">
+      <OrderedContestIds>oc20003 oc20004 oc20005 oc20025 oc20355 oc20449</OrderedContestIds>
+   </BallotStyle>
+
+
+.. _single-xml-candidate:
+
+Candidate
+~~~~~~~~~
+
+The Candidate object represents a candidate in a contest. If a candidate is
+running in multiple contests, each contest **must** have its own Candidate
+object. Candidate objects may **not** be reused between Contests.
+
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+==================================================+==============+==============+==========================================+==========================================+
+| BallotName          | :ref:`single-xml-internationalized-text`         | **Required** | Single       | The candidate's name as it will be       | If the element is invalid, then the      |
+|                     |                                                  |              |              | displayed on the official ballot (e.g.   | implementation is required to ignore the |
+|                     |                                                  |              |              | "Ken T. Cuccinelli II").                 | ``Candidate`` element containing it.     |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ContactInformation  | :ref:`single-xml-contact-information`            | Optional     | Single       | Contact and physical address information | If the element is invalid or not         |
+|                     |                                                  |              |              | for this Candidate and/or their campaign | present, then the implementation is      |
+|                     |                                                  |              |              | (see                                     | required to ignore it.                   |
+|                     |                                                  |              |              | :ref:`single-xml-contact-information`).  |                                          |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :ref:`single-xml-external-identifiers`           | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
+|                     |                                                  |              |              | links to another source of information   | present, then the implementation is      |
+|                     |                                                  |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
+|                     |                                                  |              |              | to a campaign finance system).           |                                          |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FileDate            | ``xs:date``                                      | Optional     | Single       | Date when the candidate filed for the    | If the field is invalid or not present,  |
+|                     |                                                  |              |              | contest.                                 | then the implementation is required to   |
+|                     |                                                  |              |              |                                          | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsIncumbent         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                     |                                                  |              |              | incumbent for the office associated with | then the implementation is required to   |
+|                     |                                                  |              |              | the contest.                             | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsTopTicket         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
+|                     |                                                  |              |              | top of a ticket that includes multiple   | then the implementation is required to   |
+|                     |                                                  |              |              | candidates.                              | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyId             | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-xml-party`   | If the field is invalid or not present,  |
+|                     |                                                  |              |              | element with additional information      | then the implementation is required to   |
+|                     |                                                  |              |              | about the candidate's affiliated party.  | ignore it.                               |
+|                     |                                                  |              |              | This is the party affiliation that is    |                                          |
+|                     |                                                  |              |              | intended to be presented as part of      |                                          |
+|                     |                                                  |              |              | ballot information.                      |                                          |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PersonId            | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-xml-person`  | If the field is invalid or not present,  |
+|                     |                                                  |              |              | element with additional information      | then the implementation is required to   |
+|                     |                                                  |              |              | about the candidate.                     | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PostElectionStatus  | :ref:`single-xml-candidate-post-election-status` | Optional     | Single       | Final status of the candidate (e.g.      | If the field is invalid or not present,  |
+|                     |                                                  |              |              | winner, withdrawn, etc...).              | then the implementation is required to   |
+|                     |                                                  |              |              |                                          | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PreElectionStatus   | :ref:`single-xml-candidate-pre-election-status`  | Optional     | Single       | Registration status of the candidate     | If the field is invalid or not present,  |
+|                     |                                                  |              |              | (e.g. filed, qualified, etc...).         | then the implementation is required to   |
+|                     |                                                  |              |              |                                          | ignore it.                               |
++---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <Candidate id="can10961">
+      <BallotName>
+        <Text language="en">Ken T. Cuccinelli II</Text>
+      </BallotName>
+      <PartyId>par0001</PartyId>
+      <PersonId>per10961</PersonId>
+   </Candidate>
+
+
+.. _single-xml-candidate-contest:
+
+CandidateContest
+~~~~~~~~~~~~~~~~
+
+CandidateContest extends :ref:`single-xml-contest-base` and represents a contest among
+candidates.
+
++-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag             | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++=================+================+==============+==============+==========================================+==========================================+
+| NumberElected   | ``xs:integer`` | Optional     | Single       | Number of candidates that are elected in | If the field is invalid or not present,  |
+|                 |                |              |              | the contest (i.e. "N" of N-of-M).        | then the implementation is required to   |
+|                 |                |              |              |                                          | ignore it.                               |
++-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeIds       | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                 |                |              |              | :ref:`single-xml-office` elements, if    | then the implementation is required to   |
+|                 |                |              |              | available, which give additional         | ignore it.                               |
+|                 |                |              |              | information about the offices. **Note:** |                                          |
+|                 |                |              |              | the order of the office IDs **must** be  |                                          |
+|                 |                |              |              | in the same order as the candidates      |                                          |
+|                 |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
+|                 |                |              |              | the various `BallotSelectionIds`         |                                          |
+|                 |                |              |              | reference                                |                                          |
+|                 |                |              |              | :ref:`single-xml-candidate-selection`    |                                          |
+|                 |                |              |              | elements which reference the candidate   |                                          |
+|                 |                |              |              | for President first and Vice-President   |                                          |
+|                 |                |              |              | second, the `OfficeIds` should reference |                                          |
+|                 |                |              |              | the office of President first and the    |                                          |
+|                 |                |              |              | office of Vice-President second.         |                                          |
++-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrimaryPartyIds | ``xs:IDREFS``  | Optional     | Single       | References :ref:`single-xml-party`       | If the field is invalid or not present,  |
+|                 |                |              |              | elements, if the contest is related to a | then the implementation is required to   |
+|                 |                |              |              | particular party.                        | ignore it.                               |
++-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VotesAllowed    | ``xs:integer`` | Optional     | Single       | Maximum number of votes/write-ins per    | If the field is invalid or not present,  |
+|                 |                |              |              | voter in this contest.                   | then the implementation is required to   |
+|                 |                |              |              |                                          | ignore it.                               |
++-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <CandidateContest id="cc20003">
+      <BallotSelectionIds>cs10961 cs10962 cs10963</BallotSelectionIds>
+      <BallotTitle>
+        <Text language="en">Governor of Virginia</Text>
+      </BallotTitle>
+      <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+      <Name>Governor</Name>
+      <NumberElected>1</NumberElected>
+      <OfficeId>off0000</OfficeId>
+      <VotesAllowed>1</VotesAllowed>
+   </CandidateContest>
+
+
+.. _single-xml-contest-base:
+
+ContestBase
+^^^^^^^^^^^
+
+A base model for all Contest types: :ref:`single-xml-ballot-measure-contest`,
+:ref:`single-xml-candidate-contest`, :ref:`single-xml-party-contest`,
+and :ref:`single-xml-retention-contest` (NB: the latter because it extends
+:ref:`single-xml-ballot-measure-contest`).
+
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                     | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++=========================+==========================================+==============+==============+==========================================+==========================================+
+| Abbreviation            | ``xs:string``                            | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                         |                                          |              |              |                                          | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSelectionIds      | ``xs:IDREFS``                            | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
+|                         |                                          |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                         |                                          |              |              | that extends                             | it.                                      |
+|                         |                                          |              |              | :ref:`single-xml-ballot-selection-base`. |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSubTitle          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotTitle             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId     | ``xs:IDREF``                             | **Required** | Single       | References an                            | If the field is invalid, then the        |
+|                         |                                          |              |              | :ref:`single-xml-electoral-district`     | implementation is required to ignore the |
+|                         |                                          |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
+|                         |                                          |              |              | scope of the contest.                    |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectorateSpecification | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                         |                                          |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                         |                                          |              |              | usual, "all registered voters"           | ignore it.                               |
+|                         |                                          |              |              | electorate. This subtag will most often  |                                          |
+|                         |                                          |              |              | be used for primaries and local          |                                          |
+|                         |                                          |              |              | elections. In primaries, voters may have |                                          |
+|                         |                                          |              |              | to be registered as a specific party to  |                                          |
+|                         |                                          |              |              | vote, or there may be special rules for  |                                          |
+|                         |                                          |              |              | which ballot a voter can pull. In some   |                                          |
+|                         |                                          |              |              | local elections, non-citizens can vote.  |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers     | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                         |                                          |              |              | links to another source of information.  | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasRotation             | ``xs:boolean``                           | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                         |                                          |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                    | ``xs:string``                            | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
+|                         |                                          |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
+|                         |                                          |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
+|                         |                                          |              |              | purpose).                                |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SequenceOrder           | ``xs:integer``                           | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
+|                         |                                          |              |              | on the ballot. This is the default       | then the implementation should ignore    |
+|                         |                                          |              |              | ordering, and can be overrides by data   | it.                                      |
+|                         |                                          |              |              | in a :ref:`single-xml-ballot-style`      |                                          |
+|                         |                                          |              |              | element.                                 |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VoteVariation           | :ref:`single-xml-vote-variation`         | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                         |                                          |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherVoteVariation      | ``xs:string``                            | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                         |                                          |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                         |                                          |              |              | variation can be specified here.         | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-candidate-selection:
+
+CandidateSelection
+~~~~~~~~~~~~~~~~~~
+
+CandidateSelection extends :ref:`single-xml-ballot-selection-base` and represents a
+ballot selection for a candidate contest.
+
++---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+================+==============+==============+==========================================+==========================================+
+| CandidateIds        | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                     |                |              |              | :ref:`single-xml-candidate` elements.    | then the implementation is required to   |
+|                     |                |              |              | The number of candidates that can be     | ignore it.                               |
+|                     |                |              |              | references is unbounded in cases where   |                                          |
+|                     |                |              |              | the ballot selection is for a ticket     |                                          |
+|                     |                |              |              | (e.g. "President/Vice President",        |                                          |
+|                     |                |              |              | "Governor/Lt Governor").                 |                                          |
++---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndorsementPartyIds | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
+|                     |                |              |              | :ref:`single-xml-party` elements, which  | then the implementation is required to   |
+|                     |                |              |              | signifies one or more endorsing parties  | ignore it.                               |
+|                     |                |              |              | for the candidate(s).                    |                                          |
++---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn           | ``xs:boolean`` | Optional     | Single       | Signifies if the particular ballot       | If the field is invalid or not present,  |
+|                     |                |              |              | selection allows for write-in            | then the implementation is required to   |
+|                     |                |              |              | candidates. If true, one or more         | ignore it.                               |
+|                     |                |              |              | write-in candidates are allowed for this |                                          |
+|                     |                |              |              | contest.                                 |                                          |
++---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <CandidateSelection id="cs10861">
+      <CandidateIds>can10861a can10861b</CandidateIds>
+      <EndorsementPartyIds>par0001</EndorsementPartyIds>
+   </CandidateSelection>
+
+
+.. _single-xml-ballot-selection-base:
+
+BallotSelectionBase
+^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-xml-ballot-measure-selection`,
+:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
+
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+================+==============+==============+==========================================+==========================================+
+| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-contact-information:
+
+ContactInformation
+~~~~~~~~~~~~~~~~~~
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
+:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+==========================================+==============+==============+==========================================+==========================================+
+| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
+|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
+|                  |                                          |              |              | data providers move toward contributing  |                                          |
+|                  |                                          |              |              | hours in this format)*.                  |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
+|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
+|                  |                                          |              |              | location.                                |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|                  |                                          |              |              | location.                                | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _single-xml-name-address-line-usage:
+
+``Name`` and ``AddressLine`` Usage Note
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``Name`` and ``AddressLine`` fields should be chosen so that a display
+or mailing address can be constructed programmatically by joining the
+``Name`` and ``AddressLine`` fields together.  For example, for the
+following address::
+
+    Department of Elections
+    1 Dr. Carlton B. Goodlett Place, Room 48
+    San Francisco, CA 94102
+
+The name could be "Department of Elections" and the first address line
+could be "1 Dr. Carlton B. Goodlett Place, Room 48."
+
+However, VIP does not yet support the representation of mailing addresses
+whose "name" portion spans more than one line, for example::
+
+    California Secretary of State
+    Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+For addresses like the above, we recommend choosing a name like, "California
+Secretary of State, Elections Division" with "1500 11th Street" as the
+first address line. This would result in a programmatically constructed
+address like the following::
+
+    California Secretary of State, Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+.. code-block:: xml
+   :linenos:
+
+   <ContactInformation label="ci10861a">
+      <AddressLine>1600 Pennsylvania Ave</AddressLine>
+      <AddressLine>Washington, DC 20006</AddressLine>
+      <Email>president@whitehouse.gov</Email>
+      <Phone>202-456-1111</Phone>
+      <Phone annotation="TDD">202-456-6213</Phone>
+      <Uri>http://www.whitehouse.gov</Uri>
+   </ContactInformation>
+
+
 .. _single-xml-contest-base:
 
 ContestBase
@@ -717,909 +724,6 @@ and :ref:`single-xml-retention-contest` (NB: the latter because it extends
 |                         |                                          |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
 |                         |                                          |              |              | variation can be specified here.         | it.                                      |
 +-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-time-with-zone:
-
-TimeWithZone
-~~~~~~~~~~~~
-
-A string pattern restricting the value to a time with an included offset from
-UTC. The pattern is
-
-``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
-
-.. code-block:: xml
-   :linenos:
-
-   <HoursOpen id="hours0001">
-     <Schedule>
-       <Hours>
-         <StartTime>06:00:00-05:00</StartTime>
-         <EndTime>12:00:00-05:00</EndTime>
-       </Hours>
-       <Hours>
-         <StartTime>13:00:00-05:00</StartTime>
-         <EndTime>19:00:00-05:00</EndTime>
-       </Hours>
-       <StartDate>2013-11-05</StartDate>
-       <EndDate>2013-11-05</EndDate>
-     </Schedule>
-   </HoursOpen>
-
-
-.. _single-xml-language-string:
-
-LanguageString
-~~~~~~~~~~~~~~
-
-``LanguageString`` extends xs:string and can contain text from any language. ``LanguageString``
-has one required attribute, ``language``, that must contain the 2-character `language code`_ for the
-type of language ``LanguageString`` contains.
-
-.. _`language code`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-
-.. code-block:: xml
-   :linenos:
-
-   <BallotTitle>
-      <Text language="en">Retention of Supreme Court Justice</Text>
-      <Text language="es">La retención de juez de la Corte Suprema</Text>
-   </BallotTitle>
-
-
-.. _single-xml-ballot-style:
-
-BallotStyle
-~~~~~~~~~~~
-
-A container for the contests/measures on the ballot.
-
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag               | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===================+===============+==============+==============+==========================================+==========================================+
-| ImageUri          | ``xs:anyURI`` | Optional     | Single       | Specifies a URI that returns an image of | If the field is invalid or not present,  |
-|                   |               |              |              | the sample ballot.                       | then the implementation is required to   |
-|                   |               |              |              |                                          | ignore it.                               |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OrderedContestIds | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
-|                   |               |              |              | :ref:`single-xml-ordered-contest`        | then the implementation is required to   |
-|                   |               |              |              |                                          | ignore it.                               |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PartyIds          | ``xs:IDREFS`` | Optional     | Single       | Reference to a set of                    | If the field is invalid or not present,  |
-|                   |               |              |              | :ref:`single-xml-party`s.                | then the implementation is required to   |
-|                   |               |              |              |                                          | ignore it.                               |
-+-------------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <BallotStyle id="bs00000">
-      <OrderedContestIds>oc20003 oc20004 oc20005 oc20025 oc20355 oc20449</OrderedContestIds>
-   </BallotStyle>
-
-
-.. _single-xml-external-identifier:
-
-ExternalIdentifier
-~~~~~~~~~~~~~~~~~~
-
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===================================+==============+==============+==========================================+==========================================+
-| Type         | :ref:`single-xml-identifier-type` | **Required** | Single       | Specifies the type of identifier. Must   | If the field is invalid or not present,  |
-|              |                                   |              |              | be one of the valid types as defined by  | the implementation is required to ignore |
-|              |                                   |              |              | :ref:`single-xml-identifier-type`.       | the ``ElectionIdentifier`` containing    |
-|              |                                   |              |              |                                          | it.                                      |
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherType    | ``xs:string``                     | Optional     | Single       | Allows for cataloging an                 | If the field is invalid or not present,  |
-|              |                                   |              |              | ``ExternalIdentifier`` type that falls   | then the implementation is required to   |
-|              |                                   |              |              | outside the options listed in            | ignore it.                               |
-|              |                                   |              |              | :ref:`single-xml-identifier-type`.       |                                          |
-|              |                                   |              |              | ``Type`` should be set to "other" when   |                                          |
-|              |                                   |              |              | using this field.                        |                                          |
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Value        | ``xs:string``                     | **Required** | Single       | Specifies the identifier.                | If the field is invalid or not present,  |
-|              |                                   |              |              |                                          | the implementation is required to ignore |
-|              |                                   |              |              |                                          | the ``ElectionIdentifier`` containing    |
-|              |                                   |              |              |                                          | it.                                      |
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <ExternalIdentifiers>
-      <ExternalIdentifier>
-         <Type>ocd-id</Type>
-         <Value>ocd-division/country:us/state:nc/county:durham</Value>
-      </ExternalIdentifier>
-      <ExternalIdentifier>
-         <Type>FIPS</Type>
-         <Value>37063</Value>
-      </ExternalIdentifier>
-      <ExternalIdentifier>
-         <Type>OTHER</Type>
-         <OtherType>GNIS</OtherType>
-         <Value>1008550</Value>
-      </ExternalIdentifier>
-      <external_identifer>
-         <Type>OTHER</Type>
-         <OtherType>census</OtherType>
-         <Value>99063</Value>
-      </ExternalIdentifier>
-   </ExternalIdentifiers>
-
-
-.. _single-xml-person:
-
-Person
-~~~~~~
-
-``Person`` defines information about a person. The person may be a candidate, election administrator,
-or elected official. These elements reference ``Person``:
-
-* :ref:`single-xml-candidate`
-
-* :ref:`single-xml-election-administration`
-
-* :ref:`single-xml-office`
-
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+==========================================+==============+==============+==========================================+==========================================+
-| ContactInformation  | :ref:`single-xml-contact-information`    | Optional     | Repeats      | Refers to the associated                 | If the element is invalid or not         |
-|                     |                                          |              |              | :ref:`single-xml-contact-information`.   | present, then the implementation is      |
-|                     |                                          |              |              |                                          | required to ignore it.                   |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| DateOfBirth         | ``xs:date``                              | Optional     | Single       | Represents the individual's date of      | If the field is invalid or not present,  |
-|                     |                                          |              |              | birth.                                   | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Identifiers for this person.             | If the element is invalid or not         |
-|                     |                                          |              |              |                                          | present, then the implementation is      |
-|                     |                                          |              |              |                                          | required to ignore it.                   |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FirstName           | ``xs:string``                            | Optional     | Single       | Represents an individual's first name.   | If the field is invalid or not present,  |
-|                     |                                          |              |              |                                          | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FullName            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies a person's full name (**NB:**  | If the element is invalid or not         |
-|                     |                                          |              |              | this information is                      | present, then the implementation is      |
-|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
-|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
-|                     |                                          |              |              | in multiple languages).                  |                                          |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Gender              | ``xs:string``                            | Optional     | Single       | Specifies a person's gender.             | If the field is invalid or not present,  |
-|                     |                                          |              |              |                                          | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LastName            | ``xs:string``                            | Optional     | Single       | Represents an individual's last name.    | If the field is invalid or not present,  |
-|                     |                                          |              |              |                                          | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| MiddleName          | ``xs:string``                            | Optional     | Repeats      | Represents any number of names between   | If the field is invalid or not present,  |
-|                     |                                          |              |              | an individual's first and last names     | then the implementation is required to   |
-|                     |                                          |              |              | (e.g. John **Ronald Reuel** Tolkien).    | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Nickname            | ``xs:string``                            | Optional     | Single       | Represents an individual's nickname.     | If the field is invalid or not present,  |
-|                     |                                          |              |              |                                          | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PartyId             | ``xs:IDREF``                             | Optional     | Single       | Refers to the associated                 | If the field is invalid or not present,  |
-|                     |                                          |              |              | :ref:`single-xml-party`. This            | then the implementation is required to   |
-|                     |                                          |              |              | information is intended to be used by    | ignore it.                               |
-|                     |                                          |              |              | feed consumers to help them disambiguate |                                          |
-|                     |                                          |              |              | the person's identity, but not to be     |                                          |
-|                     |                                          |              |              | presented as part of any ballot          |                                          |
-|                     |                                          |              |              | information. For that see                |                                          |
-|                     |                                          |              |              | :ref:`single-xml-candidate` **PartyId**. |                                          |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Prefix              | ``xs:string``                            | Optional     | Single       | Specifies a prefix associated with a     | If the field is invalid or not present,  |
-|                     |                                          |              |              | person (e.g. Dr.).                       | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Profession          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies a person's profession (**NB:** | If the element is invalid or not         |
-|                     |                                          |              |              | this information is                      | present, then the implementation is      |
-|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
-|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
-|                     |                                          |              |              | in multiple languages).                  |                                          |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Suffix              | ``xs:string``                            | Optional     | Single       | Specifies a suffix associated with a     | If the field is invalid or not present,  |
-|                     |                                          |              |              | person (e.g. Jr.).                       | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Title               | :ref:`single-xml-internationalized-text` | Optional     | Single       | A title associated with a person         | If the element is invalid or not         |
-|                     |                                          |              |              | (**NB:** this information is             | present, then the implementation is      |
-|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
-|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
-|                     |                                          |              |              | in multiple languages).                  |                                          |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <Person id="per50001">
-      <ContactInformation label="ci60002">
-        <Email>rwashburne@albemarle.org</Email>
-        <Phone>4349724173</Phone>
-      </ContactInformation>
-      <FirstName>RICHARD</FirstName>
-      <LastName>WASHBURNE</LastName>
-      <MiddleName>J.</MiddleName>
-      <Nickname>JAKE</Nickname>
-      <Title>
-        <Text language="en">General Registrar Physical</Text>
-      </Title>
-   </Person>
-
-
-.. _single-xml-contact-information:
-
-ContactInformation
-^^^^^^^^^^^^^^^^^^
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
-:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+==========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
-|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
-|                  |                                          |              |              | data providers move toward contributing  |                                          |
-|                  |                                          |              |              | hours in this format)*.                  |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
-|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
-|                  |                                          |              |              | location.                                |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|                  |                                          |              |              | location.                                | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _single-xml-name-address-line-usage:
-
-``Name`` and ``AddressLine`` Usage Note
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``Name`` and ``AddressLine`` fields should be chosen so that a display
-or mailing address can be constructed programmatically by joining the
-``Name`` and ``AddressLine`` fields together.  For example, for the
-following address::
-
-    Department of Elections
-    1 Dr. Carlton B. Goodlett Place, Room 48
-    San Francisco, CA 94102
-
-The name could be "Department of Elections" and the first address line
-could be "1 Dr. Carlton B. Goodlett Place, Room 48."
-
-However, VIP does not yet support the representation of mailing addresses
-whose "name" portion spans more than one line, for example::
-
-    California Secretary of State
-    Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-For addresses like the above, we recommend choosing a name like, "California
-Secretary of State, Elections Division" with "1500 11th Street" as the
-first address line. This would result in a programmatically constructed
-address like the following::
-
-    California Secretary of State, Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-.. code-block:: xml
-   :linenos:
-
-   <ContactInformation label="ci10861a">
-      <AddressLine>1600 Pennsylvania Ave</AddressLine>
-      <AddressLine>Washington, DC 20006</AddressLine>
-      <Email>president@whitehouse.gov</Email>
-      <Phone>202-456-1111</Phone>
-      <Phone annotation="TDD">202-456-6213</Phone>
-      <Uri>http://www.whitehouse.gov</Uri>
-   </ContactInformation>
-
-
-.. _single-xml-external-identifiers:
-
-ExternalIdentifiers
-~~~~~~~~~~~~~~~~~~~
-
-The ``ExternalIdentifiers`` element allows VIP data to connect with external datasets (e.g.
-candidates with campaign finance datasets, electoral geographies with `OCD-IDs`_ that allow for
-greater connectivity with additional datasets, etc...). Examples for ``ExternalIdentifiers`` can be
-found on the objects that support them:
-
-* :ref:`single-xml-candidate`
-
-* Any element that extends :ref:`single-xml-contest-base`
-
-* :ref:`single-xml-electoral-district`
-
-* :ref:`single-xml-locality`
-
-* :ref:`single-xml-office`
-
-* :ref:`single-xml-party`
-
-* :ref:`single-xml-precinct`
-
-* :ref:`single-xml-state`
-
-.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-+--------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
-+====================+=======================================+==============+==============+==========================================+==========================================+
-| ExternalIdentifier | :ref:`single-xml-external-identifier` | **Required** | Repeats      | Defines the identifier and the type of   | At least one valid `ExternalIdentifier`_ |
-|                    |                                       |              |              | identifier it is (see                    | must be present for                      |
-|                    |                                       |              |              | `ExternalIdentifier`_ for complete       | ``ExternalIdentifiers`` to be valid. If  |
-|                    |                                       |              |              | information).                            | no valid `ExternalIdentifier`_ is        |
-|                    |                                       |              |              |                                          | present, the implementation is required  |
-|                    |                                       |              |              |                                          | to ignore the ``ExternalIdentifiers``    |
-|                    |                                       |              |              |                                          | element.                                 |
-+--------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-voter-service:
-
-VoterService
-~~~~~~~~~~~~
-
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==========================+==========================================+==============+==============+==========================================+==========================================+
-| ContactInformation       | :ref:`single-xml-contact-information`    | Optional     | Single       | The contact for a particular voter       | If the element is invalid or not         |
-|                          |                                          |              |              | service.                                 | present, then the implementation is      |
-|                          |                                          |              |              |                                          | required to ignore it.                   |
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Description              | :ref:`single-xml-internationalized-text` | Optional     | Single       | Long description of the services         | If the element is invalid or not         |
-|                          |                                          |              |              | available.                               | present, then the implementation is      |
-|                          |                                          |              |              |                                          | required to ignore it.                   |
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectionOfficialPersonId | ``xs:IDREF``                             | Optional     | Single       | The :ref:`authority <single-xml-person>` | If the field is invalid or not present,  |
-|                          |                                          |              |              | for a particular voter service.          | then the implementation is required to   |
-|                          |                                          |              |              |                                          | ignore it.                               |
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Type                     | :ref:`single-xml-voter-service-type`     | Optional     | Single       | The type of :ref:`voter service          | If the field is invalid or not present,  |
-|                          |                                          |              |              | <single-xml-voter-service-type>`.        | then the implementation is required to   |
-|                          |                                          |              |              |                                          | ignore it.                               |
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherType                | ``xs:string``                            | Optional     | Single       | If Type is "other", OtherType allows for | If the field is invalid or not present,  |
-|                          |                                          |              |              | cataloging another type of voter         | then the implementation is required to   |
-|                          |                                          |              |              | service.                                 | ignore it.                               |
-+--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-contact-information:
-
-ContactInformation
-~~~~~~~~~~~~~~~~~~
-
-For defining contact information about objects such as persons, boards of authorities,
-organizations, etc. ContactInformation is always a sub-element of another object (e.g.
-:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
-:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
-``label``, which allows the feed to refer back to the original label for the information
-(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
-
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==================+==========================================+==============+==============+==========================================+==========================================+
-| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
-|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
-|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
-|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
-|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
-|                  |                                          |              |              | data providers move toward contributing  |                                          |
-|                  |                                          |              |              | hours in this format)*.                  |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
-|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
-|                  |                                          |              |              | location.                                |                                          |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
-|                  |                                          |              |              |                                          | required to ignore it.                   |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
-|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
-|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
-|                  |                                          |              |              |                                          | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
-|                  |                                          |              |              | location.                                | then the implementation is required to   |
-|                  |                                          |              |              |                                          | ignore it.                               |
-+------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _single-xml-name-address-line-usage:
-
-``Name`` and ``AddressLine`` Usage Note
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``Name`` and ``AddressLine`` fields should be chosen so that a display
-or mailing address can be constructed programmatically by joining the
-``Name`` and ``AddressLine`` fields together.  For example, for the
-following address::
-
-    Department of Elections
-    1 Dr. Carlton B. Goodlett Place, Room 48
-    San Francisco, CA 94102
-
-The name could be "Department of Elections" and the first address line
-could be "1 Dr. Carlton B. Goodlett Place, Room 48."
-
-However, VIP does not yet support the representation of mailing addresses
-whose "name" portion spans more than one line, for example::
-
-    California Secretary of State
-    Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-For addresses like the above, we recommend choosing a name like, "California
-Secretary of State, Elections Division" with "1500 11th Street" as the
-first address line. This would result in a programmatically constructed
-address like the following::
-
-    California Secretary of State, Elections Division
-    1500 11th Street
-    Sacramento, CA 95814
-
-.. code-block:: xml
-   :linenos:
-
-   <ContactInformation label="ci10861a">
-      <AddressLine>1600 Pennsylvania Ave</AddressLine>
-      <AddressLine>Washington, DC 20006</AddressLine>
-      <Email>president@whitehouse.gov</Email>
-      <Phone>202-456-1111</Phone>
-      <Phone annotation="TDD">202-456-6213</Phone>
-      <Uri>http://www.whitehouse.gov</Uri>
-   </ContactInformation>
-
-
-.. _single-xml-candidate-selection:
-
-CandidateSelection
-~~~~~~~~~~~~~~~~~~
-
-CandidateSelection extends :ref:`single-xml-ballot-selection-base` and represents a
-ballot selection for a candidate contest.
-
-+---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+================+==============+==============+==========================================+==========================================+
-| CandidateIds        | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                     |                |              |              | :ref:`single-xml-candidate` elements.    | then the implementation is required to   |
-|                     |                |              |              | The number of candidates that can be     | ignore it.                               |
-|                     |                |              |              | references is unbounded in cases where   |                                          |
-|                     |                |              |              | the ballot selection is for a ticket     |                                          |
-|                     |                |              |              | (e.g. "President/Vice President",        |                                          |
-|                     |                |              |              | "Governor/Lt Governor").                 |                                          |
-+---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndorsementPartyIds | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                     |                |              |              | :ref:`single-xml-party` elements, which  | then the implementation is required to   |
-|                     |                |              |              | signifies one or more endorsing parties  | ignore it.                               |
-|                     |                |              |              | for the candidate(s).                    |                                          |
-+---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsWriteIn           | ``xs:boolean`` | Optional     | Single       | Signifies if the particular ballot       | If the field is invalid or not present,  |
-|                     |                |              |              | selection allows for write-in            | then the implementation is required to   |
-|                     |                |              |              | candidates. If true, one or more         | ignore it.                               |
-|                     |                |              |              | write-in candidates are allowed for this |                                          |
-|                     |                |              |              | contest.                                 |                                          |
-+---------------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <CandidateSelection id="cs10861">
-      <CandidateIds>can10861a can10861b</CandidateIds>
-      <EndorsementPartyIds>par0001</EndorsementPartyIds>
-   </CandidateSelection>
-
-
-.. _single-xml-ballot-selection-base:
-
-BallotSelectionBase
-^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-xml-ballot-measure-selection`,
-:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
-
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+================+==============+==============+==========================================+==========================================+
-| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-lat-lng:
-
-LatLng
-~~~~~~
-
-The latitude and longitude of a polling location in `WGS 84`_ format. Both
-latitude and longitude values are measured in decimal degrees.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| Latitude     | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
-|              |               |              |              |                                          | implementation is required to ignore it. |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Longitude    | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
-|              |               |              |              |                                          | implementation is required to ignore it. |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Source       | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
-|              |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
-|              |               |              |              | example, this could be the name of a     | ignore it.                               |
-|              |               |              |              | geocoding service.                       |                                          |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-candidate:
-
-Candidate
-~~~~~~~~~
-
-The Candidate object represents a candidate in a contest. If a candidate is
-running in multiple contests, each contest **must** have its own Candidate
-object. Candidate objects may **not** be reused between Contests.
-
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+==================================================+==============+==============+==========================================+==========================================+
-| BallotName          | :ref:`single-xml-internationalized-text`         | **Required** | Single       | The candidate's name as it will be       | If the element is invalid, then the      |
-|                     |                                                  |              |              | displayed on the official ballot (e.g.   | implementation is required to ignore the |
-|                     |                                                  |              |              | "Ken T. Cuccinelli II").                 | ``Candidate`` element containing it.     |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ContactInformation  | :ref:`single-xml-contact-information`            | Optional     | Single       | Contact and physical address information | If the element is invalid or not         |
-|                     |                                                  |              |              | for this Candidate and/or their campaign | present, then the implementation is      |
-|                     |                                                  |              |              | (see                                     | required to ignore it.                   |
-|                     |                                                  |              |              | :ref:`single-xml-contact-information`).  |                                          |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :ref:`single-xml-external-identifiers`           | Optional     | Single       | Another identifier for a candidate that  | If the element is invalid or not         |
-|                     |                                                  |              |              | links to another source of information   | present, then the implementation is      |
-|                     |                                                  |              |              | (e.g. a campaign committee ID that links | required to ignore it.                   |
-|                     |                                                  |              |              | to a campaign finance system).           |                                          |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| FileDate            | ``xs:date``                                      | Optional     | Single       | Date when the candidate filed for the    | If the field is invalid or not present,  |
-|                     |                                                  |              |              | contest.                                 | then the implementation is required to   |
-|                     |                                                  |              |              |                                          | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsIncumbent         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
-|                     |                                                  |              |              | incumbent for the office associated with | then the implementation is required to   |
-|                     |                                                  |              |              | the contest.                             | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsTopTicket         | ``xs:boolean``                                   | Optional     | Single       | Indicates whether the candidate is the   | If the field is invalid or not present,  |
-|                     |                                                  |              |              | top of a ticket that includes multiple   | then the implementation is required to   |
-|                     |                                                  |              |              | candidates.                              | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PartyId             | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-xml-party`   | If the field is invalid or not present,  |
-|                     |                                                  |              |              | element with additional information      | then the implementation is required to   |
-|                     |                                                  |              |              | about the candidate's affiliated party.  | ignore it.                               |
-|                     |                                                  |              |              | This is the party affiliation that is    |                                          |
-|                     |                                                  |              |              | intended to be presented as part of      |                                          |
-|                     |                                                  |              |              | ballot information.                      |                                          |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PersonId            | ``xs:IDREF``                                     | Optional     | Single       | Reference to a :ref:`single-xml-person`  | If the field is invalid or not present,  |
-|                     |                                                  |              |              | element with additional information      | then the implementation is required to   |
-|                     |                                                  |              |              | about the candidate.                     | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PostElectionStatus  | :ref:`single-xml-candidate-post-election-status` | Optional     | Single       | Final status of the candidate (e.g.      | If the field is invalid or not present,  |
-|                     |                                                  |              |              | winner, withdrawn, etc...).              | then the implementation is required to   |
-|                     |                                                  |              |              |                                          | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PreElectionStatus   | :ref:`single-xml-candidate-pre-election-status`  | Optional     | Single       | Registration status of the candidate     | If the field is invalid or not present,  |
-|                     |                                                  |              |              | (e.g. filed, qualified, etc...).         | then the implementation is required to   |
-|                     |                                                  |              |              |                                          | ignore it.                               |
-+---------------------+--------------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <Candidate id="can10961">
-      <BallotName>
-        <Text language="en">Ken T. Cuccinelli II</Text>
-      </BallotName>
-      <PartyId>par0001</PartyId>
-      <PersonId>per10961</PersonId>
-   </Candidate>
-
-
-.. _single-xml-polling-location:
-
-PollingLocation
-~~~~~~~~~~~~~~~
-
-The PollingLocation object represents a site where voters cast or drop off ballots.
-
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag               | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===================+==========================================+==============+==============+==========================================+==========================================+
-| AddressStructured | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
-|                   |                                          |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
-|                   |                                          |              |              |                                          | given Polling Location. If none is       |
-|                   |                                          |              |              |                                          | present, the implementation is required  |
-|                   |                                          |              |              |                                          | to ignore the ``PollingLocation``        |
-|                   |                                          |              |              |                                          | element containing it.                   |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| AddressLine       | ``xs:string``                            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
-|                   |                                          |              |              | address to a polling location.           | should be present for a given Polling    |
-|                   |                                          |              |              |                                          | Location. If none is present, the        |
-|                   |                                          |              |              |                                          | implementation is required to ignore the |
-|                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
-|                   |                                          |              |              |                                          | it.                                      |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Directions        | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
-|                   |                                          |              |              | locating the polling location.           | present, then the implementation is      |
-|                   |                                          |              |              |                                          | required to ignore it.                   |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Hours             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
-| **[deprecated]**  |                                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
-|                   |                                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
-|                   |                                          |              |              | the more structured                      |                                          |
-|                   |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
-|                   |                                          |              |              | is strongly encouraged that data         |                                          |
-|                   |                                          |              |              | providers move toward contributing hours |                                          |
-|                   |                                          |              |              | in this format).                         |                                          |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HoursOpenId       | ``xs:IDREF``                             | Optional     | Single       | Links to an :ref:`single-xml-hours-open` | If the field is invalid or not present,  |
-|                   |                                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
-|                   |                                          |              |              | and hours during which the polling       | ignore it.                               |
-|                   |                                          |              |              | location is available.                   |                                          |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsDropBox         | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
-|                   |                                          |              |              | drop box.                                | then the implementation is required to   |
-|                   |                                          |              |              |                                          | ignore it.                               |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsEarlyVoting     | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
-|                   |                                          |              |              | early vote site.                         | then the implementation is required to   |
-|                   |                                          |              |              |                                          | ignore it.                               |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LatLng            | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                   |                                          |              |              | this polling location.                   | present, then the implementation is      |
-|                   |                                          |              |              |                                          | required to ignore it.                   |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name              | ``xs:string``                            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
-|                   |                                          |              |              |                                          | then the implementation is required to   |
-|                   |                                          |              |              |                                          | ignore it.                               |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PhotoUri          | ``xs:anyURI``                            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
-|                   |                                          |              |              | polling location.                        | then the implementation is required to   |
-|                   |                                          |              |              |                                          | ignore it.                               |
-+-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <PollingLocation id="pl00000">
-      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
-      <HoursOpenId>hours0002</HoursOpenId>
-      <IsDropBox>true</IsDropBox>
-      <IsEarlyVoting>true</IsEarlyVoting>
-      <LatLng>
-         <Latitude>38.009939</Latitude>
-         <Longitude>-78.506204</Longitude>
-      </LatLng>
-      <Name>ALBERMARLE HIGH SCHOOL</Name>
-   </PollingLocation>
-   <!-- Or: -->
-   <PollingLocation id="pl00000">
-      <AddressStructured>
-         <Line1>2775 Hydraulic Rd</Line1>
-         <City>CHARLOTTESVILLE</City>
-         <State>VA</State>
-         <Zip>22901</Zip>
-      </AddressStructured>
-      <HoursOpenId>hours0002</HoursOpenId>
-      <IsDropBox>true</IsDropBox>
-      <IsEarlyVoting>true</IsEarlyVoting>
-      <LatLng>
-         <Latitude>38.009939</Latitude>
-         <Longitude>-78.506204</Longitude>
-      </LatLng>
-      <Name>ALBERMARLE HIGH SCHOOL</Name>
-   </PollingLocation>
-
-
-.. _single-xml-lat-lng:
-
-LatLng
-^^^^^^
-
-The latitude and longitude of a polling location in `WGS 84`_ format. Both
-latitude and longitude values are measured in decimal degrees.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| Latitude     | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
-|              |               |              |              |                                          | implementation is required to ignore it. |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Longitude    | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
-|              |               |              |              |                                          | implementation is required to ignore it. |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Source       | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
-|              |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
-|              |               |              |              | example, this could be the name of a     | ignore it.                               |
-|              |               |              |              | geocoding service.                       |                                          |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-simple-address-type:
-
-SimpleAddressType
-^^^^^^^^^^^^^^^^^
-
-A ``SimpleAddressType`` represents a structured address.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|              |               |              |              | suffix.                                  |                                          |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
-|              |               |              |              |                                          | implementation should ignore it.         |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
-|              |               |              |              |                                          | implementation should ignore it.         |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-locality:
-
-Locality
-~~~~~~~~
-
-The Locality object represents the jurisdiction below the :ref:`single-xml-state` (e.g. county).
-
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Tag                      | Data Type                              | Required?    | Repeats?     | Description                               | Error Handling                           |
-+==========================+========================================+==============+==============+===========================================+==========================================+
-| ElectionAdministrationId | ``xs:IDREF``                           | Optional     | Single       | Links to the locality's                   | If the field is invalid or not present,  |
-|                          |                                        |              |              | :ref:`single-xml-election-administration` | then the implementation is required to   |
-|                          |                                        |              |              | object.                                   | ignore it.                               |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| ExternalIdentifiers      | :ref:`single-xml-external-identifiers` | Optional     | Single       | Another identifier for a locality that    | If the element is invalid or not         |
-|                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
-|                          |                                        |              |              |                                           | required to ignore it.                   |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
-|                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
-|                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
-|                          |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
-|                          |                                        |              |              | may be used in addition to this flag      |                                          |
-|                          |                                        |              |              | using a :ref:`polling location            |                                          |
-|                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
-|                          |                                        |              |              | configured as a Drop Box.                 |                                          |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
-|                          |                                        |              |              |                                           | implementation is required to ignore the |
-|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
-|                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
-|                          |                                        |              |              | <single-xml-polling-location>`s. If early | it. However, the implementation should   |
-|                          |                                        |              |              | vote centers or ballot drop locations are | still check to see if there are any      |
-|                          |                                        |              |              | locality-wide, they should be specified   | polling locations associated with this   |
-|                          |                                        |              |              | here.                                     | locality's state.                        |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| StateId                  | ``xs:IDREF``                           | **Required** | Single       | References the locality's                 | If the field is invalid, then the        |
-|                          |                                        |              |              | :ref:`single-xml-state`.                  | implementation is required to ignore the |
-|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| Type                     | :ref:`single-xml-district-type`        | Optional     | Single       | Defines the kind of locality (e.g.        | If the field is invalid or not present,  |
-|                          |                                        |              |              | county, town, et al.), which is one of    | then the implementation is required to   |
-|                          |                                        |              |              | the various :ref:`DistrictType            | ignore it.                               |
-|                          |                                        |              |              | enumerations <single-xml-district-type>`. |                                          |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-| OtherType                | ``xs:string``                          | Optional     | Single       | Allows for defining a type of locality    | If the field is invalid or not present,  |
-|                          |                                        |              |              | that falls outside the options listed in  | then the implementation is required to   |
-|                          |                                        |              |              | :ref:`DistrictType                        | ignore it.                               |
-|                          |                                        |              |              | <single-xml-district-type>`.              |                                          |
-+--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
-
-.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-.. code-block:: xml
-   :linenos:
-
-   <Locality id="loc70001">
-     <ElectionAdministrationId>ea40001</ElectionAdministrationId>
-     <ExternalIdentifiers>
-       <ExternalIdentifier>
-         <Type>ocd-id</Type>
-         <Value>ocd-division/country:us/state:va/county:albemarle</Value>
-       </ExternalIdentifier>
-     </ExternalIdentifiers>
-     <IsMailOnly>true</IsMailOnly>
-     <Name>ALBEMARLE COUNTY</Name>
-     <StateId>st51</StateId>
-     <Type>county</Type>
-   </Locality>
 
 
 .. _single-xml-department:
@@ -1785,351 +889,106 @@ address like the following::
    </ContactInformation>
 
 
-.. _single-xml-html-color-string:
+.. _single-xml-election:
 
-HtmlColorString
-~~~~~~~~~~~~~~~
+Election
+~~~~~~~~
 
-A restricted string pattern for a six-character hex code representing an HTML
-color string. The pattern is:
+The Election object represents an Election Day, which usually consists of many individual contests
+and/or referenda. A feed must contain **exactly one** Election object. All relationships in the
+feed (e.g., street segment to precinct to polling location) are assumed to relate only to
+the Election specified by this object. It is permissible, and recommended, to combine unrelated
+contests (e.g., a special election and a general election) that occur on the same day into one feed
+with one Election object.
 
-``[0-9a-f]{6}``
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                        | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++============================+==========================================+==============+==============+==========================================+==========================================+
+| Date                       | ``xs:date``                              | **Required** | Single       | Specifies when the election is being     | If the field is invalid, then the        |
+|                            |                                          |              |              | held. The `Date` is considered to be in  | implementation is required to ignore the |
+|                            |                                          |              |              | the timezone local to the state holding  | ``Election`` element containing it.      |
+|                            |                                          |              |              | the election.                            |                                          |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionType               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies the highest controlling        | If the element is invalid or not         |
+|                            |                                          |              |              | authority for election (e.g., federal,   | present, then the implementation is      |
+|                            |                                          |              |              | state, county, city, town, etc.)         | required to ignore it.                   |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StateId                    | ``xs:IDREF``                             | **Required** | Single       | Specifies a link to the `State` element  | If the field is invalid, then the        |
+|                            |                                          |              |              | where the election is being held.        | implementation is required to ignore the |
+|                            |                                          |              |              |                                          | ``Election`` element containing it.      |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsStatewide                | ``xs:boolean``                           | Optional     | Single       | Indicates whether the election is        | If the field is not present or invalid,  |
+|                            |                                          |              |              | statewide.                               | the implementation is required to        |
+|                            |                                          |              |              |                                          | default to "yes".                        |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                       | :ref:`single-xml-internationalized-text` | Optional     | Single       | The name for the election (**NB:** while | If the element is invalid or not         |
+|                            |                                          |              |              | optional, this element is highly         | present, then the implementation is      |
+|                            |                                          |              |              | recommended).                            | required to ignore it.                   |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RegistrationInfo           | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies information about registration | If the element is invalid or not         |
+|                            |                                          |              |              | for this election either as text or a    | present, then the implementation is      |
+|                            |                                          |              |              | URI.                                     | required to ignore it.                   |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AbsenteeBallotInfo         | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies information about requesting   | If the element is invalid or not         |
+|                            |                                          |              |              | absentee ballots either as text or a URI | present, then the implementation is      |
+|                            |                                          |              |              |                                          | required to ignore it.                   |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ResultsUri                 | ``xs:anyURI``                            | Optional     | Single       | Contains a URI where results for the     | If the field is invalid or not present,  |
+|                            |                                          |              |              | election may be found                    | then the implementation is required to   |
+|                            |                                          |              |              |                                          | ignore it.                               |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingHours               | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**           |                                          |              |              | Election Day polling locations are open. | present, then the implementation is      |
+|                            |                                          |              |              | If polling hours differ in specific      | required to ignore it.                   |
+|                            |                                          |              |              | polling locations, alternative hours may |                                          |
+|                            |                                          |              |              | be specified in the                      |                                          |
+|                            |                                          |              |              | :ref:`single-xml-polling-location`       |                                          |
+|                            |                                          |              |              | object *(NB: this element is deprecated  |                                          |
+|                            |                                          |              |              | in favor of the more structured          |                                          |
+|                            |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
+|                            |                                          |              |              | is strongly encouraged that data         |                                          |
+|                            |                                          |              |              | providers move toward contributing hours |                                          |
+|                            |                                          |              |              | in this format)*.                        |                                          |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId                | ``xs:IDREF``                             | Optional     | Single       | References the                           | If the field is invalid or not present,  |
+|                            |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
+|                            |                                          |              |              | which lists the hours of operation for   | ignore it.                               |
+|                            |                                          |              |              | polling locations.                       |                                          |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasElectionDayRegistration | ``xs:boolean``                           | Optional     | Single       | Specifies if a voter can register on the | If the field is invalid or not present,  |
+|                            |                                          |              |              | same day of the election (i.e., the last | then the implementation is required to   |
+|                            |                                          |              |              | day of the election). Valid items are    | ignore it.                               |
+|                            |                                          |              |              | "yes" and "no".                          |                                          |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| RegistrationDeadline       | ``xs:date``                              | Optional     | Single       | Specifies the last day to register for   | If the field is invalid or not present,  |
+|                            |                                          |              |              | the election with the possible exception | then the implementation is required to   |
+|                            |                                          |              |              | of Election Day registration.            | ignore it.                               |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AbsenteeRequestDeadline    | ``xs:date``                              | Optional     | Single       | Specifies the last day to request an     | If the field is invalid or not present,  |
+|                            |                                          |              |              | absentee ballot.                         | then the implementation is required to   |
+|                            |                                          |              |              |                                          | ignore it.                               |
++----------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:
 
-   <Party id="par0001">
-     <Abbreviation>REP</Abbreviation>
-     <Color>e91d0e</Color>
+   <Election id="ele30000">
+     <AbsenteeRequestDeadline>2013-10-30</AbsenteeRequestDeadline>
+     <Date>2013-11-05</Date>
+     <ElectionType>
+       <Text language="en">General</Text>
+       <Text language="es">Generales</Text>
+     </ElectionType>
+     <HasElectionDayRegistration>false</HasElectionDayRegistration>
+     <HoursOpenId>hours0001</HoursOpenId>
+     <IsStatewide>true</IsStatewide>
      <Name>
-       <Text language="en">Republican</Text>
+       <Text language="en">2013 Statewide General</Text>
      </Name>
-   </Party>
-
-
-.. _single-xml-schedule:
-
-Schedule
-~~~~~~~~
-
-A sub-portion of the schedule. This describes a range of days, along with one or
-more set of open and close times for those days, as well as the options
-describing whether or not appointments are necessary or possible.
-
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=========================+==============+==============+==========================================+==========================================+
-| Hours               | :ref:`single-xml-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
-|                     |                         |              |              | which the place is open.                 | present, then the implementation is      |
-|                     |                         |              |              |                                          | required to ignore it.                   |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsOnlyByAppointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
-|                     |                         |              |              | the specified time window with an        | then the implementation is required to   |
-|                     |                         |              |              | appointment.                             | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsOrByAppointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
-|                     |                         |              |              | hours specified time window and may also | then the implementation is required to   |
-|                     |                         |              |              | be open with an appointment.             | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsSubjectToChange   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
-|                     |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
-|                     |                         |              |              | subject to change. People should contact | ignore it.                               |
-|                     |                         |              |              | prior to arrival to confirm hours are    |                                          |
-|                     |                         |              |              | still accurate.                          |                                          |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StartDate           | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                     |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
-|                     |                         |              |              |                                          | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndDate             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                     |                         |              |              | start and end times and options end.     | then the implementation is required to   |
-|                     |                         |              |              |                                          | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-hours:
-
-Hours
-^^^^^
-
-The open and close time for this place. All times must be fully specified,
-including a timezone offset from UTC.
-
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==================================+==============+==============+==========================================+==========================================+
-| StartTime    | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndTime      | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-time-with-zone:
-
-TimeWithZone
-%%%%%%%%%%%%
-
-A string pattern restricting the value to a time with an included offset from
-UTC. The pattern is
-
-``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
-
-.. code-block:: xml
-   :linenos:
-
-   <HoursOpen id="hours0001">
-     <Schedule>
-       <Hours>
-         <StartTime>06:00:00-05:00</StartTime>
-         <EndTime>12:00:00-05:00</EndTime>
-       </Hours>
-       <Hours>
-         <StartTime>13:00:00-05:00</StartTime>
-         <EndTime>19:00:00-05:00</EndTime>
-       </Hours>
-       <StartDate>2013-11-05</StartDate>
-       <EndDate>2013-11-05</EndDate>
-     </Schedule>
-   </HoursOpen>
-
-
-.. _single-xml-precinct:
-
-Precinct
-~~~~~~~~
-
-The Precinct object represents a precinct, which is contained within a Locality. While the id
-attribute does not have to be static across feeds for one election, the combination of
-:ref:`Source.VipId <single-xml-source>`, :ref:`Locality.Name <single-xml-locality>`, :ref:`Precinct.Ward <single-xml-precinct>`,
-:ref:`Precinct.Name <single-xml-precinct>`, and :ref:`Precinct.Number <single-xml-precinct>` should remain constant across
-feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
-non-required fields is fine).
-
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+======================+========================================+==============+==============+==========================================+==========================================+
-| BallotStyleId        | ``xs:IDREF``                           | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
-|                      |                                        |              |              | :ref:`single-xml-ballot-style`, which a  | then the implementation is required to   |
-|                      |                                        |              |              | person who lives in this precinct will   | ignore it.                               |
-|                      |                                        |              |              | vote.                                    |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictIds | ``xs:IDREFS``                          | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
-|                      |                                        |              |              | :ref:`single-xml-electoral-district`s    | then the implementation is required to   |
-|                      |                                        |              |              | (e.g., congressional district, state     | ignore it.                               |
-|                      |                                        |              |              | house district, school board district)   |                                          |
-|                      |                                        |              |              | to which the entire precinct/precinct    |                                          |
-|                      |                                        |              |              | split belongs. **Highly Recommended** if |                                          |
-|                      |                                        |              |              | candidate information is to be provided. |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers  | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
-|                      |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
-|                      |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsMailOnly           | ``xs:boolean``                         | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
-|                      |                                        |              |              | mail-only elections.                     | implementation is required to assume     |
-|                      |                                        |              |              |                                          | `IsMailOnly` is false.                   |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LocalityId           | ``xs:IDREF``                           | **Required** | Single       | Links to the :ref:`single-xml-locality`  | If the field is invalid, then the        |
-|                      |                                        |              |              | that comprises the precinct.             | implementation is required to ignore the |
-|                      |                                        |              |              |                                          | ``Precinct`` element containing it.      |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                 | ``xs:string``                          | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid, then the        |
-|                      |                                        |              |              | if no name exists).                      | implementation is required to ignore the |
-|                      |                                        |              |              |                                          | ``Precinct`` element containing it.      |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Number               | ``xs:string``                          | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
-|                      |                                        |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
-|                      |                                        |              |              | legal). Should be used if the `Name`     | ignore it.                               |
-|                      |                                        |              |              | field is populated by a name and not a   |                                          |
-|                      |                                        |              |              | number.                                  |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PollingLocationIds   | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the precinct's       | If the field is invalid or not present,  |
-|                      |                                        |              |              | :ref:`single-xml-polling-location`       | then the implementation is required to   |
-|                      |                                        |              |              | object(s).                               | ignore it.                               |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PrecinctSplitName    | ``xs:string``                          | Optional     | Single       | If this field is empty, then this        | If the field is invalid or not present,  |
-|                      |                                        |              |              | `Precinct` object represents a full      | then the implementation is required to   |
-|                      |                                        |              |              | precinct. If this field is present, then | ignore it.                               |
-|                      |                                        |              |              | this `Precinct` object represents one    |                                          |
-|                      |                                        |              |              | portion of a split precinct. Each        |                                          |
-|                      |                                        |              |              | `Precinct` object that represents one    |                                          |
-|                      |                                        |              |              | portion of a split precinct **must**     |                                          |
-|                      |                                        |              |              | have the same `Name` value, but          |                                          |
-|                      |                                        |              |              | different `PrecinctSplitName` values.    |                                          |
-|                      |                                        |              |              | See the `sample_feed.xml` file for       |                                          |
-|                      |                                        |              |              | examples.                                |                                          |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Ward                 | ``xs:string``                          | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
-|                      |                                        |              |              | contained within.                        | then the implementation is required to   |
-|                      |                                        |              |              |                                          | ignore it.                               |
-+----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-.. code-block:: xml
-   :linenos:
-
-   <Precinct id="pre90111">
-      <BallotStyleId>bs00010</BallotStyleId>
-      <ElectoralDistrictIds>ed60129 ed60311 ed60054</ElectoralDistrictIds>
-      <IsMailOnly>false</IsMailOnly>
-      <LocalityId>loc70001</LocalityId>
-      <Name>203 - GEORGETOWN</Name>
-      <Number>0203</Number>
-      <PollingLocationIds>pl81274</PollingLocationIds>
-   </Precinct>
-   <!--
-     Precinct split. Name and PollingLocationIds are the same but
-     PrecinctSplitName is present, the ElectoralDistrictIds are different,
-     and the BallotStyleId is different.
-   -->
-   <Precinct id="pre90348sp0000">
-     <BallotStyleId>bs00002</BallotStyleId>
-     <ElectoralDistrictIds>ed60129 ed60054 ed60150</ElectoralDistrictIds>
-     <IsMailOnly>false</IsMailOnly>
-     <LocalityId>loc70001</LocalityId>
-     <Name>201 - JACK JOUETT</Name>
-     <Number>0201</Number>
-     <PollingLocationIds>pl00000 pl81273 pl81662</PollingLocationIds>
-     <PrecinctSplitName>0000</PrecinctSplitName>
-   </Precinct>
-   <Precinct id="pre90348sp0001">
-     <BallotStyleId>bs00015</BallotStyleId>
-     <ElectoralDistrictIds>ed60129 ed60054 ed60267</ElectoralDistrictIds>
-     <IsMailOnly>false</IsMailOnly>
-     <LocalityId>loc70001</LocalityId>
-     <Name>201 - JACK JOUETT</Name>
-     <Number>0201</Number>
-     <PollingLocationIds>pl00000 pl81273 pl81662</PollingLocationIds>
-     <PrecinctSplitName>0001</PrecinctSplitName>
-   </Precinct>
-
-
-.. _single-xml-ordered-contest:
-
-OrderedContest
-~~~~~~~~~~~~~~
-
-``OrderedContest`` encapsulates links to the information that comprises a contest and potential
-ballot selections. ``OrderedContest`` elements can be collected within a
-:ref:`single-xml-ballot-style` to accurate depict exactly what will show up on a particular
-ballot in the proper order.
-
-+---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-| Tag                       | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                                   |
-+===========================+===============+==============+==============+==========================================+==================================================+
-| ContestId                 | ``xs:IDREF``  | **Required** | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
-|                           |               |              |              | :ref:`single-xml-contest-base`.          | implementation is required to ignore the         |
-|                           |               |              |              |                                          | ``OrderedContest`` element containing it.        |
-+---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-| OrderedBallotSelectionIds | ``xs:IDREFS`` | Optional     | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
-|                           |               |              |              | :ref:`single-xml-ballot-selection-base`. | implementation is required to ignore it. If an   |
-|                           |               |              |              |                                          | ``OrderedBallotSelectionIds`` element is not     |
-|                           |               |              |              |                                          | present, the presumed order of the selection     |
-|                           |               |              |              |                                          | will be the order of                             |
-|                           |               |              |              |                                          | :ref:`single-xml-ballot-selection-base`-extended |
-|                           |               |              |              |                                          | elements referenced by the underlying            |
-|                           |               |              |              |                                          | :ref:`single-xml-contest-base`-extended          |
-|                           |               |              |              |                                          | elements.                                        |
-+---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <OrderedContest id="oc20003abc">
-      <ContestId>cc20003</ContestId>
-      <OrderedBallotSelectionIds>cs10961 cs10962 cs10963</OrderedBallotSelectionIds>
-   </OrderedContest>
-
-
-.. _single-xml-party-contest:
-
-PartyContest
-~~~~~~~~~~~~
-
-An extension of :ref:`single-xml-contest-base` which describes a contest in
-which the possible ballot selections are of type :ref:`single-xml-party-selection`. These could include contests in which straight-party
-selections are allowed, or party-list contests (although these are more common
-outside of the United States).
-
-
-.. _single-xml-contest-base:
-
-ContestBase
-^^^^^^^^^^^
-
-A base model for all Contest types: :ref:`single-xml-ballot-measure-contest`,
-:ref:`single-xml-candidate-contest`, :ref:`single-xml-party-contest`,
-and :ref:`single-xml-retention-contest` (NB: the latter because it extends
-:ref:`single-xml-ballot-measure-contest`).
-
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                     | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=========================+==========================================+==============+==============+==========================================+==========================================+
-| Abbreviation            | ``xs:string``                            | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
-|                         |                                          |              |              |                                          | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSelectionIds      | ``xs:IDREFS``                            | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
-|                         |                                          |              |              | which could be of any selection type     | then the implementation should ignore    |
-|                         |                                          |              |              | that extends                             | it.                                      |
-|                         |                                          |              |              | :ref:`single-xml-ballot-selection-base`. |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSubTitle          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
-|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotTitle             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
-|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId     | ``xs:IDREF``                             | **Required** | Single       | References an                            | If the field is invalid, then the        |
-|                         |                                          |              |              | :ref:`single-xml-electoral-district`     | implementation is required to ignore the |
-|                         |                                          |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
-|                         |                                          |              |              | scope of the contest.                    |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectorateSpecification | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
-|                         |                                          |              |              | electorate for this contest past the     | present, then the implementation should  |
-|                         |                                          |              |              | usual, "all registered voters"           | ignore it.                               |
-|                         |                                          |              |              | electorate. This subtag will most often  |                                          |
-|                         |                                          |              |              | be used for primaries and local          |                                          |
-|                         |                                          |              |              | elections. In primaries, voters may have |                                          |
-|                         |                                          |              |              | to be registered as a specific party to  |                                          |
-|                         |                                          |              |              | vote, or there may be special rules for  |                                          |
-|                         |                                          |              |              | which ballot a voter can pull. In some   |                                          |
-|                         |                                          |              |              | local elections, non-citizens can vote.  |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers     | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
-|                         |                                          |              |              | links to another source of information.  | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HasRotation             | ``xs:boolean``                           | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
-|                         |                                          |              |              | contest are rotated.                     | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                    | ``xs:string``                            | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
-|                         |                                          |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
-|                         |                                          |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
-|                         |                                          |              |              | purpose).                                |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| SequenceOrder           | ``xs:integer``                           | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
-|                         |                                          |              |              | on the ballot. This is the default       | then the implementation should ignore    |
-|                         |                                          |              |              | ordering, and can be overrides by data   | it.                                      |
-|                         |                                          |              |              | in a :ref:`single-xml-ballot-style`      |                                          |
-|                         |                                          |              |              | element.                                 |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VoteVariation           | :ref:`single-xml-vote-variation`         | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
-|                         |                                          |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherVoteVariation      | ``xs:string``                            | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
-|                         |                                          |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
-|                         |                                          |              |              | variation can be specified here.         | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+     <RegistrationDeadline>2013-10-15</RegistrationDeadline>
+     <ResultsUri>http://www.sbe.virginia.gov/ElectionResults.html</ResultsUri>
+     <StateId>st51</StateId>
+   </Election>
 
 
 .. _single-xml-election-administration:
@@ -2435,6 +1294,178 @@ VoterService
 +--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
+.. _single-xml-election-notice:
+
+ElectionNotice
+~~~~~~~~~~~~~~
+
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==========================================+==============+==============+==========================================+==========================================+
+| NoticeText   | :ref:`single-xml-internationalized-text` | **Required** | Single       | The last minute or emergency             | If the element is invalid, then the      |
+|              |                                          |              |              | notification text should be placed here. | implementation is required to ignore the |
+|              |                                          |              |              |                                          | ``ElectionNotice`` element containing    |
+|              |                                          |              |              |                                          | it.                                      |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| NoticeUri    | ``xs:anyURI``                            | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
+|              |                                          |              |              | related to the last minute or emergency  | then the implementation is required to   |
+|              |                                          |              |              | notification.                            | ignore it.                               |
++--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-electoral-district:
+
+ElectoralDistrict
+~~~~~~~~~~~~~~~~~
+
+The ``ElectoralDistrict`` object represents the geographic area in which contests are held. Examples
+of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congressional District",
+or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
+which precincts link to the ``ElectoralDistrict``.
+
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+========================================+==============+==============+==========================================+==========================================+
+| ExternalIdentifiers | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
+|                     |                                        |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
+|                     |                                        |              |              |                                          | required to ignore it.                   |
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | ``xs:string``                          | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
+|                     |                                        |              |              |                                          | then the implementation is required to   |
+|                     |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                        |              |              |                                          | containing it.                           |
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number              | ``xs:integer``                         | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
+|                     |                                        |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
+|                     |                                        |              |              | 34th State Senate District). If a number | ignore it.                               |
+|                     |                                        |              |              | is not applicable, instead of leaving    |                                          |
+|                     |                                        |              |              | the field blank, leave this field out of |                                          |
+|                     |                                        |              |              | the object; empty strings are not valid  |                                          |
+|                     |                                        |              |              | for xs:integer fields.                   |                                          |
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                | :ref:`single-xml-district-type`        | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
+|                     |                                        |              |              |                                          | then the implementation is required to   |
+|                     |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
+|                     |                                        |              |              |                                          | containing it.                           |
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType           | ``xs:string``                          | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
+|                     |                                        |              |              | :ref:`single-xml-district-type` option   | then the implementation is required to   |
+|                     |                                        |              |              | when ``Type`` is specified as "other".   | ignore it.                               |
++---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+.. code-block:: xml
+   :linenos:
+
+   <ElectoralDistrict id="ed60129">
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va</Value>
+        </ExternalIdentifier>
+        <ExternalIdentifier>
+          <Type>fips</Type>
+          <Value>51</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>Commonwealth of Virginia</Name>
+      <Type>state</Type>
+   </ElectoralDistrict>
+
+
+.. _single-xml-external-identifier:
+
+ExternalIdentifier
+~~~~~~~~~~~~~~~~~~
+
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===================================+==============+==============+==========================================+==========================================+
+| Type         | :ref:`single-xml-identifier-type` | **Required** | Single       | Specifies the type of identifier. Must   | If the field is invalid or not present,  |
+|              |                                   |              |              | be one of the valid types as defined by  | the implementation is required to ignore |
+|              |                                   |              |              | :ref:`single-xml-identifier-type`.       | the ``ElectionIdentifier`` containing    |
+|              |                                   |              |              |                                          | it.                                      |
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType    | ``xs:string``                     | Optional     | Single       | Allows for cataloging an                 | If the field is invalid or not present,  |
+|              |                                   |              |              | ``ExternalIdentifier`` type that falls   | then the implementation is required to   |
+|              |                                   |              |              | outside the options listed in            | ignore it.                               |
+|              |                                   |              |              | :ref:`single-xml-identifier-type`.       |                                          |
+|              |                                   |              |              | ``Type`` should be set to "other" when   |                                          |
+|              |                                   |              |              | using this field.                        |                                          |
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Value        | ``xs:string``                     | **Required** | Single       | Specifies the identifier.                | If the field is invalid or not present,  |
+|              |                                   |              |              |                                          | the implementation is required to ignore |
+|              |                                   |              |              |                                          | the ``ElectionIdentifier`` containing    |
+|              |                                   |              |              |                                          | it.                                      |
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <ExternalIdentifiers>
+      <ExternalIdentifier>
+         <Type>ocd-id</Type>
+         <Value>ocd-division/country:us/state:nc/county:durham</Value>
+      </ExternalIdentifier>
+      <ExternalIdentifier>
+         <Type>FIPS</Type>
+         <Value>37063</Value>
+      </ExternalIdentifier>
+      <ExternalIdentifier>
+         <Type>OTHER</Type>
+         <OtherType>GNIS</OtherType>
+         <Value>1008550</Value>
+      </ExternalIdentifier>
+      <external_identifer>
+         <Type>OTHER</Type>
+         <OtherType>census</OtherType>
+         <Value>99063</Value>
+      </ExternalIdentifier>
+   </ExternalIdentifiers>
+
+
+.. _single-xml-external-identifiers:
+
+ExternalIdentifiers
+~~~~~~~~~~~~~~~~~~~
+
+The ``ExternalIdentifiers`` element allows VIP data to connect with external datasets (e.g.
+candidates with campaign finance datasets, electoral geographies with `OCD-IDs`_ that allow for
+greater connectivity with additional datasets, etc...). Examples for ``ExternalIdentifiers`` can be
+found on the objects that support them:
+
+* :ref:`single-xml-candidate`
+
+* Any element that extends :ref:`single-xml-contest-base`
+
+* :ref:`single-xml-electoral-district`
+
+* :ref:`single-xml-locality`
+
+* :ref:`single-xml-office`
+
+* :ref:`single-xml-party`
+
+* :ref:`single-xml-precinct`
+
+* :ref:`single-xml-state`
+
+.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
++--------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                | Data Type                             | Required?    | Repeats?     | Description                              | Error Handling                           |
++====================+=======================================+==============+==============+==========================================+==========================================+
+| ExternalIdentifier | :ref:`single-xml-external-identifier` | **Required** | Repeats      | Defines the identifier and the type of   | At least one valid `ExternalIdentifier`_ |
+|                    |                                       |              |              | identifier it is (see                    | must be present for                      |
+|                    |                                       |              |              | `ExternalIdentifier`_ for complete       | ``ExternalIdentifiers`` to be valid. If  |
+|                    |                                       |              |              | information).                            | no valid `ExternalIdentifier`_ is        |
+|                    |                                       |              |              |                                          | present, the implementation is required  |
+|                    |                                       |              |              |                                          | to ignore the ``ExternalIdentifiers``    |
+|                    |                                       |              |              |                                          | element.                                 |
++--------------------+---------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
 .. _single-xml-hours:
 
 Hours
@@ -2485,23 +1516,1189 @@ UTC. The pattern is
    </HoursOpen>
 
 
-.. _single-xml-election-notice:
+.. _single-xml-hours-open:
 
-ElectionNotice
+HoursOpen
+~~~~~~~~~
+
+A structured way of describing the days and hours that a place such as a
+:ref:`single-xml-office` or :ref:`single-xml-polling-location` is open, or
+that an event such as an :ref:`single-xml-election` is happening. The range of days
+indicated by the `StartDate` and `EndDate` in each `Schedule`_ element
+should not overlap with peer `Schedule`_ elements. For example, it is
+invalid to specify a schedule from 10/01/2016 to 10/31/2016 and also
+specify a schedule from 10/10/2016 to 10/11/2016 within the same `HoursOpen`
+element.
+
++--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                  | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+============================+==============+==============+==========================================+==========================================+
+| Schedule     | :ref:`single-xml-schedule` | **Required** | Repeats      | Defines a block of days and hours that a | At least one valid `Schedule`_ must be   |
+|              |                            |              |              | place will be open.                      | present for ``HoursOpen`` to be valid.   |
+|              |                            |              |              |                                          | If no valid `Schedule`_ is present, the  |
+|              |                            |              |              |                                          | implementation is required to ignore the |
+|              |                            |              |              |                                          | ``HoursOpen`` element.                   |
++--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-schedule:
+
+Schedule
+^^^^^^^^
+
+A sub-portion of the schedule. This describes a range of days, along with one or
+more set of open and close times for those days, as well as the options
+describing whether or not appointments are necessary or possible.
+
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=========================+==============+==============+==========================================+==========================================+
+| Hours               | :ref:`single-xml-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
+|                     |                         |              |              | which the place is open.                 | present, then the implementation is      |
+|                     |                         |              |              |                                          | required to ignore it.                   |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOnlyByAppointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
+|                     |                         |              |              | the specified time window with an        | then the implementation is required to   |
+|                     |                         |              |              | appointment.                             | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOrByAppointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
+|                     |                         |              |              | hours specified time window and may also | then the implementation is required to   |
+|                     |                         |              |              | be open with an appointment.             | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsSubjectToChange   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
+|                     |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
+|                     |                         |              |              | subject to change. People should contact | ignore it.                               |
+|                     |                         |              |              | prior to arrival to confirm hours are    |                                          |
+|                     |                         |              |              | still accurate.                          |                                          |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate           | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
+|                     |                         |              |              |                                          | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |                         |              |              | start and end times and options end.     | then the implementation is required to   |
+|                     |                         |              |              |                                          | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-hours:
+
+Hours
+%%%%%
+
+The open and close time for this place. All times must be fully specified,
+including a timezone offset from UTC.
+
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==================================+==============+==============+==========================================+==========================================+
+| StartTime    | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndTime      | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-time-with-zone:
+
+TimeWithZone
+^^^^^^^^^^^^
+
+A string pattern restricting the value to a time with an included offset from
+UTC. The pattern is
+
+``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
+
+.. code-block:: xml
+   :linenos:
+
+   <HoursOpen id="hours0001">
+     <Schedule>
+       <Hours>
+         <StartTime>06:00:00-05:00</StartTime>
+         <EndTime>12:00:00-05:00</EndTime>
+       </Hours>
+       <Hours>
+         <StartTime>13:00:00-05:00</StartTime>
+         <EndTime>19:00:00-05:00</EndTime>
+       </Hours>
+       <StartDate>2013-11-05</StartDate>
+       <EndDate>2013-11-05</EndDate>
+     </Schedule>
+   </HoursOpen>
+
+
+.. _single-xml-html-color-string:
+
+HtmlColorString
+~~~~~~~~~~~~~~~
+
+A restricted string pattern for a six-character hex code representing an HTML
+color string. The pattern is:
+
+``[0-9a-f]{6}``
+
+.. code-block:: xml
+   :linenos:
+
+   <Party id="par0001">
+     <Abbreviation>REP</Abbreviation>
+     <Color>e91d0e</Color>
+     <Name>
+       <Text language="en">Republican</Text>
+     </Name>
+   </Party>
+
+
+.. _single-xml-internationalized-text:
+
+InternationalizedText
+~~~~~~~~~~~~~~~~~~~~~
+
+``InternationalizedText`` allows for support of multiple languages for a string.
+``InternationalizedText`` has an optional attribute ``label``, which allows the feed to refer
+back to the original label for the information (e.g. if the contact information came from a
+CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can be seen in:
+* Any element that extends :ref:`single-xml-contest-base`
+* Any element that extends :ref:`single-xml-ballot-selection-base`
+* :ref:`single-xml-candidate`
+* :ref:`single-xml-contact-information`
+* :ref:`single-xml-election`
+* :ref:`single-xml-election-administration`
+* :ref:`single-xml-office`
+* :ref:`single-xml-party`
+* :ref:`single-xml-person`
+* :ref:`single-xml-polling-location`
+* :ref:`single-xml-source`
+NOTE: Internationalized Text is not currently supported for CSV submissions. 
+
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===================================+==============+==============+==========================================+==========================================+
+| Text         | :ref:`single-xml-language-string` | **Required** | Repeats      | Contains the translations of a           | At least one valid ``Text`` must be      |
+|              |                                   |              |              | particular string of text.               | present for ``InternationalizedText`` to |
+|              |                                   |              |              |                                          | be valid. If no valid ``Text`` is        |
+|              |                                   |              |              |                                          | present, the implementation is required  |
+|              |                                   |              |              |                                          | to ignore the ``InternationalizedText``  |
+|              |                                   |              |              |                                          | element.                                 |
++--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-language-string:
+
+LanguageString
 ~~~~~~~~~~~~~~
 
-+--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==========================================+==============+==============+==========================================+==========================================+
-| NoticeText   | :ref:`single-xml-internationalized-text` | **Required** | Single       | The last minute or emergency             | If the element is invalid, then the      |
-|              |                                          |              |              | notification text should be placed here. | implementation is required to ignore the |
-|              |                                          |              |              |                                          | ``ElectionNotice`` element containing    |
-|              |                                          |              |              |                                          | it.                                      |
-+--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| NoticeUri    | ``xs:anyURI``                            | Optional     | Single       | Optional URL for additional information  | If the field is invalid or not present,  |
-|              |                                          |              |              | related to the last minute or emergency  | then the implementation is required to   |
-|              |                                          |              |              | notification.                            | ignore it.                               |
-+--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+``LanguageString`` extends xs:string and can contain text from any language. ``LanguageString``
+has one required attribute, ``language``, that must contain the 2-character `language code`_ for the
+type of language ``LanguageString`` contains.
+
+.. _`language code`: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+
+.. code-block:: xml
+   :linenos:
+
+   <BallotTitle>
+      <Text language="en">Retention of Supreme Court Justice</Text>
+      <Text language="es">La retención de juez de la Corte Suprema</Text>
+   </BallotTitle>
+
+
+.. _single-xml-lat-lng:
+
+LatLng
+~~~~~~
+
+The latitude and longitude of a polling location in `WGS 84`_ format. Both
+latitude and longitude values are measured in decimal degrees.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| Latitude     | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
+|              |               |              |              |                                          | implementation is required to ignore it. |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Longitude    | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
+|              |               |              |              |                                          | implementation is required to ignore it. |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Source       | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
+|              |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
+|              |               |              |              | example, this could be the name of a     | ignore it.                               |
+|              |               |              |              | geocoding service.                       |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-locality:
+
+Locality
+~~~~~~~~
+
+The Locality object represents the jurisdiction below the :ref:`single-xml-state` (e.g. county).
+
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                              | Required?    | Repeats?     | Description                               | Error Handling                           |
++==========================+========================================+==============+==============+===========================================+==========================================+
+| ElectionAdministrationId | ``xs:IDREF``                           | Optional     | Single       | Links to the locality's                   | If the field is invalid or not present,  |
+|                          |                                        |              |              | :ref:`single-xml-election-administration` | then the implementation is required to   |
+|                          |                                        |              |              | object.                                   | ignore it.                               |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :ref:`single-xml-external-identifiers` | Optional     | Single       | Another identifier for a locality that    | If the element is invalid or not         |
+|                          |                                        |              |              | links to another dataset (e.g. `OCD-ID`_) | present, then the implementation is      |
+|                          |                                        |              |              |                                           | required to ignore it.                   |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| IsMailOnly               | ``xs:boolean``                         | Optional     | Single       | Determines if the locality runs mail-only | If the field is missing or invalid, the  |
+|                          |                                        |              |              | elections. If this is true, then all      | implementation is required to assume     |
+|                          |                                        |              |              | precincts a part of the locality will     | `IsMailOnly` is false.                   |
+|                          |                                        |              |              | also run mail-only elections. Drop boxes  |                                          |
+|                          |                                        |              |              | may be used in addition to this flag      |                                          |
+|                          |                                        |              |              | using a :ref:`polling location            |                                          |
+|                          |                                        |              |              | <single-xml-polling-location>` record     |                                          |
+|                          |                                        |              |              | configured as a Drop Box.                 |                                          |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifies the name of a locality.         | If the field is invalid, then the        |
+|                          |                                        |              |              |                                           | implementation is required to ignore the |
+|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to a set of the          | If the field is invalid or not present,  |
+|                          |                                        |              |              | locality's :ref:`polling locations        | the implementation is required to ignore |
+|                          |                                        |              |              | <single-xml-polling-location>`s. If early | it. However, the implementation should   |
+|                          |                                        |              |              | vote centers or ballot drop locations are | still check to see if there are any      |
+|                          |                                        |              |              | locality-wide, they should be specified   | polling locations associated with this   |
+|                          |                                        |              |              | here.                                     | locality's state.                        |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| StateId                  | ``xs:IDREF``                           | **Required** | Single       | References the locality's                 | If the field is invalid, then the        |
+|                          |                                        |              |              | :ref:`single-xml-state`.                  | implementation is required to ignore the |
+|                          |                                        |              |              |                                           | ``Locality`` element containing it.      |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| Type                     | :ref:`single-xml-district-type`        | Optional     | Single       | Defines the kind of locality (e.g.        | If the field is invalid or not present,  |
+|                          |                                        |              |              | county, town, et al.), which is one of    | then the implementation is required to   |
+|                          |                                        |              |              | the various :ref:`DistrictType            | ignore it.                               |
+|                          |                                        |              |              | enumerations <single-xml-district-type>`. |                                          |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+| OtherType                | ``xs:string``                          | Optional     | Single       | Allows for defining a type of locality    | If the field is invalid or not present,  |
+|                          |                                        |              |              | that falls outside the options listed in  | then the implementation is required to   |
+|                          |                                        |              |              | :ref:`DistrictType                        | ignore it.                               |
+|                          |                                        |              |              | <single-xml-district-type>`.              |                                          |
++--------------------------+----------------------------------------+--------------+--------------+-------------------------------------------+------------------------------------------+
+
+.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+.. code-block:: xml
+   :linenos:
+
+   <Locality id="loc70001">
+     <ElectionAdministrationId>ea40001</ElectionAdministrationId>
+     <ExternalIdentifiers>
+       <ExternalIdentifier>
+         <Type>ocd-id</Type>
+         <Value>ocd-division/country:us/state:va/county:albemarle</Value>
+       </ExternalIdentifier>
+     </ExternalIdentifiers>
+     <IsMailOnly>true</IsMailOnly>
+     <Name>ALBEMARLE COUNTY</Name>
+     <StateId>st51</StateId>
+     <Type>county</Type>
+   </Locality>
+
+
+.. _single-xml-office:
+
+Office
+~~~~~~
+
+``Office`` represents the office associated with a contest or district (e.g. Alderman, Mayor,
+School Board, et al).
+
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                   | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++=======================+==========================================+==============+==============+==========================================+==========================================+
+| ContactInformation    | :ref:`single-xml-contact-information`    | Optional     | Repeats      | Links to the                             | If the element is invalid or not         |
+|                       |                                          |              |              | :ref:`single-xml-contact-information`    | present, then the implementation is      |
+|                       |                                          |              |              | element associated with the office.      | required to ignore it.                   |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description           | :ref:`single-xml-internationalized-text` | Optional     | Single       | A brief description of the office and    | If the element is invalid or not         |
+|                       |                                          |              |              | its purpose.                             | present, then the implementation is      |
+|                       |                                          |              |              |                                          | required to ignore it.                   |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId   | ``xs:IDREF``                             | **Required** | Single       | Links to the                             | If the field is invalid or not present,  |
+|                       |                                          |              |              | :ref:`single-xml-electoral-district`     | the implementation is required to ignore |
+|                       |                                          |              |              | element associated with the office.      | the ``Office`` element containing it.    |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers   | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers that link this office  | If the element is invalid or not         |
+|                       |                                          |              |              | to other related datasets (e.g. campaign | present, then the implementation is      |
+|                       |                                          |              |              | finance systems, OCD IDs, et al.).       | required to ignore it.                   |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FilingDeadline        | ``xs:date``                              | Optional     | Single       | Specifies the date and time when a       | If the field is invalid or not present,  |
+|                       |                                          |              |              | candidate must have filed for the        | then the implementation is required to   |
+|                       |                                          |              |              | contest for the office.                  | ignore it.                               |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsPartisan            | ``xs:boolean``                           | Optional     | Single       | Indicates whether the office is          | If the field is invalid or not present,  |
+|                       |                                          |              |              | partisan.                                | then the implementation is required to   |
+|                       |                                          |              |              |                                          | ignore it.                               |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                  | :ref:`single-xml-internationalized-text` | **Required** | Single       | The name of the office.                  | If the field is invalid or not present,  |
+|                       |                                          |              |              |                                          | the implementation is required to ignore |
+|                       |                                          |              |              |                                          | the ``Office`` element containing it.    |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OfficeHolderPersonIds | ``xs:IDREFS``                            | Optional     | Single       | Links to the :ref:`single-xml-person`    | If the field is invalid or not present,  |
+|                       |                                          |              |              | element(s) that hold additional          | then the implementation is required to   |
+|                       |                                          |              |              | information about the current office     | ignore it.                               |
+|                       |                                          |              |              | holder(s).                               |                                          |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Term                  | :ref:`single-xml-term`                   | Optional     | Single       | Defines the term the office can be held. | If the element is invalid or not         |
+|                       |                                          |              |              |                                          | present, then the implementation is      |
+|                       |                                          |              |              |                                          | required to ignore it.                   |
++-----------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-term:
+
+Term
+^^^^
+
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+====================================+==============+==============+==========================================+==========================================+
+| Type         | :ref:`single-xml-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
+|              |                                    |              |              | :ref:`single-xml-office-term-type` for   | the implementation is required to ignore |
+|              |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate    | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
+|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                    |              |              |                                          | ignore it.                               |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate      | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
+|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                    |              |              |                                          | ignore it.                               |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <Office id="off0000">
+     <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+     <FilingDeadline>2013-01-01</FilingDeadline>
+     <IsPartisan>false</IsPartisan>
+     <Name>
+       <Text language="en">Governor</Text>
+     </Name>
+     <Term>
+       <Type>full-term</Type>
+     </Term>
+   </Office>
+
+
+.. _single-xml-contact-information:
+
+ContactInformation
+^^^^^^^^^^^^^^^^^^
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
+:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+==========================================+==============+==============+==========================================+==========================================+
+| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
+|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
+|                  |                                          |              |              | data providers move toward contributing  |                                          |
+|                  |                                          |              |              | hours in this format)*.                  |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
+|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
+|                  |                                          |              |              | location.                                |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|                  |                                          |              |              | location.                                | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _single-xml-name-address-line-usage:
+
+``Name`` and ``AddressLine`` Usage Note
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``Name`` and ``AddressLine`` fields should be chosen so that a display
+or mailing address can be constructed programmatically by joining the
+``Name`` and ``AddressLine`` fields together.  For example, for the
+following address::
+
+    Department of Elections
+    1 Dr. Carlton B. Goodlett Place, Room 48
+    San Francisco, CA 94102
+
+The name could be "Department of Elections" and the first address line
+could be "1 Dr. Carlton B. Goodlett Place, Room 48."
+
+However, VIP does not yet support the representation of mailing addresses
+whose "name" portion spans more than one line, for example::
+
+    California Secretary of State
+    Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+For addresses like the above, we recommend choosing a name like, "California
+Secretary of State, Elections Division" with "1500 11th Street" as the
+first address line. This would result in a programmatically constructed
+address like the following::
+
+    California Secretary of State, Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+.. code-block:: xml
+   :linenos:
+
+   <ContactInformation label="ci10861a">
+      <AddressLine>1600 Pennsylvania Ave</AddressLine>
+      <AddressLine>Washington, DC 20006</AddressLine>
+      <Email>president@whitehouse.gov</Email>
+      <Phone>202-456-1111</Phone>
+      <Phone annotation="TDD">202-456-6213</Phone>
+      <Uri>http://www.whitehouse.gov</Uri>
+   </ContactInformation>
+
+
+.. _single-xml-ordered-contest:
+
+OrderedContest
+~~~~~~~~~~~~~~
+
+``OrderedContest`` encapsulates links to the information that comprises a contest and potential
+ballot selections. ``OrderedContest`` elements can be collected within a
+:ref:`single-xml-ballot-style` to accurate depict exactly what will show up on a particular
+ballot in the proper order.
+
++---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+| Tag                       | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                                   |
++===========================+===============+==============+==============+==========================================+==================================================+
+| ContestId                 | ``xs:IDREF``  | **Required** | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
+|                           |               |              |              | :ref:`single-xml-contest-base`.          | implementation is required to ignore the         |
+|                           |               |              |              |                                          | ``OrderedContest`` element containing it.        |
++---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+| OrderedBallotSelectionIds | ``xs:IDREFS`` | Optional     | Single       | Links to elements that extend            | If the field is invalid or not present, the      |
+|                           |               |              |              | :ref:`single-xml-ballot-selection-base`. | implementation is required to ignore it. If an   |
+|                           |               |              |              |                                          | ``OrderedBallotSelectionIds`` element is not     |
+|                           |               |              |              |                                          | present, the presumed order of the selection     |
+|                           |               |              |              |                                          | will be the order of                             |
+|                           |               |              |              |                                          | :ref:`single-xml-ballot-selection-base`-extended |
+|                           |               |              |              |                                          | elements referenced by the underlying            |
+|                           |               |              |              |                                          | :ref:`single-xml-contest-base`-extended          |
+|                           |               |              |              |                                          | elements.                                        |
++---------------------------+---------------+--------------+--------------+------------------------------------------+--------------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <OrderedContest id="oc20003abc">
+      <ContestId>cc20003</ContestId>
+      <OrderedBallotSelectionIds>cs10961 cs10962 cs10963</OrderedBallotSelectionIds>
+   </OrderedContest>
+
+
+.. _single-xml-party:
+
+Party
+~~~~~
+
+This element describes a political party and the metadata associated with them. These can also include "dummy" parties to indicate a type of contest (e.g., a Voter Nominated :ref:`single-xml-candidate-contest` can use the **PrimaryPartyIds** field and a dummy Party object to indicate that the contest is a "Top-Two" primary).
+
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+==========================================+==============+==============+==========================================+==========================================+
+| Abbreviation        | ``xs:string``                            | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
+|                     |                                          |              |              |                                          | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Color               | :ref:`single-xml-html-color-string`      | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
+|                     |                                          |              |              | party, for use in maps and other         | present, then the implementation is      |
+|                     |                                          |              |              | displays.                                | required to ignore it.                   |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
+|                     |                                          |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
+|                     |                                          |              |              | campaign finance system, etc).           | required to ignore it.                   |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsWriteIn           | ``xs:boolean``                           | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
+|                     |                                          |              |              | that is officially recognized by a       | then the implementation is required to   |
+|                     |                                          |              |              | local, state, or federal organization,   | ignore it.                               |
+|                     |                                          |              |              | or is a "write-in" in jurisdictions      |                                          |
+|                     |                                          |              |              | which allow candidates to free-form      |                                          |
+|                     |                                          |              |              | enter their political affiliation. If    |                                          |
+|                     |                                          |              |              | this field is not present then it is     |                                          |
+|                     |                                          |              |              | assumed to be false.                     |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LogoUri             | ``xs:anyURI``                            | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
+|                     |                                          |              |              | displays.                                | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                | :ref:`single-xml-internationalized-text` | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
+|                     |                                          |              |              |                                          | present, then the implementation is      |
+|                     |                                          |              |              |                                          | required to ignore it.                   |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-html-color-string:
+
+HtmlColorString
+^^^^^^^^^^^^^^^
+
+A restricted string pattern for a six-character hex code representing an HTML
+color string. The pattern is:
+
+``[0-9a-f]{6}``
+
+.. code-block:: xml
+   :linenos:
+
+   <Party id="par0001">
+     <Abbreviation>REP</Abbreviation>
+     <Color>e91d0e</Color>
+     <Name>
+       <Text language="en">Republican</Text>
+     </Name>
+   </Party>
+
+
+.. _single-xml-party-contest:
+
+PartyContest
+~~~~~~~~~~~~
+
+An extension of :ref:`single-xml-contest-base` which describes a contest in
+which the possible ballot selections are of type :ref:`single-xml-party-selection`. These could include contests in which straight-party
+selections are allowed, or party-list contests (although these are more common
+outside of the United States).
+
+
+.. _single-xml-contest-base:
+
+ContestBase
+^^^^^^^^^^^
+
+A base model for all Contest types: :ref:`single-xml-ballot-measure-contest`,
+:ref:`single-xml-candidate-contest`, :ref:`single-xml-party-contest`,
+and :ref:`single-xml-retention-contest` (NB: the latter because it extends
+:ref:`single-xml-ballot-measure-contest`).
+
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                     | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++=========================+==========================================+==============+==============+==========================================+==========================================+
+| Abbreviation            | ``xs:string``                            | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
+|                         |                                          |              |              |                                          | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSelectionIds      | ``xs:IDREFS``                            | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
+|                         |                                          |              |              | which could be of any selection type     | then the implementation should ignore    |
+|                         |                                          |              |              | that extends                             | it.                                      |
+|                         |                                          |              |              | :ref:`single-xml-ballot-selection-base`. |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotSubTitle          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
+|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| BallotTitle             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
+|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictId     | ``xs:IDREF``                             | **Required** | Single       | References an                            | If the field is invalid, then the        |
+|                         |                                          |              |              | :ref:`single-xml-electoral-district`     | implementation is required to ignore the |
+|                         |                                          |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
+|                         |                                          |              |              | scope of the contest.                    |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectorateSpecification | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
+|                         |                                          |              |              | electorate for this contest past the     | present, then the implementation should  |
+|                         |                                          |              |              | usual, "all registered voters"           | ignore it.                               |
+|                         |                                          |              |              | electorate. This subtag will most often  |                                          |
+|                         |                                          |              |              | be used for primaries and local          |                                          |
+|                         |                                          |              |              | elections. In primaries, voters may have |                                          |
+|                         |                                          |              |              | to be registered as a specific party to  |                                          |
+|                         |                                          |              |              | vote, or there may be special rules for  |                                          |
+|                         |                                          |              |              | which ballot a voter can pull. In some   |                                          |
+|                         |                                          |              |              | local elections, non-citizens can vote.  |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers     | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
+|                         |                                          |              |              | links to another source of information.  | present, then the implementation should  |
+|                         |                                          |              |              |                                          | ignore it.                               |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HasRotation             | ``xs:boolean``                           | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
+|                         |                                          |              |              | contest are rotated.                     | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                    | ``xs:string``                            | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
+|                         |                                          |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
+|                         |                                          |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
+|                         |                                          |              |              | purpose).                                |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| SequenceOrder           | ``xs:integer``                           | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
+|                         |                                          |              |              | on the ballot. This is the default       | then the implementation should ignore    |
+|                         |                                          |              |              | ordering, and can be overrides by data   | it.                                      |
+|                         |                                          |              |              | in a :ref:`single-xml-ballot-style`      |                                          |
+|                         |                                          |              |              | element.                                 |                                          |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VoteVariation           | :ref:`single-xml-vote-variation`         | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
+|                         |                                          |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
+|                         |                                          |              |              |                                          | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherVoteVariation      | ``xs:string``                            | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
+|                         |                                          |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
+|                         |                                          |              |              | variation can be specified here.         | it.                                      |
++-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-party-selection:
+
+PartySelection
+~~~~~~~~~~~~~~
+
+This element extends :ref:`single-xml-ballot-selection-base` to
+support contests in which the selections can be groups of one or more parties.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| PartyIds     | ``xs:IDREFS`` | **Required** | Single       | One or more :ref:`single-xml-party` IDs  | If one or more parties referenced are    |
+|              |               |              |              | which collectively represent a ballot    | invalid or not present, the              |
+|              |               |              |              | selection.                               | implementation is required to ignore the |
+|              |               |              |              |                                          | PartySelection containing it.            |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-ballot-selection-base:
+
+BallotSelectionBase
+^^^^^^^^^^^^^^^^^^^
+
+A base model for all ballot selection types:
+:ref:`single-xml-ballot-measure-selection`,
+:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
+
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
++===============+================+==============+==============+==========================================+==========================================+
+| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
+|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
+|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
+|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
+|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
++---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-person:
+
+Person
+~~~~~~
+
+``Person`` defines information about a person. The person may be a candidate, election administrator,
+or elected official. These elements reference ``Person``:
+
+* :ref:`single-xml-candidate`
+
+* :ref:`single-xml-election-administration`
+
+* :ref:`single-xml-office`
+
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+==========================================+==============+==============+==========================================+==========================================+
+| ContactInformation  | :ref:`single-xml-contact-information`    | Optional     | Repeats      | Refers to the associated                 | If the element is invalid or not         |
+|                     |                                          |              |              | :ref:`single-xml-contact-information`.   | present, then the implementation is      |
+|                     |                                          |              |              |                                          | required to ignore it.                   |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateOfBirth         | ``xs:date``                              | Optional     | Single       | Represents the individual's date of      | If the field is invalid or not present,  |
+|                     |                                          |              |              | birth.                                   | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Identifiers for this person.             | If the element is invalid or not         |
+|                     |                                          |              |              |                                          | present, then the implementation is      |
+|                     |                                          |              |              |                                          | required to ignore it.                   |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FirstName           | ``xs:string``                            | Optional     | Single       | Represents an individual's first name.   | If the field is invalid or not present,  |
+|                     |                                          |              |              |                                          | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FullName            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies a person's full name (**NB:**  | If the element is invalid or not         |
+|                     |                                          |              |              | this information is                      | present, then the implementation is      |
+|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
+|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
+|                     |                                          |              |              | in multiple languages).                  |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Gender              | ``xs:string``                            | Optional     | Single       | Specifies a person's gender.             | If the field is invalid or not present,  |
+|                     |                                          |              |              |                                          | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LastName            | ``xs:string``                            | Optional     | Single       | Represents an individual's last name.    | If the field is invalid or not present,  |
+|                     |                                          |              |              |                                          | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| MiddleName          | ``xs:string``                            | Optional     | Repeats      | Represents any number of names between   | If the field is invalid or not present,  |
+|                     |                                          |              |              | an individual's first and last names     | then the implementation is required to   |
+|                     |                                          |              |              | (e.g. John **Ronald Reuel** Tolkien).    | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Nickname            | ``xs:string``                            | Optional     | Single       | Represents an individual's nickname.     | If the field is invalid or not present,  |
+|                     |                                          |              |              |                                          | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PartyId             | ``xs:IDREF``                             | Optional     | Single       | Refers to the associated                 | If the field is invalid or not present,  |
+|                     |                                          |              |              | :ref:`single-xml-party`. This            | then the implementation is required to   |
+|                     |                                          |              |              | information is intended to be used by    | ignore it.                               |
+|                     |                                          |              |              | feed consumers to help them disambiguate |                                          |
+|                     |                                          |              |              | the person's identity, but not to be     |                                          |
+|                     |                                          |              |              | presented as part of any ballot          |                                          |
+|                     |                                          |              |              | information. For that see                |                                          |
+|                     |                                          |              |              | :ref:`single-xml-candidate` **PartyId**. |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Prefix              | ``xs:string``                            | Optional     | Single       | Specifies a prefix associated with a     | If the field is invalid or not present,  |
+|                     |                                          |              |              | person (e.g. Dr.).                       | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Profession          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies a person's profession (**NB:** | If the element is invalid or not         |
+|                     |                                          |              |              | this information is                      | present, then the implementation is      |
+|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
+|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
+|                     |                                          |              |              | in multiple languages).                  |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Suffix              | ``xs:string``                            | Optional     | Single       | Specifies a suffix associated with a     | If the field is invalid or not present,  |
+|                     |                                          |              |              | person (e.g. Jr.).                       | then the implementation is required to   |
+|                     |                                          |              |              |                                          | ignore it.                               |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Title               | :ref:`single-xml-internationalized-text` | Optional     | Single       | A title associated with a person         | If the element is invalid or not         |
+|                     |                                          |              |              | (**NB:** this information is             | present, then the implementation is      |
+|                     |                                          |              |              | :ref:`single-xml-internationalized-text` | required to ignore it.                   |
+|                     |                                          |              |              | because it sometimes appears on ballots  |                                          |
+|                     |                                          |              |              | in multiple languages).                  |                                          |
++---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <Person id="per50001">
+      <ContactInformation label="ci60002">
+        <Email>rwashburne@albemarle.org</Email>
+        <Phone>4349724173</Phone>
+      </ContactInformation>
+      <FirstName>RICHARD</FirstName>
+      <LastName>WASHBURNE</LastName>
+      <MiddleName>J.</MiddleName>
+      <Nickname>JAKE</Nickname>
+      <Title>
+        <Text language="en">General Registrar Physical</Text>
+      </Title>
+   </Person>
+
+
+.. _single-xml-contact-information:
+
+ContactInformation
+^^^^^^^^^^^^^^^^^^
+
+For defining contact information about objects such as persons, boards of authorities,
+organizations, etc. ContactInformation is always a sub-element of another object (e.g.
+:ref:`single-xml-election-administration`, :ref:`single-xml-office`,
+:ref:`single-xml-person`, :ref:`single-xml-source`). ContactInformation has an optional attribute
+``label``, which allows the feed to refer back to the original label for the information
+(e.g. if the contact information came from a CSV, ``label`` may refer to a row ID).
+
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag              | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==================+==========================================+==============+==============+==========================================+==========================================+
+| AddressLine      | ``xs:string``                            | Optional     | Repeats      | The "location" portion of a mailing      | If the field is invalid or not present,  |
+|                  |                                          |              |              | address. :ref:`See usage note.           | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions       | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                  |                                          |              |              | locating this entity.                    | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Email            | ``xs:string``                            | Optional     | Repeats      | An email address for the contact.        | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Fax              | ``xs:string``                            | Optional     | Repeats      | A fax line for the contact.              | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]** |                                          |              |              | the location is open *(NB: this element  | present, then the implementation is      |
+|                  |                                          |              |              | is deprecated in favor of the more       | required to ignore it.                   |
+|                  |                                          |              |              | structured :ref:`single-xml-hours-open`  |                                          |
+|                  |                                          |              |              | element. It is strongly encouraged that  |                                          |
+|                  |                                          |              |              | data providers move toward contributing  |                                          |
+|                  |                                          |              |              | hours in this format)*.                  |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId      | ``xs:IDREF``                             | Optional     | Single       | References an                            | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`single-xml-hours-open` element,    | then the implementation is required to   |
+|                  |                                          |              |              | which lists the hours of operation for a | ignore it.                               |
+|                  |                                          |              |              | location.                                |                                          |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng           | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                  |                                          |              |              | this entity.                             | present, then the implementation is      |
+|                  |                                          |              |              |                                          | required to ignore it.                   |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name             | ``xs:string``                            | Optional     | Single       | The name of the location or contact.     | If the field is invalid or not present,  |
+|                  |                                          |              |              | :ref:`See usage note.                    | then the implementation is required to   |
+|                  |                                          |              |              | <single-xml-name-address-line-usage>`    | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Phone            | ``xs:string``                            | Optional     | Repeats      | A phone number for the contact.          | If the field is invalid or not present,  |
+|                  |                                          |              |              |                                          | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Uri              | ``xs:anyURI``                            | Optional     | Repeats      | An informational URI for the contact or  | If the field is invalid or not present,  |
+|                  |                                          |              |              | location.                                | then the implementation is required to   |
+|                  |                                          |              |              |                                          | ignore it.                               |
++------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _single-xml-name-address-line-usage:
+
+``Name`` and ``AddressLine`` Usage Note
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``Name`` and ``AddressLine`` fields should be chosen so that a display
+or mailing address can be constructed programmatically by joining the
+``Name`` and ``AddressLine`` fields together.  For example, for the
+following address::
+
+    Department of Elections
+    1 Dr. Carlton B. Goodlett Place, Room 48
+    San Francisco, CA 94102
+
+The name could be "Department of Elections" and the first address line
+could be "1 Dr. Carlton B. Goodlett Place, Room 48."
+
+However, VIP does not yet support the representation of mailing addresses
+whose "name" portion spans more than one line, for example::
+
+    California Secretary of State
+    Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+For addresses like the above, we recommend choosing a name like, "California
+Secretary of State, Elections Division" with "1500 11th Street" as the
+first address line. This would result in a programmatically constructed
+address like the following::
+
+    California Secretary of State, Elections Division
+    1500 11th Street
+    Sacramento, CA 95814
+
+.. code-block:: xml
+   :linenos:
+
+   <ContactInformation label="ci10861a">
+      <AddressLine>1600 Pennsylvania Ave</AddressLine>
+      <AddressLine>Washington, DC 20006</AddressLine>
+      <Email>president@whitehouse.gov</Email>
+      <Phone>202-456-1111</Phone>
+      <Phone annotation="TDD">202-456-6213</Phone>
+      <Uri>http://www.whitehouse.gov</Uri>
+   </ContactInformation>
+
+
+.. _single-xml-polling-location:
+
+PollingLocation
+~~~~~~~~~~~~~~~
+
+The PollingLocation object represents a site where voters cast or drop off ballots.
+
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag               | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++===================+==========================================+==============+==============+==========================================+==========================================+
+| AddressStructured | :ref:`single-xml-simple-address-type`    | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
+|                   |                                          |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
+|                   |                                          |              |              |                                          | given Polling Location. If none is       |
+|                   |                                          |              |              |                                          | present, the implementation is required  |
+|                   |                                          |              |              |                                          | to ignore the ``PollingLocation``        |
+|                   |                                          |              |              |                                          | element containing it.                   |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| AddressLine       | ``xs:string``                            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
+|                   |                                          |              |              | address to a polling location.           | should be present for a given Polling    |
+|                   |                                          |              |              |                                          | Location. If none is present, the        |
+|                   |                                          |              |              |                                          | implementation is required to ignore the |
+|                   |                                          |              |              |                                          | ``PollingLocation`` element containing   |
+|                   |                                          |              |              |                                          | it.                                      |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Directions        | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies further instructions for       | If the element is invalid or not         |
+|                   |                                          |              |              | locating the polling location.           | present, then the implementation is      |
+|                   |                                          |              |              |                                          | required to ignore it.                   |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Hours             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Contains the hours (in local time) that  | If the element is invalid or not         |
+| **[deprecated]**  |                                          |              |              | the polling location is open (**NB:**    | present, then the implementation is      |
+|                   |                                          |              |              | this element is deprecated in favor of   | required to ignore it.                   |
+|                   |                                          |              |              | the more structured                      |                                          |
+|                   |                                          |              |              | :ref:`single-xml-hours-open` element. It |                                          |
+|                   |                                          |              |              | is strongly encouraged that data         |                                          |
+|                   |                                          |              |              | providers move toward contributing hours |                                          |
+|                   |                                          |              |              | in this format).                         |                                          |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| HoursOpenId       | ``xs:IDREF``                             | Optional     | Single       | Links to an :ref:`single-xml-hours-open` | If the field is invalid or not present,  |
+|                   |                                          |              |              | element, which is a schedule of dates    | then the implementation is required to   |
+|                   |                                          |              |              | and hours during which the polling       | ignore it.                               |
+|                   |                                          |              |              | location is available.                   |                                          |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsDropBox         | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is a  | If the field is invalid or not present,  |
+|                   |                                          |              |              | drop box.                                | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsEarlyVoting     | ``xs:boolean``                           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
+|                   |                                          |              |              | early vote site.                         | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LatLng            | :ref:`single-xml-lat-lng`                | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
+|                   |                                          |              |              | this polling location.                   | present, then the implementation is      |
+|                   |                                          |              |              |                                          | required to ignore it.                   |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name              | ``xs:string``                            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
+|                   |                                          |              |              |                                          | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PhotoUri          | ``xs:anyURI``                            | Optional     | Single       | Contains a link to an image of the       | If the field is invalid or not present,  |
+|                   |                                          |              |              | polling location.                        | then the implementation is required to   |
+|                   |                                          |              |              |                                          | ignore it.                               |
++-------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. code-block:: xml
+   :linenos:
+
+   <PollingLocation id="pl00000">
+      <AddressLine>2775 Hydraulic Rd Charlottesville, VA 22901</AddressLine>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
+   </PollingLocation>
+   <!-- Or: -->
+   <PollingLocation id="pl00000">
+      <AddressStructured>
+         <Line1>2775 Hydraulic Rd</Line1>
+         <City>CHARLOTTESVILLE</City>
+         <State>VA</State>
+         <Zip>22901</Zip>
+      </AddressStructured>
+      <HoursOpenId>hours0002</HoursOpenId>
+      <IsDropBox>true</IsDropBox>
+      <IsEarlyVoting>true</IsEarlyVoting>
+      <LatLng>
+         <Latitude>38.009939</Latitude>
+         <Longitude>-78.506204</Longitude>
+      </LatLng>
+      <Name>ALBERMARLE HIGH SCHOOL</Name>
+   </PollingLocation>
+
+
+.. _single-xml-lat-lng:
+
+LatLng
+^^^^^^
+
+The latitude and longitude of a polling location in `WGS 84`_ format. Both
+latitude and longitude values are measured in decimal degrees.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| Latitude     | ``xs:double`` | **Required** | Single       | The latitude of the polling location.    | If the field is invalid, then the        |
+|              |               |              |              |                                          | implementation is required to ignore it. |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Longitude    | ``xs:double`` | **Required** | Single       | The longitude of the polling location.   | If the field is invalid, then the        |
+|              |               |              |              |                                          | implementation is required to ignore it. |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Source       | ``xs:string`` | Optional     | Single       | The system used to perform the lookup    | If the field is invalid or not present,  |
+|              |               |              |              | from location name to lat/lng. For       | then the implementation is required to   |
+|              |               |              |              | example, this could be the name of a     | ignore it.                               |
+|              |               |              |              | geocoding service.                       |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-simple-address-type:
+
+SimpleAddressType
+^^^^^^^^^^^^^^^^^
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-precinct:
+
+Precinct
+~~~~~~~~
+
+The Precinct object represents a precinct, which is contained within a Locality. While the id
+attribute does not have to be static across feeds for one election, the combination of
+:ref:`Source.VipId <single-xml-source>`, :ref:`Locality.Name <single-xml-locality>`, :ref:`Precinct.Ward <single-xml-precinct>`,
+:ref:`Precinct.Name <single-xml-precinct>`, and :ref:`Precinct.Number <single-xml-precinct>` should remain constant across
+feeds for one election (NB: not all of the fields just mentioned are required -- omitting those
+non-required fields is fine).
+
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                  | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++======================+========================================+==============+==============+==========================================+==========================================+
+| BallotStyleId        | ``xs:IDREF``                           | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
+|                      |                                        |              |              | :ref:`single-xml-ballot-style`, which a  | then the implementation is required to   |
+|                      |                                        |              |              | person who lives in this precinct will   | ignore it.                               |
+|                      |                                        |              |              | vote.                                    |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectoralDistrictIds | ``xs:IDREFS``                          | Optional     | Single       | Links to the                             | If the field is invalid or not present,  |
+|                      |                                        |              |              | :ref:`single-xml-electoral-district`s    | then the implementation is required to   |
+|                      |                                        |              |              | (e.g., congressional district, state     | ignore it.                               |
+|                      |                                        |              |              | house district, school board district)   |                                          |
+|                      |                                        |              |              | to which the entire precinct/precinct    |                                          |
+|                      |                                        |              |              | split belongs. **Highly Recommended** if |                                          |
+|                      |                                        |              |              | candidate information is to be provided. |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers  | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifier for the precinct that   | If the element is invalid or not         |
+|                      |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                      |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsMailOnly           | ``xs:boolean``                         | Optional     | Single       | Determines if the precinct runs          | If the field is missing or invalid, the  |
+|                      |                                        |              |              | mail-only elections.                     | implementation is required to assume     |
+|                      |                                        |              |              |                                          | `IsMailOnly` is false.                   |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| LocalityId           | ``xs:IDREF``                           | **Required** | Single       | Links to the :ref:`single-xml-locality`  | If the field is invalid, then the        |
+|                      |                                        |              |              | that comprises the precinct.             | implementation is required to ignore the |
+|                      |                                        |              |              |                                          | ``Precinct`` element containing it.      |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                 | ``xs:string``                          | **Required** | Single       | Specifies the precinct's name (or number | If the field is invalid, then the        |
+|                      |                                        |              |              | if no name exists).                      | implementation is required to ignore the |
+|                      |                                        |              |              |                                          | ``Precinct`` element containing it.      |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Number               | ``xs:string``                          | Optional     | Single       | Specifies the precinct's number (e.g.,   | If the field is invalid or not present,  |
+|                      |                                        |              |              | 32 or 32A -- alpha characters are        | then the implementation is required to   |
+|                      |                                        |              |              | legal). Should be used if the `Name`     | ignore it.                               |
+|                      |                                        |              |              | field is populated by a name and not a   |                                          |
+|                      |                                        |              |              | number.                                  |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationIds   | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the precinct's       | If the field is invalid or not present,  |
+|                      |                                        |              |              | :ref:`single-xml-polling-location`       | then the implementation is required to   |
+|                      |                                        |              |              | object(s).                               | ignore it.                               |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PrecinctSplitName    | ``xs:string``                          | Optional     | Single       | If this field is empty, then this        | If the field is invalid or not present,  |
+|                      |                                        |              |              | `Precinct` object represents a full      | then the implementation is required to   |
+|                      |                                        |              |              | precinct. If this field is present, then | ignore it.                               |
+|                      |                                        |              |              | this `Precinct` object represents one    |                                          |
+|                      |                                        |              |              | portion of a split precinct. Each        |                                          |
+|                      |                                        |              |              | `Precinct` object that represents one    |                                          |
+|                      |                                        |              |              | portion of a split precinct **must**     |                                          |
+|                      |                                        |              |              | have the same `Name` value, but          |                                          |
+|                      |                                        |              |              | different `PrecinctSplitName` values.    |                                          |
+|                      |                                        |              |              | See the `sample_feed.xml` file for       |                                          |
+|                      |                                        |              |              | examples.                                |                                          |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Ward                 | ``xs:string``                          | Optional     | Single       | Specifies the ward the precinct is       | If the field is invalid or not present,  |
+|                      |                                        |              |              | contained within.                        | then the implementation is required to   |
+|                      |                                        |              |              |                                          | ignore it.                               |
++----------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+.. code-block:: xml
+   :linenos:
+
+   <Precinct id="pre90111">
+      <BallotStyleId>bs00010</BallotStyleId>
+      <ElectoralDistrictIds>ed60129 ed60311 ed60054</ElectoralDistrictIds>
+      <IsMailOnly>false</IsMailOnly>
+      <LocalityId>loc70001</LocalityId>
+      <Name>203 - GEORGETOWN</Name>
+      <Number>0203</Number>
+      <PollingLocationIds>pl81274</PollingLocationIds>
+   </Precinct>
+   <!--
+     Precinct split. Name and PollingLocationIds are the same but
+     PrecinctSplitName is present, the ElectoralDistrictIds are different,
+     and the BallotStyleId is different.
+   -->
+   <Precinct id="pre90348sp0000">
+     <BallotStyleId>bs00002</BallotStyleId>
+     <ElectoralDistrictIds>ed60129 ed60054 ed60150</ElectoralDistrictIds>
+     <IsMailOnly>false</IsMailOnly>
+     <LocalityId>loc70001</LocalityId>
+     <Name>201 - JACK JOUETT</Name>
+     <Number>0201</Number>
+     <PollingLocationIds>pl00000 pl81273 pl81662</PollingLocationIds>
+     <PrecinctSplitName>0000</PrecinctSplitName>
+   </Precinct>
+   <Precinct id="pre90348sp0001">
+     <BallotStyleId>bs00015</BallotStyleId>
+     <ElectoralDistrictIds>ed60129 ed60054 ed60267</ElectoralDistrictIds>
+     <IsMailOnly>false</IsMailOnly>
+     <LocalityId>loc70001</LocalityId>
+     <Name>201 - JACK JOUETT</Name>
+     <Number>0201</Number>
+     <PollingLocationIds>pl00000 pl81273 pl81662</PollingLocationIds>
+     <PrecinctSplitName>0001</PrecinctSplitName>
+   </Precinct>
 
 
 .. _single-xml-retention-contest:
@@ -2539,6 +2736,245 @@ contest where a candidate is retained in a position (e.g. a judge).
       <CandidateId>can14444</CandidateId>
       <OfficeId>off20006</OfficeId>
    </RetentionContest>
+
+
+.. _single-xml-schedule:
+
+Schedule
+~~~~~~~~
+
+A sub-portion of the schedule. This describes a range of days, along with one or
+more set of open and close times for those days, as well as the options
+describing whether or not appointments are necessary or possible.
+
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                 | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
++=====================+=========================+==============+==============+==========================================+==========================================+
+| Hours               | :ref:`single-xml-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
+|                     |                         |              |              | which the place is open.                 | present, then the implementation is      |
+|                     |                         |              |              |                                          | required to ignore it.                   |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOnlyByAppointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
+|                     |                         |              |              | the specified time window with an        | then the implementation is required to   |
+|                     |                         |              |              | appointment.                             | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsOrByAppointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
+|                     |                         |              |              | hours specified time window and may also | then the implementation is required to   |
+|                     |                         |              |              | be open with an appointment.             | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| IsSubjectToChange   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
+|                     |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
+|                     |                         |              |              | subject to change. People should contact | ignore it.                               |
+|                     |                         |              |              | prior to arrival to confirm hours are    |                                          |
+|                     |                         |              |              | still accurate.                          |                                          |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate           | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
+|                     |                         |              |              |                                          | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
+|                     |                         |              |              | start and end times and options end.     | then the implementation is required to   |
+|                     |                         |              |              |                                          | ignore it.                               |
++---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-hours:
+
+Hours
+^^^^^
+
+The open and close time for this place. All times must be fully specified,
+including a timezone offset from UTC.
+
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+==================================+==============+==============+==========================================+==========================================+
+| StartTime    | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndTime      | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
+|              |                                  |              |              |                                          | present, then the implementation is      |
+|              |                                  |              |              |                                          | required to ignore it.                   |
++--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-time-with-zone:
+
+TimeWithZone
+%%%%%%%%%%%%
+
+A string pattern restricting the value to a time with an included offset from
+UTC. The pattern is
+
+``(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))``
+
+.. code-block:: xml
+   :linenos:
+
+   <HoursOpen id="hours0001">
+     <Schedule>
+       <Hours>
+         <StartTime>06:00:00-05:00</StartTime>
+         <EndTime>12:00:00-05:00</EndTime>
+       </Hours>
+       <Hours>
+         <StartTime>13:00:00-05:00</StartTime>
+         <EndTime>19:00:00-05:00</EndTime>
+       </Hours>
+       <StartDate>2013-11-05</StartDate>
+       <EndDate>2013-11-05</EndDate>
+     </Schedule>
+   </HoursOpen>
+
+
+.. _single-xml-simple-address-type:
+
+SimpleAddressType
+~~~~~~~~~~~~~~~~~
+
+A ``SimpleAddressType`` represents a structured address.
+
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+===============+==============+==============+==========================================+==========================================+
+| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
+|              |               |              |              | address. Should include the street       | implementation should ignore the         |
+|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
+|              |               |              |              | suffix.                                  |                                          |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
+|              |               |              |              |                                          | implementation should ignore it.         |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
+|              |               |              |              |                                          | implementation should ignore the         |
+|              |               |              |              |                                          | ``SimpleAddressType``.                   |
++--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+
+.. _single-xml-source:
+
+Source
+~~~~~~
+
+The Source object represents the organization that is publishing the information. This object is
+the only required object in the feed file, and only one source object is allowed to be present.
+
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                    | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++========================+==========================================+==============+==============+==========================================+==========================================+
+| Name                   | ``xs:string``                            | **Required** | Single       | Specifies the name of the organization   | If the field is invalid, then the        |
+|                        |                                          |              |              | that is providing the information.       | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| VipId                  | ``xs:string``                            | **Required** | Single       | Specifies the ID of the organization.    | If the field is invalid, then the        |
+|                        |                                          |              |              | VIP uses FIPS_ codes for this ID.        | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| DateTime               | ``xs:dateTime``                          | **Required** | Single       | Specifies the date and time of the feed  | If the field is invalid, then the        |
+|                        |                                          |              |              | production. The date/time is considered  | implementation is required to ignore the |
+|                        |                                          |              |              | to be in the timezone local to the       | ``Source`` element containing it.        |
+|                        |                                          |              |              | organization.                            |                                          |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description            | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies both the nature of the         | If the element is invalid or not         |
+|                        |                                          |              |              | organization providing the data and what | present, then the implementation is      |
+|                        |                                          |              |              | data is in the feed.                     | required to ignore it.                   |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OrganizationUri        | ``xs:string``                            | Optional     | Single       | Specifies a URI to the home page of the  | If the field is invalid or not present,  |
+|                        |                                          |              |              | organization publishing the data.        | then the implementation is required to   |
+|                        |                                          |              |              |                                          | ignore it.                               |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| FeedContactInformation | :ref:`single-xml-contact-information`    | Optional     | Single       | Reference to the                         | If the element is invalid or not         |
+|                        |                                          |              |              | :ref:`single-xml-person` who will        | present, then the implementation is      |
+|                        |                                          |              |              | respond to inquiries about the           | required to ignore it.                   |
+|                        |                                          |              |              | information contained within the file.   |                                          |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| TouUri                 | ``xs:anyURI``                            | Optional     | Single       | Specifies the website where the Terms of | If the field is invalid or not present,  |
+|                        |                                          |              |              | Use for the information in this file can | then the implementation is required to   |
+|                        |                                          |              |              | be found.                                | ignore it.                               |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Version                | ``xs:string``                            | **Required** | Single       | Specifies the version of the data        | If the field is invalid, then the        |
+|                        |                                          |              |              |                                          | implementation is required to ignore the |
+|                        |                                          |              |              |                                          | ``Source`` element containing it.        |
++------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _FIPS: https://www.census.gov/geo/reference/codes/cou.html
+
+.. code-block:: xml
+   :linenos:
+
+   <Source id="src1">
+      <DateTime>2013-10-24T14:25:28</DateTime>
+      <Description>
+         <Text language="en">SBE is the official source for Virginia data</Text>
+      </Description>
+      <Name>State Board of Elections, Commonwealth of Virginia</Name>
+      <OrganizationUri>http://www.sbe.virginia.gov/</OrganizationUri>
+      <VipId>51</VipId>
+      <Version>5.0</Version>
+   </Source>
+
+
+.. _single-xml-state:
+
+State
+~~~~~
+
+The State object includes state-wide election information. The ID attribute is
+recommended to be the state's FIPS code, along with the prefix "st".
+
++--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+========================================+==============+==============+==========================================+==========================================+
+| ElectionAdministrationId | ``xs:IDREF``                           | Optional     | Single       | Links to the state's election            | If the field is invalid or not present,  |
+|                          |                                        |              |              | administration object.                   | then the implementation is required to   |
+|                          |                                        |              |              |                                          | ignore it.                               |
++--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ExternalIdentifiers      | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifier for the state that      | If the element is invalid or not         |
+|                          |                                        |              |              | relates to another dataset (e.g.         | present, then the implementation is      |
+|                          |                                        |              |              | `OCD-ID`_).                              | required to ignore it.                   |
++--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Name                     | ``xs:string``                          | **Required** | Single       | Specifiers the name of a state, such as  | If the field is invalid, then the        |
+|                          |                                        |              |              | Alabama.                                 | implementation is required to ignore the |
+|                          |                                        |              |              |                                          | ``State`` element containing it.         |
++--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| PollingLocationIds       | ``xs:IDREFS``                          | Optional     | Single       | Specifies a link to the state's          | If the field is invalid or not present,  |
+|                          |                                        |              |              | :ref:`polling locations                  | then the implementation is required to   |
+|                          |                                        |              |              | <single-xml-polling-location>`. If early | ignore it.                               |
+|                          |                                        |              |              | vote centers or ballot drop locations    |                                          |
+|                          |                                        |              |              | are state-wide (e.g., anyone in the      |                                          |
+|                          |                                        |              |              | state can use them), they can be         |                                          |
+|                          |                                        |              |              | specified here, but you are encouraged   |                                          |
+|                          |                                        |              |              | to only use the                          |                                          |
+|                          |                                        |              |              | :ref:`single-xml-precinct` element.      |                                          |
++--------------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+
+.. _OCD-ID: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
+
+.. code-block:: xml
+   :linenos:
+
+   <State id="st51">
+      <ElectionAdministrationId>ea40133</ElectionAdministrationId>
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>Virginia</Name>
+   </State>
 
 
 .. _single-xml-street-segment:
@@ -2702,379 +3138,47 @@ are equal.
    </StreetSegment>
 
 
-.. _single-xml-candidate-contest:
+.. _single-xml-term:
 
-CandidateContest
-~~~~~~~~~~~~~~~~
+Term
+~~~~
 
-CandidateContest extends :ref:`single-xml-contest-base` and represents a contest among
-candidates.
-
-+-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag             | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=================+================+==============+==============+==========================================+==========================================+
-| NumberElected   | ``xs:integer`` | Optional     | Single       | Number of candidates that are elected in | If the field is invalid or not present,  |
-|                 |                |              |              | the contest (i.e. "N" of N-of-M).        | then the implementation is required to   |
-|                 |                |              |              |                                          | ignore it.                               |
-+-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OfficeIds       | ``xs:IDREFS``  | Optional     | Single       | References a set of                      | If the field is invalid or not present,  |
-|                 |                |              |              | :ref:`single-xml-office` elements, if    | then the implementation is required to   |
-|                 |                |              |              | available, which give additional         | ignore it.                               |
-|                 |                |              |              | information about the offices. **Note:** |                                          |
-|                 |                |              |              | the order of the office IDs **must** be  |                                          |
-|                 |                |              |              | in the same order as the candidates      |                                          |
-|                 |                |              |              | listed in `BallotSelectionIds`. E.g., if |                                          |
-|                 |                |              |              | the various `BallotSelectionIds`         |                                          |
-|                 |                |              |              | reference                                |                                          |
-|                 |                |              |              | :ref:`single-xml-candidate-selection`    |                                          |
-|                 |                |              |              | elements which reference the candidate   |                                          |
-|                 |                |              |              | for President first and Vice-President   |                                          |
-|                 |                |              |              | second, the `OfficeIds` should reference |                                          |
-|                 |                |              |              | the office of President first and the    |                                          |
-|                 |                |              |              | office of Vice-President second.         |                                          |
-+-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| PrimaryPartyIds | ``xs:IDREFS``  | Optional     | Single       | References :ref:`single-xml-party`       | If the field is invalid or not present,  |
-|                 |                |              |              | elements, if the contest is related to a | then the implementation is required to   |
-|                 |                |              |              | particular party.                        | ignore it.                               |
-+-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VotesAllowed    | ``xs:integer`` | Optional     | Single       | Maximum number of votes/write-ins per    | If the field is invalid or not present,  |
-|                 |                |              |              | voter in this contest.                   | then the implementation is required to   |
-|                 |                |              |              |                                          | ignore it.                               |
-+-----------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag          | Data Type                          | Required?    | Repeats?     | Description                              | Error Handling                           |
++==============+====================================+==============+==============+==========================================+==========================================+
+| Type         | :ref:`single-xml-office-term-type` | Optional     | Single       | Specifies the type of office term (see   | If the field is invalid or not present,  |
+|              |                                    |              |              | :ref:`single-xml-office-term-type` for   | the implementation is required to ignore |
+|              |                                    |              |              | valid values).                           | the ``Office`` element containing it.    |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| StartDate    | ``xs:date``                        | Optional     | Single       | Specifies the start date for the current | If the field is invalid or not present,  |
+|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                    |              |              |                                          | ignore it.                               |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| EndDate      | ``xs:date``                        | Optional     | Single       | Specifies the end date for the current   | If the field is invalid or not present,  |
+|              |                                    |              |              | term of the office.                      | then the implementation is required to   |
+|              |                                    |              |              |                                          | ignore it.                               |
++--------------+------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 .. code-block:: xml
    :linenos:
 
-   <CandidateContest id="cc20003">
-      <BallotSelectionIds>cs10961 cs10962 cs10963</BallotSelectionIds>
-      <BallotTitle>
-        <Text language="en">Governor of Virginia</Text>
-      </BallotTitle>
-      <ElectoralDistrictId>ed60129</ElectoralDistrictId>
-      <Name>Governor</Name>
-      <NumberElected>1</NumberElected>
-      <OfficeId>off0000</OfficeId>
-      <VotesAllowed>1</VotesAllowed>
-   </CandidateContest>
-
-
-.. _single-xml-contest-base:
-
-ContestBase
-^^^^^^^^^^^
-
-A base model for all Contest types: :ref:`single-xml-ballot-measure-contest`,
-:ref:`single-xml-candidate-contest`, :ref:`single-xml-party-contest`,
-and :ref:`single-xml-retention-contest` (NB: the latter because it extends
-:ref:`single-xml-ballot-measure-contest`).
-
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                     | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=========================+==========================================+==============+==============+==========================================+==========================================+
-| Abbreviation            | ``xs:string``                            | Optional     | Single       | An abbreviation for the contest.         | If the field is invalid or not present,  |
-|                         |                                          |              |              |                                          | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSelectionIds      | ``xs:IDREFS``                            | Optional     | Single       | References a set of BallotSelections,    | If the field is invalid or not present,  |
-|                         |                                          |              |              | which could be of any selection type     | then the implementation should ignore    |
-|                         |                                          |              |              | that extends                             | it.                                      |
-|                         |                                          |              |              | :ref:`single-xml-ballot-selection-base`. |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotSubTitle          | :ref:`single-xml-internationalized-text` | Optional     | Single       | Subtitle of the contest as it appears on | If the element is invalid or not         |
-|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| BallotTitle             | :ref:`single-xml-internationalized-text` | Optional     | Single       | Title of the contest as it appears on    | If the element is invalid or not         |
-|                         |                                          |              |              | the ballot.                              | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectoralDistrictId     | ``xs:IDREF``                             | **Required** | Single       | References an                            | If the field is invalid, then the        |
-|                         |                                          |              |              | :ref:`single-xml-electoral-district`     | implementation is required to ignore the |
-|                         |                                          |              |              | element that represents the geographical | ``ContestBase`` element containing it.   |
-|                         |                                          |              |              | scope of the contest.                    |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ElectorateSpecification | :ref:`single-xml-internationalized-text` | Optional     | Single       | Specifies any changes to the eligible    | If the element is invalid or not         |
-|                         |                                          |              |              | electorate for this contest past the     | present, then the implementation should  |
-|                         |                                          |              |              | usual, "all registered voters"           | ignore it.                               |
-|                         |                                          |              |              | electorate. This subtag will most often  |                                          |
-|                         |                                          |              |              | be used for primaries and local          |                                          |
-|                         |                                          |              |              | elections. In primaries, voters may have |                                          |
-|                         |                                          |              |              | to be registered as a specific party to  |                                          |
-|                         |                                          |              |              | vote, or there may be special rules for  |                                          |
-|                         |                                          |              |              | which ballot a voter can pull. In some   |                                          |
-|                         |                                          |              |              | local elections, non-citizens can vote.  |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers     | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers for a contest that     | If the element is invalid or not         |
-|                         |                                          |              |              | links to another source of information.  | present, then the implementation should  |
-|                         |                                          |              |              |                                          | ignore it.                               |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| HasRotation             | ``xs:boolean``                           | Optional     | Single       | Indicates whether the selections in the  | If the field is invalid or not present,  |
-|                         |                                          |              |              | contest are rotated.                     | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                    | ``xs:string``                            | **Required** | Single       | Name of the contest, not necessarily how | If the field is invalid, then the        |
-|                         |                                          |              |              | it appears on the ballot (NB:            | implementation is required to ignore the |
-|                         |                                          |              |              | BallotTitle should be used for this      | ``ContestBase`` element containing it.   |
-|                         |                                          |              |              | purpose).                                |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| SequenceOrder           | ``xs:integer``                           | Optional     | Single       | Order in which the contests are listed   | If the field is invalid or not present,  |
-|                         |                                          |              |              | on the ballot. This is the default       | then the implementation should ignore    |
-|                         |                                          |              |              | ordering, and can be overrides by data   | it.                                      |
-|                         |                                          |              |              | in a :ref:`single-xml-ballot-style`      |                                          |
-|                         |                                          |              |              | element.                                 |                                          |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| VoteVariation           | :ref:`single-xml-vote-variation`         | Optional     | Single       | Vote variation associated with the       | If the field is invalid or not present,  |
-|                         |                                          |              |              | contest (e.g. n-of-m, majority, et al).  | then the implementation should ignore    |
-|                         |                                          |              |              |                                          | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherVoteVariation      | ``xs:string``                            | Optional     | Single       | If "other" is selected as the            | If the field is invalid or not present,  |
-|                         |                                          |              |              | **VoteVariation**, the name of the       | then the implementation should ignore    |
-|                         |                                          |              |              | variation can be specified here.         | it.                                      |
-+-------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-party:
-
-Party
-~~~~~
-
-This element describes a political party and the metadata associated with them. These can also include "dummy" parties to indicate a type of contest (e.g., a Voter Nominated :ref:`single-xml-candidate-contest` can use the **PrimaryPartyIds** field and a dummy Party object to indicate that the contest is a "Top-Two" primary).
-
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+==========================================+==============+==============+==========================================+==========================================+
-| Abbreviation        | ``xs:string``                            | Optional     | Single       | An abbreviation for the party name.      | If the field is invalid or not present,  |
-|                     |                                          |              |              |                                          | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Color               | :ref:`single-xml-html-color-string`      | Optional     | Single       | The preferred display color for the      | If the element is invalid or not         |
-|                     |                                          |              |              | party, for use in maps and other         | present, then the implementation is      |
-|                     |                                          |              |              | displays.                                | required to ignore it.                   |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| ExternalIdentifiers | :ref:`single-xml-external-identifiers`   | Optional     | Single       | Other identifiers that link this party   | If the element is invalid or not         |
-|                     |                                          |              |              | to other related data sets (e.g. a       | present, then the implementation is      |
-|                     |                                          |              |              | campaign finance system, etc).           | required to ignore it.                   |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsWriteIn           | ``xs:boolean``                           | Optional     | Single       | Signals if this political party is one   | If the field is invalid or not present,  |
-|                     |                                          |              |              | that is officially recognized by a       | then the implementation is required to   |
-|                     |                                          |              |              | local, state, or federal organization,   | ignore it.                               |
-|                     |                                          |              |              | or is a "write-in" in jurisdictions      |                                          |
-|                     |                                          |              |              | which allow candidates to free-form      |                                          |
-|                     |                                          |              |              | enter their political affiliation. If    |                                          |
-|                     |                                          |              |              | this field is not present then it is     |                                          |
-|                     |                                          |              |              | assumed to be false.                     |                                          |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| LogoUri             | ``xs:anyURI``                            | Optional     | Single       | Web address of a logo to use in          | If the field is invalid or not present,  |
-|                     |                                          |              |              | displays.                                | then the implementation is required to   |
-|                     |                                          |              |              |                                          | ignore it.                               |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                | :ref:`single-xml-internationalized-text` | Optional     | Single       | The name of the party.                   | If the element is invalid or not         |
-|                     |                                          |              |              |                                          | present, then the implementation is      |
-|                     |                                          |              |              |                                          | required to ignore it.                   |
-+---------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-html-color-string:
-
-HtmlColorString
-^^^^^^^^^^^^^^^
-
-A restricted string pattern for a six-character hex code representing an HTML
-color string. The pattern is:
-
-``[0-9a-f]{6}``
-
-.. code-block:: xml
-   :linenos:
-
-   <Party id="par0001">
-     <Abbreviation>REP</Abbreviation>
-     <Color>e91d0e</Color>
+   <Office id="off0000">
+     <ElectoralDistrictId>ed60129</ElectoralDistrictId>
+     <FilingDeadline>2013-01-01</FilingDeadline>
+     <IsPartisan>false</IsPartisan>
      <Name>
-       <Text language="en">Republican</Text>
+       <Text language="en">Governor</Text>
      </Name>
-   </Party>
-
-
-.. _single-xml-internationalized-text:
-
-InternationalizedText
-~~~~~~~~~~~~~~~~~~~~~
-
-``InternationalizedText`` allows for support of multiple languages for a string.
-``InternationalizedText`` has an optional attribute ``label``, which allows the feed to refer
-back to the original label for the information (e.g. if the contact information came from a
-CSV, ``label`` may refer to a row ID). Examples of ``InternationalizedText`` can be seen in:
-* Any element that extends :ref:`single-xml-contest-base`
-* Any element that extends :ref:`single-xml-ballot-selection-base`
-* :ref:`single-xml-candidate`
-* :ref:`single-xml-contact-information`
-* :ref:`single-xml-election`
-* :ref:`single-xml-election-administration`
-* :ref:`single-xml-office`
-* :ref:`single-xml-party`
-* :ref:`single-xml-person`
-* :ref:`single-xml-polling-location`
-* :ref:`single-xml-source`
-NOTE: Internationalized Text is not currently supported for CSV submissions. 
-
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                         | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===================================+==============+==============+==========================================+==========================================+
-| Text         | :ref:`single-xml-language-string` | **Required** | Repeats      | Contains the translations of a           | At least one valid ``Text`` must be      |
-|              |                                   |              |              | particular string of text.               | present for ``InternationalizedText`` to |
-|              |                                   |              |              |                                          | be valid. If no valid ``Text`` is        |
-|              |                                   |              |              |                                          | present, the implementation is required  |
-|              |                                   |              |              |                                          | to ignore the ``InternationalizedText``  |
-|              |                                   |              |              |                                          | element.                                 |
-+--------------+-----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-ballot-measure-selection:
-
-BallotMeasureSelection
-~~~~~~~~~~~~~~~~~~~~~~
-
-Represents the possible selection (e.g. yes/no, recall/do not recall, et al) for a
-:ref:`single-xml-ballot-measure-contest` that would appear on the ballot.
-BallotMeasureSelection extends :ref:`single-xml-ballot-selection-base`.
-
-+--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==========================================+==============+==============+==========================================+==========================================+
-| Selection    | :ref:`single-xml-internationalized-text` | **Required** | Single       | Selection text for a                     | If the element is invalid or not         |
-|              |                                          |              |              | :ref:`single-xml-ballot-measure-contest` | present, the implementation is required  |
-|              |                                          |              |              |                                          | to ignore the BallotMeasureSelection     |
-|              |                                          |              |              |                                          | containing it.                           |
-+--------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. code-block:: xml
-   :linenos:
-
-   <BallotMeasureSelection id="bms30001a">
-      <Selection label="bms30001at">
-         <Text language="en">Yes</Text>
-         <Text language="es">Sí</Text>
-      </Selection>
-   </BallotMeasureSelection>
-   <BallotMeasureSelection id="bms30001b">
-      <Selection label="bms30001bt">
-         <Text language="en">No</Text>
-         <Text language="es">No</Text>
-      </Selection>
-   </BallotMeasureSelection>
-
-
-.. _single-xml-ballot-selection-base:
-
-BallotSelectionBase
-^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-xml-ballot-measure-selection`,
-:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
-
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+================+==============+==============+==========================================+==========================================+
-| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-hours-open:
-
-HoursOpen
-~~~~~~~~~
-
-A structured way of describing the days and hours that a place such as a
-:ref:`single-xml-office` or :ref:`single-xml-polling-location` is open, or
-that an event such as an :ref:`single-xml-election` is happening. The range of days
-indicated by the `StartDate` and `EndDate` in each `Schedule`_ element
-should not overlap with peer `Schedule`_ elements. For example, it is
-invalid to specify a schedule from 10/01/2016 to 10/31/2016 and also
-specify a schedule from 10/10/2016 to 10/11/2016 within the same `HoursOpen`
-element.
-
-+--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                  | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+============================+==============+==============+==========================================+==========================================+
-| Schedule     | :ref:`single-xml-schedule` | **Required** | Repeats      | Defines a block of days and hours that a | At least one valid `Schedule`_ must be   |
-|              |                            |              |              | place will be open.                      | present for ``HoursOpen`` to be valid.   |
-|              |                            |              |              |                                          | If no valid `Schedule`_ is present, the  |
-|              |                            |              |              |                                          | implementation is required to ignore the |
-|              |                            |              |              |                                          | ``HoursOpen`` element.                   |
-+--------------+----------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-schedule:
-
-Schedule
-^^^^^^^^
-
-A sub-portion of the schedule. This describes a range of days, along with one or
-more set of open and close times for those days, as well as the options
-describing whether or not appointments are necessary or possible.
-
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type               | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+=========================+==============+==============+==========================================+==========================================+
-| Hours               | :ref:`single-xml-hours` | Optional     | Repeats      | Blocks of hours in the date range in     | If the element is invalid or not         |
-|                     |                         |              |              | which the place is open.                 | present, then the implementation is      |
-|                     |                         |              |              |                                          | required to ignore it.                   |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsOnlyByAppointment | ``xs:boolean``          | Optional     | Single       | If true, the place is only open during   | If the field is invalid or not present,  |
-|                     |                         |              |              | the specified time window with an        | then the implementation is required to   |
-|                     |                         |              |              | appointment.                             | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsOrByAppointment   | ``xs:boolean``          | Optional     | Single       | If true, the place is open during the    | If the field is invalid or not present,  |
-|                     |                         |              |              | hours specified time window and may also | then the implementation is required to   |
-|                     |                         |              |              | be open with an appointment.             | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| IsSubjectToChange   | ``xs:boolean``          | Optional     | Single       | If true, the place should be open during | If the field is invalid or not present,  |
-|                     |                         |              |              | the specified time window, but may be    | then the implementation is required to   |
-|                     |                         |              |              | subject to change. People should contact | ignore it.                               |
-|                     |                         |              |              | prior to arrival to confirm hours are    |                                          |
-|                     |                         |              |              | still accurate.                          |                                          |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| StartDate           | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                     |                         |              |              | start and end times and options begin.   | then the implementation is required to   |
-|                     |                         |              |              |                                          | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndDate             | ``xs:date``             | Optional     | Single       | The date at which this collection of     | If the field is invalid or not present,  |
-|                     |                         |              |              | start and end times and options end.     | then the implementation is required to   |
-|                     |                         |              |              |                                          | ignore it.                               |
-+---------------------+-------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-hours:
-
-Hours
-%%%%%
-
-The open and close time for this place. All times must be fully specified,
-including a timezone offset from UTC.
-
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type                        | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+==================================+==============+==============+==========================================+==========================================+
-| StartTime    | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place opens.      | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| EndTime      | :ref:`single-xml-time-with-zone` | Optional     | Single       | The time at which this place closes.     | If the element is invalid or not         |
-|              |                                  |              |              |                                          | present, then the implementation is      |
-|              |                                  |              |              |                                          | required to ignore it.                   |
-+--------------+----------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+     <Term>
+       <Type>full-term</Type>
+     </Term>
+   </Office>
 
 
 .. _single-xml-time-with-zone:
 
 TimeWithZone
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 A string pattern restricting the value to a time with an included offset from
 UTC. The pattern is
@@ -3100,138 +3204,34 @@ UTC. The pattern is
    </HoursOpen>
 
 
-.. _single-xml-electoral-district:
+.. _single-xml-voter-service:
 
-ElectoralDistrict
-~~~~~~~~~~~~~~~~~
+VoterService
+~~~~~~~~~~~~
 
-The ``ElectoralDistrict`` object represents the geographic area in which contests are held. Examples
-of ``ElectoralDistrict`` include: "the state of Maryland", "Virginia's 5th Congressional District",
-or "Union School District". The geographic area that comprises a ``ElectoralDistrict`` is defined by
-which precincts link to the ``ElectoralDistrict``.
-
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag                 | Data Type                              | Required?    | Repeats?     | Description                              | Error Handling                           |
-+=====================+========================================+==============+==============+==========================================+==========================================+
-| ExternalIdentifiers | :ref:`single-xml-external-identifiers` | Optional     | Single       | Other identifiers that link to external  | If the element is invalid or not         |
-|                     |                                        |              |              | datasets (e.g. `OCD-IDs`_)               | present, then the implementation is      |
-|                     |                                        |              |              |                                          | required to ignore it.                   |
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Name                | ``xs:string``                          | **Required** | Single       | Specifies the electoral area's name.     | If the field is invalid or not present,  |
-|                     |                                        |              |              |                                          | then the implementation is required to   |
-|                     |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                     |                                        |              |              |                                          | containing it.                           |
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Number              | ``xs:integer``                         | Optional     | Single       | Specifies the district number of the     | If the field is invalid or not present,  |
-|                     |                                        |              |              | district (e.g. 34, in the case of the    | then the implementation is required to   |
-|                     |                                        |              |              | 34th State Senate District). If a number | ignore it.                               |
-|                     |                                        |              |              | is not applicable, instead of leaving    |                                          |
-|                     |                                        |              |              | the field blank, leave this field out of |                                          |
-|                     |                                        |              |              | the object; empty strings are not valid  |                                          |
-|                     |                                        |              |              | for xs:integer fields.                   |                                          |
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Type                | :ref:`single-xml-district-type`        | **Required** | Single       | Specifies the type of electoral area.    | If the field is invalid or not present,  |
-|                     |                                        |              |              |                                          | then the implementation is required to   |
-|                     |                                        |              |              |                                          | ignore the ``ElectoralDistrict`` object  |
-|                     |                                        |              |              |                                          | containing it.                           |
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| OtherType           | ``xs:string``                          | Optional     | Single       | Allows for cataloging a new              | If the field is invalid or not present,  |
-|                     |                                        |              |              | :ref:`single-xml-district-type` option   | then the implementation is required to   |
-|                     |                                        |              |              | when ``Type`` is specified as "other".   | ignore it.                               |
-+---------------------+----------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-.. _OCD-IDs: http://opencivicdata.readthedocs.org/en/latest/ocdids.html
-
-.. code-block:: xml
-   :linenos:
-
-   <ElectoralDistrict id="ed60129">
-      <ExternalIdentifiers>
-        <ExternalIdentifier>
-          <Type>ocd-id</Type>
-          <Value>ocd-division/country:us/state:va</Value>
-        </ExternalIdentifier>
-        <ExternalIdentifier>
-          <Type>fips</Type>
-          <Value>51</Value>
-        </ExternalIdentifier>
-      </ExternalIdentifiers>
-      <Name>Commonwealth of Virginia</Name>
-      <Type>state</Type>
-   </ElectoralDistrict>
-
-
-.. _single-xml-party-selection:
-
-PartySelection
-~~~~~~~~~~~~~~
-
-This element extends :ref:`single-xml-ballot-selection-base` to
-support contests in which the selections can be groups of one or more parties.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| PartyIds     | ``xs:IDREFS`` | **Required** | Single       | One or more :ref:`single-xml-party` IDs  | If one or more parties referenced are    |
-|              |               |              |              | which collectively represent a ballot    | invalid or not present, the              |
-|              |               |              |              | selection.                               | implementation is required to ignore the |
-|              |               |              |              |                                          | PartySelection containing it.            |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-ballot-selection-base:
-
-BallotSelectionBase
-^^^^^^^^^^^^^^^^^^^
-
-A base model for all ballot selection types:
-:ref:`single-xml-ballot-measure-selection`,
-:ref:`single-xml-candidate-selection`, and :ref:`single-xml-party-selection`.
-
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag           | Data Type      | Required?    | Repeats?     | Description                              | Error Handling                           |
-+===============+================+==============+==============+==========================================+==========================================+
-| SequenceOrder | ``xs:integer`` | Optional     | Single       | The order in which a selection can be    | If the field is invalid or not present,  |
-|               |                |              |              | listed on the ballot or in results. This | then the implementation is required to   |
-|               |                |              |              | is the default ordering, and can be      | ignore it.                               |
-|               |                |              |              | overridden by `OrderedBallotSlectionIds` |                                          |
-|               |                |              |              | in :ref:`single-xml-ordered-contest`.    |                                          |
-+---------------+----------------+--------------+--------------+------------------------------------------+------------------------------------------+
-
-
-.. _single-xml-simple-address-type:
-
-SimpleAddressType
-~~~~~~~~~~~~~~~~~
-
-A ``SimpleAddressType`` represents a structured address.
-
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Tag          | Data Type     | Required?    | Repeats?     | Description                              | Error Handling                           |
-+==============+===============+==============+==============+==========================================+==========================================+
-| Line1        | ``xs:string`` | **Required** | Single       | The address line for a structured        | If no ``Line1`` is provided, the         |
-|              |               |              |              | address. Should include the street       | implementation should ignore the         |
-|              |               |              |              | number, street name, and any prefix and  | ``SimpleAddressType``.                   |
-|              |               |              |              | suffix.                                  |                                          |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line2        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line2`` is provided, the         |
-|              |               |              |              |                                          | implementation should ignore it.         |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Line3        | ``xs:string`` | Optional     | Single       | Additional field for an address          | If no ``Line3`` is provided, the         |
-|              |               |              |              |                                          | implementation should ignore it.         |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| City         | ``xs:string`` | **Required** | Single       | The City value of a structured address.  | If ``City`` is not provided, the         |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| State        | ``xs:string`` | **Required** | Single       | The State value of a structured address. | If ``State`` is not provided, the        |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| Zip          | ``xs:string`` | Optional     | Single       | The ZIP code of a structured address.    | If ``Zip`` is not provided, the          |
-|              |               |              |              |                                          | implementation should ignore the         |
-|              |               |              |              |                                          | ``SimpleAddressType``.                   |
-+--------------+---------------+--------------+--------------+------------------------------------------+------------------------------------------+
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Tag                      | Data Type                                | Required?    | Repeats?     | Description                              | Error Handling                           |
++==========================+==========================================+==============+==============+==========================================+==========================================+
+| ContactInformation       | :ref:`single-xml-contact-information`    | Optional     | Single       | The contact for a particular voter       | If the element is invalid or not         |
+|                          |                                          |              |              | service.                                 | present, then the implementation is      |
+|                          |                                          |              |              |                                          | required to ignore it.                   |
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Description              | :ref:`single-xml-internationalized-text` | Optional     | Single       | Long description of the services         | If the element is invalid or not         |
+|                          |                                          |              |              | available.                               | present, then the implementation is      |
+|                          |                                          |              |              |                                          | required to ignore it.                   |
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| ElectionOfficialPersonId | ``xs:IDREF``                             | Optional     | Single       | The :ref:`authority <single-xml-person>` | If the field is invalid or not present,  |
+|                          |                                          |              |              | for a particular voter service.          | then the implementation is required to   |
+|                          |                                          |              |              |                                          | ignore it.                               |
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| Type                     | :ref:`single-xml-voter-service-type`     | Optional     | Single       | The type of :ref:`voter service          | If the field is invalid or not present,  |
+|                          |                                          |              |              | <single-xml-voter-service-type>`.        | then the implementation is required to   |
+|                          |                                          |              |              |                                          | ignore it.                               |
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
+| OtherType                | ``xs:string``                            | Optional     | Single       | If Type is "other", OtherType allows for | If the field is invalid or not present,  |
+|                          |                                          |              |              | cataloging another type of voter         | then the implementation is required to   |
+|                          |                                          |              |              | service.                                 | ignore it.                               |
++--------------------------+------------------------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 
 
 .. _single-xml-enumerations:
@@ -3240,36 +3240,39 @@ Enumerations
 ------------
 
 
-.. _single-xml-identifier-type:
+.. _single-xml-ballot-measure-type:
 
-IdentifierType
-~~~~~~~~~~~~~~
+BallotMeasureType
+~~~~~~~~~~~~~~~~~
+
+A list of the various types of ballot measures. States may have different legal
+definitions of each type; Wikipedia_ has more details about each type.  These
+values are to help states with multiple types of non-candidate-based contests
+distinguish between each type; as such, the definitions in this table are simple
+guidelines. Ultimately it is up to the state or local election official to
+choose the value which best describes the ballot measure(s) in their
+jurisdiction.
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| fips           | Federal Information Processing Standards codes for |
-|                | states_, counties_, and cities_.                   |
+| ballot-measure | A catch-all for generic types of                   |
+|                | non-candidate-based contests.                      |
 +----------------+----------------------------------------------------+
-| local-level    | An identifier generated or used by local           |
-|                | governments or organizations.                      |
+| initiative     | These are usually citizen-driven measures to be    |
+|                | placed on the ballot. These could include both     |
+|                | statutory changes and constitutional amendments.   |
 +----------------+----------------------------------------------------+
-| national-level | An identifier generated or used by national        |
-|                | organizations.                                     |
+| referendum     | These could include measures to repeal existing    |
+|                | acts of legislation, legislative referrals, and    |
+|                | legislatively-referred state constitutional        |
+|                | amendments.                                        |
 +----------------+----------------------------------------------------+
-| ocd-id         | An `Open Civic Data Division Identifier`_.         |
-+----------------+----------------------------------------------------+
-| state-level    | An identifier generated or used by state           |
-|                | governments or organizations.                      |
-+----------------+----------------------------------------------------+
-| other          | Any identifier which doesn't fall into any of the  |
-|                | above categories.                                  |
+| other          | Anything that does not fall into the above         |
+|                | categories.                                        |
 +----------------+----------------------------------------------------+
 
-.. _states: http://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code
-.. _counties: http://en.wikipedia.org/wiki/FIPS_county_code
-.. _cities: http://geonames.usgs.gov/domestic/fips55codedef.html
-.. _`Open Civic Data Division Identifier`: http://docs.opencivicdata.org/en/latest/proposals/0002.html
+.. _Wikipedia: http://en.wikipedia.org/wiki/Initiatives_and_referendums_in_the_United_States
 
 
 .. _single-xml-candidate-post-election-status:
@@ -3310,30 +3313,6 @@ CandidatePreElectionStatus
 +--------------+----------------------------------------------------+
 | write-in     |                                                    |
 +--------------+----------------------------------------------------+
-
-
-.. _single-xml-voter-service-type:
-
-VoterServiceType
-~~~~~~~~~~~~~~~~
-
-+--------------------+----------------------------------------------------+
-| Tag                | Description                                        |
-+====================+====================================================+
-| absentee-ballots   | This department handles the dispatch, tracking,    |
-|                    | and return of absentee ballots.                    |
-+--------------------+----------------------------------------------------+
-| overseas-voting    | The department for overseas, military, and other   |
-|                    | outside-the-U.S. voters.                           |
-+--------------------+----------------------------------------------------+
-| polling-places     | This deparment handles the selection and           |
-|                    | management of polling places.                      |
-+--------------------+----------------------------------------------------+
-| voter-registration | The deparment that manages voter registration.     |
-+--------------------+----------------------------------------------------+
-| other              | Any other service not covered by the above         |
-|                    | descriptions.                                      |
-+--------------------+----------------------------------------------------+
 
 
 .. _single-xml-district-type:
@@ -3405,20 +3384,36 @@ state, so please use the definition which best matches your local meaning.
 .. _`Wikipedia article`: http://en.wikipedia.org/wiki/Town#United_States
 
 
-.. _single-xml-office-term-type:
+.. _single-xml-identifier-type:
 
-OfficeTermType
+IdentifierType
 ~~~~~~~~~~~~~~
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| full-term      | This election is for an office for which the       |
-|                | existing term has been completed.                  |
+| fips           | Federal Information Processing Standards codes for |
+|                | states_, counties_, and cities_.                   |
 +----------------+----------------------------------------------------+
-| unexpired-term | This election is for an office for which the       |
-|                | original term is not yet complete.                 |
+| local-level    | An identifier generated or used by local           |
+|                | governments or organizations.                      |
 +----------------+----------------------------------------------------+
+| national-level | An identifier generated or used by national        |
+|                | organizations.                                     |
++----------------+----------------------------------------------------+
+| ocd-id         | An `Open Civic Data Division Identifier`_.         |
++----------------+----------------------------------------------------+
+| state-level    | An identifier generated or used by state           |
+|                | governments or organizations.                      |
++----------------+----------------------------------------------------+
+| other          | Any identifier which doesn't fall into any of the  |
+|                | above categories.                                  |
++----------------+----------------------------------------------------+
+
+.. _states: http://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code
+.. _counties: http://en.wikipedia.org/wiki/FIPS_county_code
+.. _cities: http://geonames.usgs.gov/domestic/fips55codedef.html
+.. _`Open Civic Data Division Identifier`: http://docs.opencivicdata.org/en/latest/proposals/0002.html
 
 
 .. _single-xml-oeb-enum:
@@ -3437,39 +3432,20 @@ OebEnum
 +--------------+----------------------------------------------------+
 
 
-.. _single-xml-ballot-measure-type:
+.. _single-xml-office-term-type:
 
-BallotMeasureType
-~~~~~~~~~~~~~~~~~
-
-A list of the various types of ballot measures. States may have different legal
-definitions of each type; Wikipedia_ has more details about each type.  These
-values are to help states with multiple types of non-candidate-based contests
-distinguish between each type; as such, the definitions in this table are simple
-guidelines. Ultimately it is up to the state or local election official to
-choose the value which best describes the ballot measure(s) in their
-jurisdiction.
+OfficeTermType
+~~~~~~~~~~~~~~
 
 +----------------+----------------------------------------------------+
 | Tag            | Description                                        |
 +================+====================================================+
-| ballot-measure | A catch-all for generic types of                   |
-|                | non-candidate-based contests.                      |
+| full-term      | This election is for an office for which the       |
+|                | existing term has been completed.                  |
 +----------------+----------------------------------------------------+
-| initiative     | These are usually citizen-driven measures to be    |
-|                | placed on the ballot. These could include both     |
-|                | statutory changes and constitutional amendments.   |
+| unexpired-term | This election is for an office for which the       |
+|                | original term is not yet complete.                 |
 +----------------+----------------------------------------------------+
-| referendum     | These could include measures to repeal existing    |
-|                | acts of legislation, legislative referrals, and    |
-|                | legislatively-referred state constitutional        |
-|                | amendments.                                        |
-+----------------+----------------------------------------------------+
-| other          | Anything that does not fall into the above         |
-|                | categories.                                        |
-+----------------+----------------------------------------------------+
-
-.. _Wikipedia: http://en.wikipedia.org/wiki/Initiatives_and_referendums_in_the_United_States
 
 
 .. _single-xml-vote-variation:
@@ -3538,3 +3514,27 @@ to be assigned to a contest.
 .. _`proportional representation`: https://en.wikipedia.org/wiki/Proportional_representation
 .. _`Range voting`: http://en.wikipedia.org/wiki/Range_voting
 .. _`Ranked choice voting`: http://http://en.wikipedia.org/wiki/Ranked_Choice_Voting
+
+
+.. _single-xml-voter-service-type:
+
+VoterServiceType
+~~~~~~~~~~~~~~~~
+
++--------------------+----------------------------------------------------+
+| Tag                | Description                                        |
++====================+====================================================+
+| absentee-ballots   | This department handles the dispatch, tracking,    |
+|                    | and return of absentee ballots.                    |
++--------------------+----------------------------------------------------+
+| overseas-voting    | The department for overseas, military, and other   |
+|                    | outside-the-U.S. voters.                           |
++--------------------+----------------------------------------------------+
+| polling-places     | This deparment handles the selection and           |
+|                    | management of polling places.                      |
++--------------------+----------------------------------------------------+
+| voter-registration | The deparment that manages voter registration.     |
++--------------------+----------------------------------------------------+
+| other              | Any other service not covered by the above         |
+|                    | descriptions.                                      |
++--------------------+----------------------------------------------------+


### PR DESCRIPTION
This PR is the outcome of running the following. The main change here is that the single page RSTs now contain all the elements in lexicographical order.

```
$ python3 scripts/vip.py norm_yaml
$ python3 scripts/vip.py make_rest
```