### PR TITLE
allow for named timezones

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -146,7 +146,7 @@
 
   <xs:simpleType name="TimeWithZone">
     <xs:restriction base="xs:string">
-      <xs:pattern value="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|[+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))" />
+      <xs:pattern value="(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|(24:00:00))(Z|([+-]((0[0-9]|1[0-3]):[0-5][0-9]|14:00))|(\s\S+))" />
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Updates regex in TimeWithZone element to allow for named timezones. It's pretty permissive, since validation of named timezones will take place on Civic Info side, not in XML validation. Screenshot included of tested values. Tests based on [Google Maps Time Zone API examples](https://developers.google.com/maps/documentation/timezone/requests-timezone#examples).

![Screenshot 2023-10-23 at 10 53 50 AM](https://github.com/votinginfoproject/vip-specification/assets/96207156/53b7d792-b3bf-4b98-b67d-60c7554cb5da)
