### PR TITLE
suppressing misleading fields on PL

### DIFF
--- a/docs/built_rst/csv/elements/polling_location.rst
+++ b/docs/built_rst/csv/elements/polling_location.rst
@@ -10,13 +10,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                  | Data Type                | Required?    | Repeats?     | Description                              | Error Handling                           |
 +======================================+==========================+==============+==============+==========================================+==========================================+
-| :ref:`multi-csv-simple-address-type` | ``simple-address-type``  | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
-|                                      |                          |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
-|                                      |                          |              |              |                                          | given Polling Location. If none is       |
-|                                      |                          |              |              |                                          | present, the implementation is required  |
-|                                      |                          |              |              |                                          | to ignore the ``PollingLocation``        |
-|                                      |                          |              |              |                                          | element containing it.                   |
-+--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | address_line                         | ``xs:string``            | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                                      |                          |              |              | address to a polling location.           | should be present for a given Polling    |
 |                                      |                          |              |              |                                          | Location. If none is present, the        |
@@ -49,10 +42,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 | is_early_voting                      | ``xs:boolean``           | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
 |                                      |                          |              |              | early vote site.                         | then the implementation is required to   |
 |                                      |                          |              |              |                                          | ignore it.                               |
-+--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_lng                              | :ref:`multi-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                                      |                          |              |              | this polling location.                   | present, then the implementation is      |
-|                                      |                          |              |              |                                          | required to ignore it.                   |
 +--------------------------------------+--------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | name                                 | ``xs:string``            | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
 |                                      |                          |              |              |                                          | then the implementation is required to   |

--- a/docs/built_rst/csv/single_page.rst
+++ b/docs/built_rst/csv/single_page.rst
@@ -1619,13 +1619,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | Tag                                   | Data Type                 | Required?    | Repeats?     | Description                              | Error Handling                           |
 +=======================================+===========================+==============+==============+==========================================+==========================================+
-| :ref:`single-csv-simple-address-type` | ``simple-address-type``   | Optional     | Single       | Represents the various structured parts  | One of **AddressStructured** and         |
-|                                       |                           |              |              | of an address to a polling location.     | **AddressLine** should be present for a  |
-|                                       |                           |              |              |                                          | given Polling Location. If none is       |
-|                                       |                           |              |              |                                          | present, the implementation is required  |
-|                                       |                           |              |              |                                          | to ignore the ``PollingLocation``        |
-|                                       |                           |              |              |                                          | element containing it.                   |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | address_line                          | ``xs:string``             | Optional     | Repeats      | Represents the various parts of an       | One of AddressStructured and AddressLine |
 |                                       |                           |              |              | address to a polling location.           | should be present for a given Polling    |
 |                                       |                           |              |              |                                          | Location. If none is present, the        |
@@ -1658,10 +1651,6 @@ The PollingLocation object represents a site where voters cast or drop off ballo
 | is_early_voting                       | ``xs:boolean``            | Optional     | Single       | Indicates if this polling location is an | If the field is invalid or not present,  |
 |                                       |                           |              |              | early vote site.                         | then the implementation is required to   |
 |                                       |                           |              |              |                                          | ignore it.                               |
-+---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
-| lat_lng                               | :ref:`single-csv-lat-lng` | Optional     | Single       | Specifies the latitude and longitude of  | If the element is invalid or not         |
-|                                       |                           |              |              | this polling location.                   | present, then the implementation is      |
-|                                       |                           |              |              |                                          | required to ignore it.                   |
 +---------------------------------------+---------------------------+--------------+--------------+------------------------------------------+------------------------------------------+
 | name                                  | ``xs:string``             | Optional     | Single       | Name of the polling location.            | If the field is invalid or not present,  |
 |                                       |                           |              |              |                                          | then the implementation is required to   |

--- a/docs/yaml/elements/polling_location.yaml
+++ b/docs/yaml/elements/polling_location.yaml
@@ -56,6 +56,7 @@ tags:
     ignore the ``PollingLocation`` element containing it.
   repeating: false
   required: false
+  skip_on: csv
   type: SimpleAddressType
 - _name: AddressLine
   csv-header-name: address_line
@@ -106,6 +107,7 @@ tags:
   csv-type: LatLng
   description: Specifies the latitude and longitude of this polling location.
   error_then: =must-ignore
+  skip_on: csv
   type: LatLng
 - _name: Name
   csv-header-name: name


### PR DESCRIPTION
**lat_lng** and **simple_address_type** no longer appear as fields in polling location.