### PR TITLE
Fixes a bug in rest file generation

### DIFF
--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -263,7 +263,7 @@ def update_rest_file_single_page(all_types,mode):
     write_rest_file(path, rest)
 
 
-def update_rest_files(type_name=None):
+def update_rest_files(override_type_name=None):
     """
     Update auto-generated reST files.
     """
@@ -272,10 +272,10 @@ def update_rest_files(type_name=None):
         update_rest_file_single_page(all_types, mode)
         
         type_map = all_types.type_map
-        if type_name is None:
+        if override_type_name is None:
             type_names = sorted(type_map.keys())
         else:
-            type_names = [type_name]
+            type_names = [override_type_name]
 
         prefix = "multi-{}".format(mode)
         for type_name in type_names:


### PR DESCRIPTION
A bug was recently introduced with a1d546bba67b563af9e05e3db86f4055a5c8965d where the name of the argument `type_name` of the method `update_rest_files` was reused in the method itself. This caused unexpected behavior when the loop over modes was executed the second time.  This bug is addressed by changing the name of the argument to this method from `type_name` to `override_type_name`, since the argument is used when the user wants to manually override which single type to process.