### PR TITLE
Fixing field name in election_administration

### DIFF
--- a/docs/built_rst/csv/elements/election_administration.rst
+++ b/docs/built_rst/csv/elements/election_administration.rst
@@ -48,7 +48,7 @@ functions.
 |                                 |                                  |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
 |                                 |                                  |              |              |                                                             | ignore it.                               |
 +---------------------------------+----------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
-| what_is_on_my_ballot            | ``xs:anyURI``                    | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+| what_is_on_my_ballot_uri        | ``xs:anyURI``                    | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
 |                                 |                                  |              |              | individual's ballot.                                        | then the implementation is required to   |
 |                                 |                                  |              |              |                                                             | ignore it.                               |
 +---------------------------------+----------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -970,7 +970,7 @@ functions.
 |                                 |                                   |              |              | for the jurisdiction of the administration.                 | then the implementation is required to   |
 |                                 |                                   |              |              |                                                             | ignore it.                               |
 +---------------------------------+-----------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+
-| what_is_on_my_ballot            | ``xs:anyURI``                     | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
+| what_is_on_my_ballot_uri        | ``xs:anyURI``                     | Optional     | Single       | Specifies web address for information on what is on an      | If the field is invalid or not present,  |
 |                                 |                                   |              |              | individual's ballot.                                        | then the implementation is required to   |
 |                                 |                                   |              |              |                                                             | ignore it.                               |
 +---------------------------------+-----------------------------------+--------------+--------------+-------------------------------------------------------------+------------------------------------------+

--- a/docs/yaml/elements/election_administration.yaml
+++ b/docs/yaml/elements/election_administration.yaml
@@ -106,7 +106,7 @@ tags:
   error_then: =must-ignore
   type: xs:anyURI
 - _name: WhatIsOnMyBallotUri
-  csv-header-name: what_is_on_my_ballot
+  csv-header-name: what_is_on_my_ballot_uri
   csv-type: xs:anyURI
   description: Specifies web address for information on what is on an individual's
     ballot.


### PR DESCRIPTION
In election_administration in the CSV spec, a field is misnamed "what_is_on_my_ballot". It should be "what_is_on_my_ballot_uri".