### PR TITLE
Removes obsolete call to update_table_file

### DIFF
--- a/scripts/vippy/rest.py
+++ b/scripts/vippy/rest.py
@@ -316,9 +316,6 @@ def update_rest_files(override_type_name=None):
             _log.debug("updating rest files for type: {0}".format(type_name))
             data_type = common.get_type(type_map, type_name)
             update_rest_file(all_types, data_type, prefix=prefix)
-            if mode == "xml":
-                # The table file is not mode-specific, so only update it once (using the XML case)
-                update_table_file(type_map, data_type, prefix=prefix)
 
 
 def analyze_types():


### PR DESCRIPTION
This addresses an anomaly introduces during the merge of `vip6` branch into `master`. The intention is that this call to update_table_file should be removed (see b8179d37d99a1bab4a8afb76fce568998db6e642).