### PR TITLE
add PartyIds field to PollingLocation

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -651,6 +651,8 @@ and will enforce that each text language is different.
       <xs:element optionalInOverlay="true" name="LocationType" type="PollingLocationType" minOccurs="1" />
       <xs:element clearable="true" name="LatLng" type="LatLng" minOccurs="0" maxOccurs="1" />
       <xs:element clearable="true" name="Name" type="InternationalizedText" minOccurs="0" maxOccurs="1" />
+      <!-- PartyIds are for closed primary elections where a voter may be directed to different polling locations depending on their registered party -->
+      <xs:element clearable="true" name="PartyIds" type="xs:IDREFS" minOccurs="0" maxOccurs="1" />
       <xs:element clearable="true" name="PhotoUri" type="InternationalizedUri" minOccurs="0" maxOccurs="1" />
       <xs:element clearable="true" name="EmergencyNotice" type="EmergencyNotice" minOccurs="0" maxOccurs="unbounded" />
 


### PR DESCRIPTION
This change should, ideally, enable us to represent split-party primaries (such as in TX and VA) as a single feed file, instead of two as we need to now. If the field is blank it can be assumed the site is open to all parties.

Currently the field is IDREFS to enable multiple parties to share a single site, but it may be preferable to enforce a single party per site and require feeds to duplicate sites if they are shared by party.

To be clear, the intention is still to show all sites in the API response regardless of party.

(I'm not sure if updates to any other files are necessary for this change, let me know)