### PR TITLE
remove department, move contactInfo to electionAdmin

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -319,43 +319,35 @@
       <xs:element clearable="true" name="AmIRegisteredUri" type="InternationalizedUri" minOccurs="0" />
       <xs:element clearable="true" name="BallotTrackingUri" type="InternationalizedUri" minOccurs="0" />
       <xs:element clearable="true" name="BallotProvisionalTrackingUri" type="InternationalizedUri" minOccurs="0" />
-      <!-- A locality may have more than one department with each handling different services. -->
-      <xs:element name="Department" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
-            <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
-            <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
-              <xs:complexType>
-                <xs:sequence>
-                  <!--
-                      The contact information below can be used to override or
-                      add specific fields to the base Departmental contact information if
-                      the service has different information.  For example, if the voter
-                      service has its own phone number, the ContactInformation object
-                      below can be an object containing only a Phone element.
-                  -->
-                  <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
-                  <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
-                  <!--
-                      This is for use if a certain person handles the particular service,
-                      for example a contact person for overseas voting.
-                  -->
-                  <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
-                  <xs:element name="Type" type="VoterServiceType" minOccurs="0" />
-                  <xs:element name="OtherType" type="xs:string" minOccurs="0" />
-                </xs:sequence>
-                <xs:attribute name="label" type="xs:string" />
-              </xs:complexType>
-            </xs:element>
-          </xs:sequence>
-          <xs:attribute name="label" type="xs:string" />
-        </xs:complexType>
-      </xs:element>
+      <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
       <xs:element clearable="true" name="EmergencyNotice" type="EmergencyNotice" minOccurs="0" />
       <xs:element clearable="true" name="ElectionsUri" type="InternationalizedUri" minOccurs="0" />
       <xs:element clearable="true" name="RegistrationUri" type="InternationalizedUri" minOccurs="0" />
       <xs:element clearable="true" name="RulesUri" type="InternationalizedUri" minOccurs="0" />
+      <!-- A locality may have more than one department with each handling different services. -->
+      <xs:element name="VoterService" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <!--
+                The contact information below can be used to override or
+                add specific fields to the base Departmental contact information if
+                the service has different information.  For example, if the voter
+                service has its own phone number, the ContactInformation object
+                below can be an object containing only a Phone element.
+            -->
+            <xs:element name="ContactInformation" type="ContactInformation" minOccurs="0" />
+            <xs:element name="Description" type="InternationalizedText" minOccurs="0" />
+            <!--
+                This is for use if a certain person handles the particular service,
+                for example a contact person for overseas voting.
+            -->
+            <xs:element name="ElectionOfficialPersonId" type="xs:IDREF" minOccurs="0" />
+            <xs:element name="Type" type="VoterServiceType" minOccurs="0" />
+            <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+          </xs:sequence>
+          <xs:attribute name="label" type="xs:string" />
+        </xs:complexType>
+      </xs:element>
       <xs:element clearable="true" name="WhatIsOnMyBallotUri" type="InternationalizedUri" minOccurs="0" />
       <xs:element clearable="true" name="WhereDoIVoteUri" type="InternationalizedUri" minOccurs="0" />
     </xs:sequence>


### PR DESCRIPTION
In my opinion this is one of the most confusing and underutilized parts of the specification.

In 6.0 and earlier, the `Department` object only exists to hold contact information and/or a PersonId for the election official (which might be redundant as `Person` elements can have their own contact information).

Meanwhile the `VoterService` object is a child of the `Department` and holds its own contact information as well as a description of the provided service (voter registration, overseas voting, etc.)

This proposal removes `Department` entirely and makes `VoterService` a direct child of `ElectionAdministration`, as well as giving `ElectionAdministration` its own contact information field.

Strictly speaking this could lead to data loss from older versions of the feed, but as I said these elements are very underutilized and I believe any loss would be minimal.