### PR TITLE
Update ExternalGeospatialFeature.Index type to xs:int to match spec.

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -386,7 +386,7 @@
       <xs:element name="FeatureIdentifier" minOccurs="1" maxOccurs="unbounded">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="Index" type="xs:string" />
+            <xs:element name="Index" type="xs:int" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>


### PR DESCRIPTION
The specification states that ExternalGeospatialFeature.FeatureIdentifier.Index is and xs:int.  This should updated the xsd to match.